### PR TITLE
UPDATE: Textarea resize

### DIFF
--- a/src/Textarea/README.md
+++ b/src/Textarea/README.md
@@ -22,15 +22,16 @@ Table below contains all types of the props available in Textarea component.
 | onFocus       | `func`            |              | Function for handling onFocus event.
 | onBlur        | `func`            |              | Function for handling onBlur event.
 | placeholder   | `string`          |              | The placeholder of the Textarea.
+| resize        | [`enum`](#enum)   | `"vertical"` | The resize option for Textarea.
 | size          | [`enum`](#enum)   | `"normal"`   | The size of the Textarea.
 | value         | `string`          |              | Specifies the value of the Textarea.
 
 ### enum
 
-| size         |
-| :----------- |
-| `"small"`    |
-| `"normal"`   |
+| size         | resize        |
+| :----------- | :------------ |
+| `"small"`    | `"vertical"`
+| `"normal"`   | `"none"`
 
 
 ## Functional specs

--- a/src/Textarea/Textarea.stories.js
+++ b/src/Textarea/Textarea.stories.js
@@ -7,7 +7,7 @@ import styles from "@sambego/storybook-styles";
 import chaptersAddon from "react-storybook-addon-chapters";
 import { withKnobs, text, boolean, select, number } from "@storybook/addon-knobs/react";
 
-import SIZE_OPTIONS from "./consts";
+import { SIZE_OPTIONS, RESIZE_OPTIONS } from "./consts";
 
 import Textarea from "./index";
 
@@ -146,6 +146,7 @@ storiesOf("Textarea", module)
     const help = text("Help", undefined);
     const error = text("Error", "Something went wrong.");
     const disabled = boolean("Disabled", true);
+    const resize = select("resize", Object.values(RESIZE_OPTIONS), RESIZE_OPTIONS.VERTICAL);
     const maxLength = number("maxLength", undefined);
 
     return {
@@ -164,6 +165,7 @@ storiesOf("Textarea", module)
                   error={error}
                   disabled={disabled}
                   maxLength={maxLength}
+                  resize={resize}
                   onChange={action("change")}
                   onFocus={action("focus")}
                   onBlur={action("blur")}

--- a/src/Textarea/__snapshots__/Textarea.stories.storyshot
+++ b/src/Textarea/__snapshots__/Textarea.stories.storyshot
@@ -102,7 +102,7 @@ exports[`Storyshots Textarea Default 1`] = `
             className="Textarea__Field-kPVRAV bXkLzV"
           >
             <textarea
-              className="Textarea__StyledTextArea-iLqCZR gJcQYq"
+              className="Textarea__StyledTextArea-iLqCZR iGNvEa"
               disabled={undefined}
               maxLength={undefined}
               name={undefined}
@@ -110,6 +110,7 @@ exports[`Storyshots Textarea Default 1`] = `
               onChange={[Function]}
               onFocus={undefined}
               placeholder="Placeholder"
+              resize="vertical"
               value=""
             />
           </label>
@@ -380,7 +381,7 @@ exports[`Storyshots Textarea Playground 1`] = `
               Label
             </span>
             <textarea
-              className="Textarea__StyledTextArea-iLqCZR gMThpy"
+              className="Textarea__StyledTextArea-iLqCZR dmuRbo"
               disabled={true}
               maxLength={undefined}
               name={undefined}
@@ -388,6 +389,7 @@ exports[`Storyshots Textarea Playground 1`] = `
               onChange={[Function]}
               onFocus={[Function]}
               placeholder="Placeholder"
+              resize="vertical"
               value=""
             />
             <div
@@ -682,6 +684,36 @@ exports[`Storyshots Textarea Playground 1`] = `
                         <span
                           style={Object {}}
                         >
+                          resize
+                        </span>
+                        <span>
+                          =
+                          <span
+                            style={Object {}}
+                          >
+                            <span
+                              style={
+                                Object {
+                                  "color": "#22a",
+                                  "wordBreak": "break-word",
+                                }
+                              }
+                            >
+                              "
+                              vertical
+                              "
+                            </span>
+                          </span>
+                        </span>
+                      </span>
+                      <span>
+                        <span>
+                          <br />
+                            
+                        </span>
+                        <span
+                          style={Object {}}
+                        >
                           onChange
                         </span>
                         <span>
@@ -892,7 +924,7 @@ exports[`Storyshots Textarea Small size 1`] = `
             className="Textarea__Field-kPVRAV bXkLzV"
           >
             <textarea
-              className="Textarea__StyledTextArea-iLqCZR ftiWeK"
+              className="Textarea__StyledTextArea-iLqCZR cJMXZI"
               disabled={undefined}
               maxLength={undefined}
               name={undefined}
@@ -900,6 +932,7 @@ exports[`Storyshots Textarea Small size 1`] = `
               onChange={[Function]}
               onFocus={undefined}
               placeholder="Placeholder"
+              resize="vertical"
               value=""
             />
           </label>
@@ -1204,7 +1237,7 @@ exports[`Storyshots Textarea With error 1`] = `
             className="Textarea__Field-kPVRAV bXkLzV"
           >
             <textarea
-              className="Textarea__StyledTextArea-iLqCZR QEMrH"
+              className="Textarea__StyledTextArea-iLqCZR ifTVOV"
               disabled={undefined}
               maxLength={undefined}
               name={undefined}
@@ -1212,6 +1245,7 @@ exports[`Storyshots Textarea With error 1`] = `
               onChange={[Function]}
               onFocus={undefined}
               placeholder="Placeholder"
+              resize="vertical"
               value="Something"
             />
             <div
@@ -1521,7 +1555,7 @@ exports[`Storyshots Textarea With help 1`] = `
             className="Textarea__Field-kPVRAV bXkLzV"
           >
             <textarea
-              className="Textarea__StyledTextArea-iLqCZR gJcQYq"
+              className="Textarea__StyledTextArea-iLqCZR iGNvEa"
               disabled={undefined}
               maxLength={undefined}
               name={undefined}
@@ -1529,6 +1563,7 @@ exports[`Storyshots Textarea With help 1`] = `
               onChange={[Function]}
               onFocus={undefined}
               placeholder="Placeholder"
+              resize="vertical"
               value="Something"
             />
             <div
@@ -1843,7 +1878,7 @@ exports[`Storyshots Textarea With label 1`] = `
               Label
             </span>
             <textarea
-              className="Textarea__StyledTextArea-iLqCZR gJcQYq"
+              className="Textarea__StyledTextArea-iLqCZR iGNvEa"
               disabled={undefined}
               maxLength={undefined}
               name={undefined}
@@ -1851,6 +1886,7 @@ exports[`Storyshots Textarea With label 1`] = `
               onChange={[Function]}
               onFocus={undefined}
               placeholder="Placeholder"
+              resize="vertical"
               value=""
             />
           </label>

--- a/src/Textarea/__tests__/__snapshots__/index.test.js.snap
+++ b/src/Textarea/__tests__/__snapshots__/index.test.js.snap
@@ -330,6 +330,7 @@ exports[`Textarea number with error and help should match snapshot 1`] = `
         Something went wrong.
       </div>
     }
+    resize="none"
     size="small"
     theme={
       Object {
@@ -1373,6 +1374,7 @@ exports[`Textarea with help should match snapshot 1`] = `
       }
     }
     placeholder="placeholder"
+    resize="vertical"
     size="normal"
     theme={
       Object {

--- a/src/Textarea/__tests__/index.test.js
+++ b/src/Textarea/__tests__/index.test.js
@@ -3,7 +3,7 @@ import * as React from "react";
 import { shallow } from "enzyme";
 
 import Textarea from "../index";
-import SIZE_OPTIONS from "../consts";
+import { SIZE_OPTIONS, RESIZE_OPTIONS } from "../consts";
 
 describe(`Textarea with help`, () => {
   const size = SIZE_OPTIONS.NORMAL;
@@ -72,10 +72,12 @@ describe(`Textarea with help`, () => {
 });
 describe(`Textarea number with error and help`, () => {
   const size = SIZE_OPTIONS.SMALL;
+  const resize = RESIZE_OPTIONS.NONE;
 
   const component = shallow(
     <Textarea
       size={size}
+      resize={resize}
       help={<div>Everything is fine.</div>}
       error={<div>Something went wrong.</div>}
     />,
@@ -86,6 +88,9 @@ describe(`Textarea number with error and help`, () => {
   });
   it("should have size prop", () => {
     expect(component.find("Textarea__StyledTextArea").prop("size")).toBe(size);
+  });
+  it("should have size prop", () => {
+    expect(component.find("Textarea__StyledTextArea").prop("resize")).toBe(resize);
   });
   it("should NOT contain FeedBack help", () => {
     expect(component.find(`FormFeedback[type="help"]`).exists()).toBe(false);

--- a/src/Textarea/consts.js
+++ b/src/Textarea/consts.js
@@ -1,8 +1,10 @@
 // @flow
 
-const SIZE_OPTIONS = {
+export const SIZE_OPTIONS = {
   SMALL: "small",
   NORMAL: "normal",
 };
-
-export default SIZE_OPTIONS;
+export const RESIZE_OPTIONS = {
+  VERTICAL: "vertical",
+  NONE: "none",
+};

--- a/src/Textarea/index.js
+++ b/src/Textarea/index.js
@@ -5,7 +5,7 @@ import styled from "styled-components";
 import defaultTokens from "../defaultTokens";
 import FormFeedback from "../FormFeedback";
 import FormLabel from "../FormLabel";
-import SIZE_OPTIONS from "./consts";
+import { SIZE_OPTIONS, RESIZE_OPTIONS } from "./consts";
 
 import type { Props } from "./index";
 
@@ -38,8 +38,10 @@ const StyledTextArea = styled(({ theme, tokens, size, error, help, ...props }) =
   line-height: ${({ theme }) => theme.orbit.lineHeightText};
   cursor: ${({ disabled }) => (disabled ? "not-allowed" : "text")};
   font-family: inherit;
-  resize: none;
-  transition: all ${({ theme }) => theme.orbit.durationFast} ease-in-out;
+  resize: ${({ resize }) => resize};
+  transition: box-shadow ${({ theme }) => theme.orbit.durationFast} ease-in-out, border-color ${({
+  theme,
+}) => theme.orbit.durationFast} ease-in-out;
   
   &::placeholder {
     color: ${({ theme }) => theme.orbit.colorPlaceholderInput};
@@ -69,7 +71,12 @@ StyledTextArea.defaultProps = {
 };
 
 const Textarea = (props: Props) => {
-  const { size = SIZE_OPTIONS.NORMAL, theme = defaultTokens, disabled } = props;
+  const {
+    size = SIZE_OPTIONS.NORMAL,
+    theme = defaultTokens,
+    disabled,
+    resize = RESIZE_OPTIONS.VERTICAL,
+  } = props;
 
   const tokens = {
     fontSizeInput: {
@@ -100,6 +107,7 @@ const Textarea = (props: Props) => {
         onChange={props.onChange}
         onFocus={props.onFocus}
         onBlur={props.onBlur}
+        resize={resize}
       />
       {props.help && !props.error && <FormFeedback type="help">{props.help}</FormFeedback>}
       {props.error && <FormFeedback type="error">{props.error}</FormFeedback>}

--- a/src/Textarea/index.js.flow
+++ b/src/Textarea/index.js.flow
@@ -9,6 +9,7 @@ export type Props = {|
   +placeholder?: string,
   +help?: React$Node,
   +error?: React$Node,
+  +resize?: "vertical" | "none",
   +disabled?: boolean,
   +maxLength?: number,
   +onChange?: (ev: SyntheticInputEvent<HTMLTextAreaElement>) => void | Promise<any>,


### PR DESCRIPTION
Default `resize` changed to `vertical`.

Added optional prop `noResize` that sets `resize` to `none`.

Updated test and transition - animating only `border-color` and `box-shadow` due to enabled resizing.