### PR TITLE
DEV: Fix build of deprecated component

### DIFF
--- a/src/_deprecated/Checkbox/index.js
+++ b/src/_deprecated/Checkbox/index.js
@@ -1,6 +1,6 @@
 // @flow
 import Checkbox from "./Checkbox";
-import DeprecatedComponent from "../../../config/DeprecatedComponent";
+import DeprecatedComponent from "../DeprecatedComponent";
 
 export default DeprecatedComponent(
   Checkbox,

--- a/src/_deprecated/DeprecatedComponent.js
+++ b/src/_deprecated/DeprecatedComponent.js
@@ -1,9 +1,9 @@
 // @flow
 import React from "react";
 
-const DeprecatedComponent = (Component: React$ComponentType<any>, text: string) => {
+const DeprecatedComponent = <Props>(Component: React$ComponentType<any>, text: string) => {
   let warned = false;
-  return (props: Object) => {
+  return (props: Props) => {
     if (!warned) {
       warned = true;
       if (process.env.NODE_ENV !== "production") console.warn(`[Deprecation] ${text}`);
@@ -12,4 +12,4 @@ const DeprecatedComponent = (Component: React$ComponentType<any>, text: string) 
   };
 };
 
-module.exports = DeprecatedComponent;
+export default DeprecatedComponent;

--- a/src/_deprecated/FieldFeedback/index.js
+++ b/src/_deprecated/FieldFeedback/index.js
@@ -1,6 +1,6 @@
 // @flow
 import FieldFeedback from "./FieldFeedback";
-import DeprecatedComponent from "../../../config/DeprecatedComponent";
+import DeprecatedComponent from "../DeprecatedComponent";
 
 export default DeprecatedComponent(
   FieldFeedback,

--- a/src/_deprecated/InputText/index.js
+++ b/src/_deprecated/InputText/index.js
@@ -1,6 +1,6 @@
 // @flow
 import InputText from "./InputText";
-import DeprecatedComponent from "../../../config/DeprecatedComponent";
+import DeprecatedComponent from "../DeprecatedComponent";
 
 export default DeprecatedComponent(
   InputText,

--- a/src/_deprecated/InputTextarea/index.js
+++ b/src/_deprecated/InputTextarea/index.js
@@ -1,6 +1,6 @@
 // @flow
 import InputTextarea from "./InputTextarea";
-import DeprecatedComponent from "../../../config/DeprecatedComponent";
+import DeprecatedComponent from "../DeprecatedComponent";
 
 export default DeprecatedComponent(
   InputTextarea,

--- a/src/_deprecated/Radio/index.js
+++ b/src/_deprecated/Radio/index.js
@@ -1,6 +1,6 @@
 // @flow
 import Radio from "./Radio";
-import DeprecatedComponent from "../../../config/DeprecatedComponent";
+import DeprecatedComponent from "../DeprecatedComponent";
 
 export default DeprecatedComponent(
   Radio,

--- a/src/_deprecated/Select/index.js
+++ b/src/_deprecated/Select/index.js
@@ -1,6 +1,6 @@
 // @flow
 import Select from "./Select";
-import DeprecatedComponent from "../../../config/DeprecatedComponent";
+import DeprecatedComponent from "../DeprecatedComponent";
 
 export default DeprecatedComponent(
   Select,

--- a/src/_deprecated/SystemMessage/index.js
+++ b/src/_deprecated/SystemMessage/index.js
@@ -1,6 +1,6 @@
 // @flow
 import SystemMessage from "./SystemMessage";
-import DeprecatedComponent from "../../../config/DeprecatedComponent";
+import DeprecatedComponent from "../DeprecatedComponent";
 
 export default DeprecatedComponent(
   SystemMessage,

--- a/src/_deprecated/Typography/index.js
+++ b/src/_deprecated/Typography/index.js
@@ -1,6 +1,6 @@
 // @flow
 import Typography from "./Typography";
-import DeprecatedComponent from "../../../config/DeprecatedComponent";
+import DeprecatedComponent from "../DeprecatedComponent";
 
 export default DeprecatedComponent(
   Typography,


### PR DESCRIPTION
Deprecated component was in wrong folder which is not handled by babel, moved to `src/_deprecated/DeprecatedComponent`

