### PR TITLE
Separate withTheme from Heading component

### DIFF
--- a/src/Heading/Heading.js
+++ b/src/Heading/Heading.js
@@ -1,0 +1,72 @@
+// @flow
+import * as React from "react";
+import styled from "styled-components";
+import defaultTokens from "@kiwicom/orbit-design-tokens";
+import createComponentFromTagProp from "react-create-component-from-tag-prop";
+
+export const ELEMENT_OPTIONS = {
+  H1: "h1",
+  H2: "h2",
+  H3: "h3",
+  H4: "h4",
+  H5: "h5",
+};
+
+export const TYPE_OPTIONS = {
+  DISPLAY: "display",
+  TITLE1: "title1",
+  TITLE2: "title2",
+  TITLE3: "title3",
+};
+
+type Props = {|
+  element: $Values<typeof ELEMENT_OPTIONS>,
+  type: $Values<typeof TYPE_OPTIONS>,
+  children: React.Node,
+  theme: typeof defaultTokens,
+|};
+
+const HeadingElement = createComponentFromTagProp({
+  prop: "element",
+  propsToOmit: ["type", "tokens", "theme"],
+});
+
+const StyledHeading = styled(HeadingElement)`
+  font-family: ${props => props.theme.fontFamily};
+  font-size: ${props => props.tokens.sizeHeading[props.type]};
+  font-weight: ${props => props.tokens.weightHeading[props.type]};
+  color: ${props => props.theme.colorHeading};
+  line-height: ${props => props.theme.lineHeightHeading};
+  margin: 0;
+`;
+
+const Heading = (props: Props) => {
+  const { children, theme, type, element } = props;
+  const tokens = {
+    weightHeading: {
+      [TYPE_OPTIONS.DISPLAY]: theme.fontWeightHeadingDisplay,
+      [TYPE_OPTIONS.TITLE1]: theme.fontWeightHeadingLevel1,
+      [TYPE_OPTIONS.TITLE2]: theme.fontWeightHeadingLevel2,
+      [TYPE_OPTIONS.TITLE3]: theme.fontWeightHeadingLevel3,
+    },
+    sizeHeading: {
+      [TYPE_OPTIONS.DISPLAY]: theme.fontSizeHeadingDisplay,
+      [TYPE_OPTIONS.TITLE1]: theme.fontSizeHeadingTitle1,
+      [TYPE_OPTIONS.TITLE2]: theme.fontSizeHeadingTitle2,
+      [TYPE_OPTIONS.TITLE3]: theme.fontSizeHeadingTitle3,
+    },
+  };
+  return (
+    <StyledHeading theme={theme} tokens={tokens} type={type} element={element}>
+      {children}
+    </StyledHeading>
+  );
+};
+
+Heading.defaultProps = {
+  element: "h1",
+  type: "title1",
+  theme: defaultTokens,
+};
+
+export default Heading;

--- a/src/Heading/Heading.stories.js
+++ b/src/Heading/Heading.stories.js
@@ -5,16 +5,9 @@ import styles from "@sambego/storybook-styles";
 import chaptersAddon from "react-storybook-addon-chapters";
 import { withKnobs, text, select } from "@storybook/addon-knobs/react";
 
-import ThemeProvider from "../Theming/ThemeProvider";
-
-import Heading from "./index";
+import Heading, { ELEMENT_OPTIONS, TYPE_OPTIONS } from "./Heading";
 
 setAddon(chaptersAddon);
-
-const options = {
-  allowSourceToggling: false,
-  allowPropTablesToggling: false,
-};
 
 storiesOf("Heading", module)
   .addDecorator(withKnobs)
@@ -33,12 +26,7 @@ storiesOf("Heading", module)
         {
           sections: [
             {
-              sectionFn: () => (
-                <ThemeProvider>
-                  <Heading>{customTitle}</Heading>
-                </ThemeProvider>
-              ),
-              options,
+              sectionFn: () => <Heading>{customTitle}</Heading>,
             },
           ],
         },
@@ -47,17 +35,7 @@ storiesOf("Heading", module)
   })
   .addWithChapters("Title Display", () => {
     const customTitle = text("Title", "Orbit design system");
-    const element = select(
-      "Element",
-      {
-        h1: "h1",
-        h2: "h2",
-        h3: "h3",
-        h4: "h4",
-        h5: "h5",
-      },
-      "h1",
-    );
+    const element = select("Element", Object.values(ELEMENT_OPTIONS), "h1");
     return {
       title: "Title Display",
       info:
@@ -67,13 +45,10 @@ storiesOf("Heading", module)
           sections: [
             {
               sectionFn: () => (
-                <ThemeProvider>
-                  <Heading type="display" element={element}>
-                    {customTitle}
-                  </Heading>
-                </ThemeProvider>
+                <Heading type="display" element={element}>
+                  {customTitle}
+                </Heading>
               ),
-              options,
             },
           ],
         },
@@ -82,17 +57,7 @@ storiesOf("Heading", module)
   })
   .addWithChapters("Title 1", () => {
     const customTitle = text("Title", "Orbit design system");
-    const element = select(
-      "Element",
-      {
-        h1: "h1",
-        h2: "h2",
-        h3: "h3",
-        h4: "h4",
-        h5: "h5",
-      },
-      "h1",
-    );
+    const element = select("Element", Object.values(ELEMENT_OPTIONS), "h1");
     return {
       info:
         "Headings are used for showing content hierarchy and are important for improving the reading experience for our users. Visit Orbit.Kiwi for more detailed guidelines.",
@@ -101,13 +66,10 @@ storiesOf("Heading", module)
           sections: [
             {
               sectionFn: () => (
-                <ThemeProvider>
-                  <Heading type="title1" element={element}>
-                    {customTitle}
-                  </Heading>
-                </ThemeProvider>
+                <Heading type="title1" element={element}>
+                  {customTitle}
+                </Heading>
               ),
-              options,
             },
           ],
         },
@@ -116,17 +78,7 @@ storiesOf("Heading", module)
   })
   .addWithChapters("Title 2", () => {
     const customTitle = text("Title", "Orbit design system");
-    const element = select(
-      "Element",
-      {
-        h1: "h1",
-        h2: "h2",
-        h3: "h3",
-        h4: "h4",
-        h5: "h5",
-      },
-      "h2",
-    );
+    const element = select("Element", Object.values(ELEMENT_OPTIONS), "h2");
     return {
       info:
         "Headings are used for showing content hierarchy and are important for improving the reading experience for our users. Visit Orbit.Kiwi for more detailed guidelines.",
@@ -135,13 +87,10 @@ storiesOf("Heading", module)
           sections: [
             {
               sectionFn: () => (
-                <ThemeProvider>
-                  <Heading type="title2" element={element}>
-                    {customTitle}
-                  </Heading>
-                </ThemeProvider>
+                <Heading type="title2" element={element}>
+                  {customTitle}
+                </Heading>
               ),
-              options,
             },
           ],
         },
@@ -150,17 +99,7 @@ storiesOf("Heading", module)
   })
   .addWithChapters("Title 3", () => {
     const customTitle = text("Title", "Orbit design system");
-    const element = select(
-      "Element",
-      {
-        h1: "h1",
-        h2: "h2",
-        h3: "h3",
-        h4: "h4",
-        h5: "h5",
-      },
-      "h3",
-    );
+    const element = select("Element", Object.values(ELEMENT_OPTIONS), "h3");
     return {
       info:
         "Headings are used for showing content hierarchy and are important for improving the reading experience for our users. Visit Orbit.Kiwi for more detailed guidelines.",
@@ -169,13 +108,10 @@ storiesOf("Heading", module)
           sections: [
             {
               sectionFn: () => (
-                <ThemeProvider>
-                  <Heading type="title3" element={element}>
-                    {customTitle}
-                  </Heading>
-                </ThemeProvider>
+                <Heading type="title3" element={element}>
+                  {customTitle}
+                </Heading>
               ),
-              options,
             },
           ],
         },
@@ -183,27 +119,8 @@ storiesOf("Heading", module)
     };
   })
   .addWithChapters("Playground", () => {
-    const element = select(
-      "Element",
-      {
-        h1: "h1",
-        h2: "h2",
-        h3: "h3",
-        h4: "h4",
-        h5: "h5",
-      },
-      "h2",
-    );
-    const type = select(
-      "Type",
-      {
-        display: "display",
-        title1: "title1",
-        title2: "title2",
-        title3: "title3",
-      },
-      "display",
-    );
+    const element = select("Element", Object.values(ELEMENT_OPTIONS), "h2");
+    const type = select("Type", Object.values(TYPE_OPTIONS), "display");
 
     const customTitle = text("Title", "Orbit design system");
     return {
@@ -214,13 +131,10 @@ storiesOf("Heading", module)
           sections: [
             {
               sectionFn: () => (
-                <ThemeProvider>
-                  <Heading element={element} type={type}>
-                    {customTitle}
-                  </Heading>
-                </ThemeProvider>
+                <Heading element={element} type={type}>
+                  {customTitle}
+                </Heading>
               ),
-              options,
             },
           ],
         },

--- a/src/Heading/__snapshots__/Heading.stories.storyshot
+++ b/src/Heading/__snapshots__/Heading.stories.storyshot
@@ -156,7 +156,7 @@ exports[`Storyshots Heading Default 1`] = `
                         }
                       >
                         &lt;
-                        ThemeProvider
+                        Heading
                       </span>
                       <span />
                       <span
@@ -169,74 +169,23 @@ exports[`Storyshots Heading Default 1`] = `
                         &gt;
                       </span>
                     </div>
-                    <div>
-                      <div
+                    <div
+                      style={
+                        Object {
+                          "paddingLeft": 33,
+                          "paddingRight": 3,
+                        }
+                      }
+                    >
+                      <span
                         style={
                           Object {
-                            "paddingLeft": 33,
-                            "paddingRight": 3,
+                            "color": "#777",
                           }
                         }
                       >
-                        <span
-                          style={
-                            Object {
-                              "color": "#777",
-                            }
-                          }
-                        >
-                          &lt;
-                          Heading
-                        </span>
-                        <span />
-                        <span
-                          style={
-                            Object {
-                              "color": "#777",
-                            }
-                          }
-                        >
-                          &gt;
-                        </span>
-                      </div>
-                      <div
-                        style={
-                          Object {
-                            "paddingLeft": 48,
-                            "paddingRight": 3,
-                          }
-                        }
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#777",
-                            }
-                          }
-                        >
-                          Orbit design system
-                        </span>
-                      </div>
-                      <div
-                        style={
-                          Object {
-                            "paddingLeft": 33,
-                            "paddingRight": 3,
-                          }
-                        }
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#777",
-                            }
-                          }
-                        >
-                          &lt;/
-                          Heading
-                          &gt;
-                        </span>
-                      </div>
+                        Orbit design system
+                      </span>
                     </div>
                     <div
                       style={
@@ -254,7 +203,7 @@ exports[`Storyshots Heading Default 1`] = `
                         }
                       >
                         &lt;/
-                        ThemeProvider
+                        Heading
                         &gt;
                       </span>
                     </div>
@@ -426,9 +375,65 @@ exports[`Storyshots Heading Playground 1`] = `
                         }
                       >
                         &lt;
-                        ThemeProvider
+                        Heading
                       </span>
-                      <span />
+                      <span>
+                        <span>
+                           
+                          <span
+                            style={Object {}}
+                          >
+                            element
+                          </span>
+                          <span>
+                            =
+                            <span
+                              style={Object {}}
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#22a",
+                                    "wordBreak": "break-word",
+                                  }
+                                }
+                              >
+                                "
+                                h2
+                                "
+                              </span>
+                            </span>
+                          </span>
+                        </span>
+                        <span>
+                           
+                          <span
+                            style={Object {}}
+                          >
+                            type
+                          </span>
+                          <span>
+                            =
+                            <span
+                              style={Object {}}
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#22a",
+                                    "wordBreak": "break-word",
+                                  }
+                                }
+                              >
+                                "
+                                display
+                                "
+                              </span>
+                            </span>
+                          </span>
+                          
+                        </span>
+                      </span>
                       <span
                         style={
                           Object {
@@ -439,130 +444,23 @@ exports[`Storyshots Heading Playground 1`] = `
                         &gt;
                       </span>
                     </div>
-                    <div>
-                      <div
+                    <div
+                      style={
+                        Object {
+                          "paddingLeft": 33,
+                          "paddingRight": 3,
+                        }
+                      }
+                    >
+                      <span
                         style={
                           Object {
-                            "paddingLeft": 33,
-                            "paddingRight": 3,
+                            "color": "#777",
                           }
                         }
                       >
-                        <span
-                          style={
-                            Object {
-                              "color": "#777",
-                            }
-                          }
-                        >
-                          &lt;
-                          Heading
-                        </span>
-                        <span>
-                          <span>
-                             
-                            <span
-                              style={Object {}}
-                            >
-                              element
-                            </span>
-                            <span>
-                              =
-                              <span
-                                style={Object {}}
-                              >
-                                <span
-                                  style={
-                                    Object {
-                                      "color": "#22a",
-                                      "wordBreak": "break-word",
-                                    }
-                                  }
-                                >
-                                  "
-                                  h2
-                                  "
-                                </span>
-                              </span>
-                            </span>
-                          </span>
-                          <span>
-                             
-                            <span
-                              style={Object {}}
-                            >
-                              type
-                            </span>
-                            <span>
-                              =
-                              <span
-                                style={Object {}}
-                              >
-                                <span
-                                  style={
-                                    Object {
-                                      "color": "#22a",
-                                      "wordBreak": "break-word",
-                                    }
-                                  }
-                                >
-                                  "
-                                  display
-                                  "
-                                </span>
-                              </span>
-                            </span>
-                            
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#777",
-                            }
-                          }
-                        >
-                          &gt;
-                        </span>
-                      </div>
-                      <div
-                        style={
-                          Object {
-                            "paddingLeft": 48,
-                            "paddingRight": 3,
-                          }
-                        }
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#777",
-                            }
-                          }
-                        >
-                          Orbit design system
-                        </span>
-                      </div>
-                      <div
-                        style={
-                          Object {
-                            "paddingLeft": 33,
-                            "paddingRight": 3,
-                          }
-                        }
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#777",
-                            }
-                          }
-                        >
-                          &lt;/
-                          Heading
-                          &gt;
-                        </span>
-                      </div>
+                        Orbit design system
+                      </span>
                     </div>
                     <div
                       style={
@@ -580,7 +478,7 @@ exports[`Storyshots Heading Playground 1`] = `
                         }
                       >
                         &lt;/
-                        ThemeProvider
+                        Heading
                         &gt;
                       </span>
                     </div>
@@ -752,7 +650,7 @@ exports[`Storyshots Heading Title 1 1`] = `
                         }
                       >
                         &lt;
-                        ThemeProvider
+                        Heading
                       </span>
                       <span />
                       <span
@@ -765,74 +663,23 @@ exports[`Storyshots Heading Title 1 1`] = `
                         &gt;
                       </span>
                     </div>
-                    <div>
-                      <div
+                    <div
+                      style={
+                        Object {
+                          "paddingLeft": 33,
+                          "paddingRight": 3,
+                        }
+                      }
+                    >
+                      <span
                         style={
                           Object {
-                            "paddingLeft": 33,
-                            "paddingRight": 3,
+                            "color": "#777",
                           }
                         }
                       >
-                        <span
-                          style={
-                            Object {
-                              "color": "#777",
-                            }
-                          }
-                        >
-                          &lt;
-                          Heading
-                        </span>
-                        <span />
-                        <span
-                          style={
-                            Object {
-                              "color": "#777",
-                            }
-                          }
-                        >
-                          &gt;
-                        </span>
-                      </div>
-                      <div
-                        style={
-                          Object {
-                            "paddingLeft": 48,
-                            "paddingRight": 3,
-                          }
-                        }
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#777",
-                            }
-                          }
-                        >
-                          Orbit design system
-                        </span>
-                      </div>
-                      <div
-                        style={
-                          Object {
-                            "paddingLeft": 33,
-                            "paddingRight": 3,
-                          }
-                        }
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#777",
-                            }
-                          }
-                        >
-                          &lt;/
-                          Heading
-                          &gt;
-                        </span>
-                      </div>
+                        Orbit design system
+                      </span>
                     </div>
                     <div
                       style={
@@ -850,7 +697,7 @@ exports[`Storyshots Heading Title 1 1`] = `
                         }
                       >
                         &lt;/
-                        ThemeProvider
+                        Heading
                         &gt;
                       </span>
                     </div>
@@ -1022,9 +869,65 @@ exports[`Storyshots Heading Title 2 1`] = `
                         }
                       >
                         &lt;
-                        ThemeProvider
+                        Heading
                       </span>
-                      <span />
+                      <span>
+                        <span>
+                           
+                          <span
+                            style={Object {}}
+                          >
+                            type
+                          </span>
+                          <span>
+                            =
+                            <span
+                              style={Object {}}
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#22a",
+                                    "wordBreak": "break-word",
+                                  }
+                                }
+                              >
+                                "
+                                title2
+                                "
+                              </span>
+                            </span>
+                          </span>
+                        </span>
+                        <span>
+                           
+                          <span
+                            style={Object {}}
+                          >
+                            element
+                          </span>
+                          <span>
+                            =
+                            <span
+                              style={Object {}}
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#22a",
+                                    "wordBreak": "break-word",
+                                  }
+                                }
+                              >
+                                "
+                                h2
+                                "
+                              </span>
+                            </span>
+                          </span>
+                          
+                        </span>
+                      </span>
                       <span
                         style={
                           Object {
@@ -1035,130 +938,23 @@ exports[`Storyshots Heading Title 2 1`] = `
                         &gt;
                       </span>
                     </div>
-                    <div>
-                      <div
+                    <div
+                      style={
+                        Object {
+                          "paddingLeft": 33,
+                          "paddingRight": 3,
+                        }
+                      }
+                    >
+                      <span
                         style={
                           Object {
-                            "paddingLeft": 33,
-                            "paddingRight": 3,
+                            "color": "#777",
                           }
                         }
                       >
-                        <span
-                          style={
-                            Object {
-                              "color": "#777",
-                            }
-                          }
-                        >
-                          &lt;
-                          Heading
-                        </span>
-                        <span>
-                          <span>
-                             
-                            <span
-                              style={Object {}}
-                            >
-                              type
-                            </span>
-                            <span>
-                              =
-                              <span
-                                style={Object {}}
-                              >
-                                <span
-                                  style={
-                                    Object {
-                                      "color": "#22a",
-                                      "wordBreak": "break-word",
-                                    }
-                                  }
-                                >
-                                  "
-                                  title2
-                                  "
-                                </span>
-                              </span>
-                            </span>
-                          </span>
-                          <span>
-                             
-                            <span
-                              style={Object {}}
-                            >
-                              element
-                            </span>
-                            <span>
-                              =
-                              <span
-                                style={Object {}}
-                              >
-                                <span
-                                  style={
-                                    Object {
-                                      "color": "#22a",
-                                      "wordBreak": "break-word",
-                                    }
-                                  }
-                                >
-                                  "
-                                  h2
-                                  "
-                                </span>
-                              </span>
-                            </span>
-                            
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#777",
-                            }
-                          }
-                        >
-                          &gt;
-                        </span>
-                      </div>
-                      <div
-                        style={
-                          Object {
-                            "paddingLeft": 48,
-                            "paddingRight": 3,
-                          }
-                        }
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#777",
-                            }
-                          }
-                        >
-                          Orbit design system
-                        </span>
-                      </div>
-                      <div
-                        style={
-                          Object {
-                            "paddingLeft": 33,
-                            "paddingRight": 3,
-                          }
-                        }
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#777",
-                            }
-                          }
-                        >
-                          &lt;/
-                          Heading
-                          &gt;
-                        </span>
-                      </div>
+                        Orbit design system
+                      </span>
                     </div>
                     <div
                       style={
@@ -1176,7 +972,7 @@ exports[`Storyshots Heading Title 2 1`] = `
                         }
                       >
                         &lt;/
-                        ThemeProvider
+                        Heading
                         &gt;
                       </span>
                     </div>
@@ -1348,9 +1144,65 @@ exports[`Storyshots Heading Title 3 1`] = `
                         }
                       >
                         &lt;
-                        ThemeProvider
+                        Heading
                       </span>
-                      <span />
+                      <span>
+                        <span>
+                           
+                          <span
+                            style={Object {}}
+                          >
+                            type
+                          </span>
+                          <span>
+                            =
+                            <span
+                              style={Object {}}
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#22a",
+                                    "wordBreak": "break-word",
+                                  }
+                                }
+                              >
+                                "
+                                title3
+                                "
+                              </span>
+                            </span>
+                          </span>
+                        </span>
+                        <span>
+                           
+                          <span
+                            style={Object {}}
+                          >
+                            element
+                          </span>
+                          <span>
+                            =
+                            <span
+                              style={Object {}}
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#22a",
+                                    "wordBreak": "break-word",
+                                  }
+                                }
+                              >
+                                "
+                                h3
+                                "
+                              </span>
+                            </span>
+                          </span>
+                          
+                        </span>
+                      </span>
                       <span
                         style={
                           Object {
@@ -1361,130 +1213,23 @@ exports[`Storyshots Heading Title 3 1`] = `
                         &gt;
                       </span>
                     </div>
-                    <div>
-                      <div
+                    <div
+                      style={
+                        Object {
+                          "paddingLeft": 33,
+                          "paddingRight": 3,
+                        }
+                      }
+                    >
+                      <span
                         style={
                           Object {
-                            "paddingLeft": 33,
-                            "paddingRight": 3,
+                            "color": "#777",
                           }
                         }
                       >
-                        <span
-                          style={
-                            Object {
-                              "color": "#777",
-                            }
-                          }
-                        >
-                          &lt;
-                          Heading
-                        </span>
-                        <span>
-                          <span>
-                             
-                            <span
-                              style={Object {}}
-                            >
-                              type
-                            </span>
-                            <span>
-                              =
-                              <span
-                                style={Object {}}
-                              >
-                                <span
-                                  style={
-                                    Object {
-                                      "color": "#22a",
-                                      "wordBreak": "break-word",
-                                    }
-                                  }
-                                >
-                                  "
-                                  title3
-                                  "
-                                </span>
-                              </span>
-                            </span>
-                          </span>
-                          <span>
-                             
-                            <span
-                              style={Object {}}
-                            >
-                              element
-                            </span>
-                            <span>
-                              =
-                              <span
-                                style={Object {}}
-                              >
-                                <span
-                                  style={
-                                    Object {
-                                      "color": "#22a",
-                                      "wordBreak": "break-word",
-                                    }
-                                  }
-                                >
-                                  "
-                                  h3
-                                  "
-                                </span>
-                              </span>
-                            </span>
-                            
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#777",
-                            }
-                          }
-                        >
-                          &gt;
-                        </span>
-                      </div>
-                      <div
-                        style={
-                          Object {
-                            "paddingLeft": 48,
-                            "paddingRight": 3,
-                          }
-                        }
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#777",
-                            }
-                          }
-                        >
-                          Orbit design system
-                        </span>
-                      </div>
-                      <div
-                        style={
-                          Object {
-                            "paddingLeft": 33,
-                            "paddingRight": 3,
-                          }
-                        }
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#777",
-                            }
-                          }
-                        >
-                          &lt;/
-                          Heading
-                          &gt;
-                        </span>
-                      </div>
+                        Orbit design system
+                      </span>
                     </div>
                     <div
                       style={
@@ -1502,7 +1247,7 @@ exports[`Storyshots Heading Title 3 1`] = `
                         }
                       >
                         &lt;/
-                        ThemeProvider
+                        Heading
                         &gt;
                       </span>
                     </div>
@@ -1674,9 +1419,38 @@ exports[`Storyshots Heading Title Display 1`] = `
                         }
                       >
                         &lt;
-                        ThemeProvider
+                        Heading
                       </span>
-                      <span />
+                      <span>
+                        <span>
+                           
+                          <span
+                            style={Object {}}
+                          >
+                            type
+                          </span>
+                          <span>
+                            =
+                            <span
+                              style={Object {}}
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#22a",
+                                    "wordBreak": "break-word",
+                                  }
+                                }
+                              >
+                                "
+                                display
+                                "
+                              </span>
+                            </span>
+                          </span>
+                          
+                        </span>
+                      </span>
                       <span
                         style={
                           Object {
@@ -1687,103 +1461,23 @@ exports[`Storyshots Heading Title Display 1`] = `
                         &gt;
                       </span>
                     </div>
-                    <div>
-                      <div
+                    <div
+                      style={
+                        Object {
+                          "paddingLeft": 33,
+                          "paddingRight": 3,
+                        }
+                      }
+                    >
+                      <span
                         style={
                           Object {
-                            "paddingLeft": 33,
-                            "paddingRight": 3,
+                            "color": "#777",
                           }
                         }
                       >
-                        <span
-                          style={
-                            Object {
-                              "color": "#777",
-                            }
-                          }
-                        >
-                          &lt;
-                          Heading
-                        </span>
-                        <span>
-                          <span>
-                             
-                            <span
-                              style={Object {}}
-                            >
-                              type
-                            </span>
-                            <span>
-                              =
-                              <span
-                                style={Object {}}
-                              >
-                                <span
-                                  style={
-                                    Object {
-                                      "color": "#22a",
-                                      "wordBreak": "break-word",
-                                    }
-                                  }
-                                >
-                                  "
-                                  display
-                                  "
-                                </span>
-                              </span>
-                            </span>
-                            
-                          </span>
-                        </span>
-                        <span
-                          style={
-                            Object {
-                              "color": "#777",
-                            }
-                          }
-                        >
-                          &gt;
-                        </span>
-                      </div>
-                      <div
-                        style={
-                          Object {
-                            "paddingLeft": 48,
-                            "paddingRight": 3,
-                          }
-                        }
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#777",
-                            }
-                          }
-                        >
-                          Orbit design system
-                        </span>
-                      </div>
-                      <div
-                        style={
-                          Object {
-                            "paddingLeft": 33,
-                            "paddingRight": 3,
-                          }
-                        }
-                      >
-                        <span
-                          style={
-                            Object {
-                              "color": "#777",
-                            }
-                          }
-                        >
-                          &lt;/
-                          Heading
-                          &gt;
-                        </span>
-                      </div>
+                        Orbit design system
+                      </span>
                     </div>
                     <div
                       style={
@@ -1801,7 +1495,7 @@ exports[`Storyshots Heading Title Display 1`] = `
                         }
                       >
                         &lt;/
-                        ThemeProvider
+                        Heading
                         &gt;
                       </span>
                     </div>

--- a/src/Heading/__tests__/__snapshots__/index.test.js.snap
+++ b/src/Heading/__tests__/__snapshots__/index.test.js.snap
@@ -1,7 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Heading with defaultProps should match snapshot 1`] = `
-<ThemeProvider
+<Heading__StyledHeading
+  element="h1"
   theme={
     Object {
       "backgroundAlertCritical": "#fae8e8",
@@ -359,12 +360,24 @@ exports[`Heading with defaultProps should match snapshot 1`] = `
       "zIndexSticky": "100",
     }
   }
+  tokens={
+    Object {
+      "sizeHeading": Object {
+        "display": "40px",
+        "title1": "28px",
+        "title2": "22px",
+        "title3": "16px",
+      },
+      "weightHeading": Object {
+        "display": "700",
+        "title1": "700",
+        "title2": "500",
+        "title3": "500",
+      },
+    }
+  }
+  type="title1"
 >
-  <Heading
-    element="h1"
-    type="title1"
-  >
-    Children title
-  </Heading>
-</ThemeProvider>
+  Children title
+</Heading__StyledHeading>
 `;

--- a/src/Heading/__tests__/index.test.js
+++ b/src/Heading/__tests__/index.test.js
@@ -2,25 +2,20 @@
 import * as React from "react";
 import { shallow } from "enzyme";
 
-import Heading from "../index";
-import ThemeProvider from "../../Theming/ThemeProvider";
+import Heading from "../Heading";
 
 const children = "Children title";
-const component = shallow(
-  <ThemeProvider>
-    <Heading>{children}</Heading>
-  </ThemeProvider>,
-);
 
 describe("Heading with defaultProps", () => {
-  // it("should contain children", () => {
-  //   expect(
-  //     component
-  //       .find("Heading__StyledHeading")
-  //       .render()
-  //       .text(),
-  //   ).toBe(children);
-  // });
+  const component = shallow(<Heading>{children}</Heading>);
+  it("should contain children", () => {
+    expect(
+      component
+        .find("Heading__StyledHeading")
+        .render()
+        .text(),
+    ).toBe(children);
+  });
   it("should match snapshot", () => {
     expect(component).toMatchSnapshot();
   });

--- a/src/Heading/index.js
+++ b/src/Heading/index.js
@@ -1,59 +1,6 @@
 // @flow
-import * as React from "react";
-import styled from "styled-components";
-import defaultTokens from "@kiwicom/orbit-design-tokens";
 import { withTheme } from "theming";
-import createComponentFromTagProp from "react-create-component-from-tag-prop";
 
-type Props = {
-  element: "h1" | "h2" | "h3" | "h4" | "h5",
-  type: "display" | "title1" | "title2" | "title3",
-  children: React.Node,
-  theme: typeof defaultTokens,
-};
+import Heading from "./Heading";
 
-const HeadingElement = createComponentFromTagProp({
-  prop: "element",
-  propsToOmit: ["type", "tokens", "theme"],
-});
-
-const StyledHeading = styled(HeadingElement)`
-  font-family: ${props => props.theme.fontFamily};
-  font-size: ${props => props.tokens.sizeHeading[props.type]};
-  font-weight: ${props => props.tokens.weightHeading[props.type]};
-  color: ${props => props.theme.colorHeading};
-  line-height: ${props => props.theme.lineHeightHeading};
-  margin: 0;
-`;
-
-const Heading = (props: Props) => {
-  const { children, theme } = props;
-  const tokens = {
-    weightHeading: {
-      display: theme.fontWeightHeadingDisplay,
-      title1: theme.fontWeightHeadingLevel1,
-      title2: theme.fontWeightHeadingLevel2,
-      title3: theme.fontWeightHeadingLevel3,
-    },
-    sizeHeading: {
-      display: theme.fontSizeHeadingDisplay,
-      title1: theme.fontSizeHeadingTitle1,
-      title2: theme.fontSizeHeadingTitle2,
-      title3: theme.fontSizeHeadingTitle3,
-    },
-  };
-  return (
-    <StyledHeading tokens={tokens} {...props}>
-      {children}
-    </StyledHeading>
-  );
-};
-
-const HeadingWithTheme = withTheme(Heading);
-HeadingWithTheme.displayName = "Heading";
-HeadingWithTheme.defaultProps = {
-  element: "h1",
-  type: "title1",
-};
-
-export default HeadingWithTheme;
+export default withTheme(Heading);


### PR DESCRIPTION
Separated withTheme from Heading component.
Deleted ThemeProvider and unnecessary options from stories.
Updated test.
Added constants for element and type options.

**No more changes**