### PR TITLE
TextLink: Make href prop optional

### DIFF
--- a/src/TextLink/TextLink.js
+++ b/src/TextLink/TextLink.js
@@ -10,7 +10,7 @@ export const TYPE_OPTIONS = {
 
 type Props = {|
   children: React.Node,
-  href: string,
+  href?: string,
   onClick?: (SyntheticEvent<HTMLLinkElement>) => any,
   external: boolean,
   type: $Values<typeof TYPE_OPTIONS>,


### PR DESCRIPTION
TextLink's `href` prop should be optional. As said in #181 