### PR TITLE
Update imported Roboto font and orbit-design-tokens version

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,1 +1,1 @@
-<link href="https://fonts.googleapis.com/css?family=Roboto:300,500" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css?family=Roboto:400,400i,500,500i,700" rel="stylesheet">

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,1 +1,1 @@
-<link href="https://fonts.googleapis.com/css?family=Roboto:400,400i,500,500i,700" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css?family=Roboto:300,500" rel="stylesheet">

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@sambego/storybook-styles": "^1.0.0",
     "classnames": "^2.2.5",
-    "orbit-design-token": "git+https://github.com/kiwicom/orbit-design-tokens.git#v0.0.1",
+    "orbit-design-token": "git+https://github.com/kiwicom/orbit-design-tokens.git#v0.0.2",
     "polished": "^1.9.2",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",

--- a/src/Button/__snapshots__/Button.stories.storyshot
+++ b/src/Button/__snapshots__/Button.stories.storyshot
@@ -142,7 +142,7 @@ exports[`Storyshots Button Destructive button 1`] = `
           }
         >
           <button
-            className="jsx-371495103"
+            className="jsx-1588866154"
             disabled={false}
             onClick={[Function]}
           >
@@ -570,7 +570,7 @@ exports[`Storyshots Button Facebook button 1`] = `
           }
         >
           <button
-            className="jsx-565795052"
+            className="jsx-262234713"
             disabled={false}
             onClick={[Function]}
           >
@@ -998,7 +998,7 @@ exports[`Storyshots Button Google button 1`] = `
           }
         >
           <button
-            className="jsx-2189338253"
+            className="jsx-1735277144"
             disabled={false}
             onClick={[Function]}
           >
@@ -1426,7 +1426,7 @@ exports[`Storyshots Button Link button 1`] = `
           }
         >
           <button
-            className="jsx-3000803371"
+            className="jsx-2401004894"
             disabled={false}
             onClick={[Function]}
           >
@@ -1745,7 +1745,7 @@ exports[`Storyshots Button Link button 1`] = `
           }
         >
           <button
-            className="jsx-2002313652"
+            className="jsx-2792682273"
             disabled={false}
             onClick={[Function]}
           >
@@ -2173,7 +2173,7 @@ exports[`Storyshots Button Primary button 1`] = `
           }
         >
           <button
-            className="jsx-421991794"
+            className="jsx-1153840231"
             disabled={false}
             onClick={[Function]}
           >
@@ -2461,7 +2461,7 @@ exports[`Storyshots Button Primary button 1`] = `
           }
         >
           <button
-            className="jsx-1866407245"
+            className="jsx-849819448"
             disabled={false}
             onClick={[Function]}
           >
@@ -2858,7 +2858,7 @@ exports[`Storyshots Button Secondary button 1`] = `
           }
         >
           <button
-            className="jsx-1339973033"
+            className="jsx-512780380"
             disabled={false}
             onClick={[Function]}
           >
@@ -3177,7 +3177,7 @@ exports[`Storyshots Button Secondary button 1`] = `
           }
         >
           <button
-            className="jsx-605992918"
+            className="jsx-1492333315"
             disabled={false}
             onClick={[Function]}
           >

--- a/src/Button/__tests__/__snapshots__/index.test.js.snap
+++ b/src/Button/__tests__/__snapshots__/index.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Rendered with children Should contain IconWrapper 1`] = `
 <button
-  className="jsx-1314013687"
+  className="jsx-588294754"
   disabled={false}
   onClick={[MockFunction]}
 >
@@ -17,7 +17,7 @@ exports[`Rendered with children Should contain IconWrapper 1`] = `
     size="32"
   />
   <JSXStyle
-    css="button.__jsx-style-dynamic-selector{box-sizing:border-box;display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;-webkit-box-pack:center;-webkit-justify-content:center;-ms-flex-pack:center;justify-content:center;-webkit-align-items:center;-webkit-box-align:center;-ms-flex-align:center;align-items:center;width:180px;min-width:180px;height:52px;background:#00a991;color:#fff;border:none;border-radius:3px;padding-left:28px;padding-right:28px;font-weight:700;font-size:16px;cursor:pointer;opacity:1;-webkit-transition:all 0.15s ease-in-out;transition:all 0.15s ease-in-out;outline:0;}button.__jsx-style-dynamic-selector:hover{background:#00907b;color:#fff;border:none;}button.__jsx-style-dynamic-selector:active{-webkit-transform:scale(0.95);-ms-transform:scale(0.95);transform:scale(0.95);background:#007665;color:#fff;border:none;}"
+    css="button.__jsx-style-dynamic-selector{box-sizing:border-box;display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;-webkit-box-pack:center;-webkit-justify-content:center;-ms-flex-pack:center;justify-content:center;-webkit-align-items:center;-webkit-box-align:center;-ms-flex-align:center;align-items:center;width:180px;min-width:180px;height:52px;background:#00a991;color:#fff;border:none;border-radius:3px;padding-left:28px;padding-right:28px;font-weight:700;font-size:16px;cursor:pointer;opacity:1;-webkit-transition:all 0.15s ease-in-out;transition:all 0.15s ease-in-out;outline:0;}button.__jsx-style-dynamic-selector:hover{background:#00907b;color:#fff;border:none;}button.__jsx-style-dynamic-selector:active{-webkit-transform:scale(0.9);-ms-transform:scale(0.9);transform:scale(0.9);background:#007665;color:#fff;border:none;}"
     dynamic={
       Array [
         "180px",
@@ -36,7 +36,7 @@ exports[`Rendered with children Should contain IconWrapper 1`] = `
         "#00907b",
         "#fff",
         "none",
-        0.95,
+        0.9,
         "#007665",
         "#fff",
         "none",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6690,9 +6690,9 @@ optionator@^0.8.1, optionator@^0.8.2:
     type-check "~0.3.2"
     wordwrap "~1.0.0"
 
-"orbit-design-token@git+https://github.com/kiwicom/orbit-design-tokens.git#v0.0.1":
-  version "0.0.1"
-  resolved "git+https://github.com/kiwicom/orbit-design-tokens.git#b1fa6c979a7c8d3345e80dad2095a42e1c5ba3d6"
+"orbit-design-token@git+https://github.com/kiwicom/orbit-design-tokens.git#v0.0.2":
+  version "0.0.2"
+  resolved "git+https://github.com/kiwicom/orbit-design-tokens.git#25f8d91d99bb4ee01d7945473e078300f0f4de3f"
 
 original@>=0.0.5:
   version "1.0.0"


### PR DESCRIPTION
There is a new version of orbit-design-tokens available: https://github.com/kiwicom/orbit-design-tokens/releases/tag/v0.0.2

We need also to import more Roboto weights and styles, because we use them through tokens.
