### PR TITLE
Update dependency eslint to v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "^1.1.1",
     "enzyme-to-json": "^3.3.3",
-    "eslint": "^4.19.1",
+    "eslint": "^5.0.0",
     "eslint-config-airbnb": "^16.1.0",
     "eslint-config-prettier": "^2.9.0",
     "eslint-plugin-flowtype": "^2.46.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -569,15 +569,11 @@ acorn-globals@^4.1.0:
   dependencies:
     acorn "^5.0.0"
 
-acorn-jsx@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-3.0.1.tgz#afdf9488fb1ecefc8348f6fb22f464e32a58b36b"
+acorn-jsx@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-4.1.1.tgz#e8e41e48ea2fe0c896740610ab6a4ffd8add225e"
   dependencies:
-    acorn "^3.0.4"
-
-acorn@^3.0.4:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
+    acorn "^5.0.3"
 
 acorn@^4.0.3:
   version "4.0.13"
@@ -587,9 +583,9 @@ acorn@^5.0.0, acorn@^5.3.0:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.4.1.tgz#fdc58d9d17f4a4e98d102ded826a9b9759125102"
 
-acorn@^5.5.0:
-  version "5.5.3"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.5.3.tgz#f473dd47e0277a08e28e9bec5aeeb04751f0b8c9"
+acorn@^5.0.3, acorn@^5.6.0:
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.1.tgz#f095829297706a7c9776958c0afc8930a9b9d9d8"
 
 address@1.0.3, address@^1.0.1:
   version "1.0.3"
@@ -618,9 +614,9 @@ airbnb-js-shims@^1.4.0, airbnb-js-shims@^1.4.1:
     string.prototype.padend "^3.0.0"
     string.prototype.padstart "^3.0.0"
 
-ajv-keywords@^2.1.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-2.1.1.tgz#617997fc5f60576894c435f940d819e135b80762"
+ajv-keywords@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.2.0.tgz#e86b819c602cf8821ad637413698f1dec021847a"
 
 ajv-keywords@^3.1.0:
   version "3.1.0"
@@ -633,7 +629,7 @@ ajv@^4.9.1:
     co "^4.6.0"
     json-stable-stringify "^1.0.1"
 
-ajv@^5.0.0, ajv@^5.1.0, ajv@^5.2.3, ajv@^5.3.0:
+ajv@^5.0.0, ajv@^5.1.0:
   version "5.5.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.2.tgz#73b5eeca3fab653e3d3f9422b341ad42205dc965"
   dependencies:
@@ -641,6 +637,15 @@ ajv@^5.0.0, ajv@^5.1.0, ajv@^5.2.3, ajv@^5.3.0:
     fast-deep-equal "^1.0.0"
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.3.0"
+
+ajv@^6.0.1, ajv@^6.5.0:
+  version "6.5.3"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.5.3.tgz#71a569d189ecf4f4f321224fecb166f071dd90f9"
+  dependencies:
+    fast-deep-equal "^2.0.1"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
 
 ajv@^6.1.0:
   version "6.1.1"
@@ -968,7 +973,7 @@ babel-cli@^6.26.0:
   optionalDependencies:
     chokidar "^1.6.1"
 
-babel-code-frame@6.26.0, babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
+babel-code-frame@6.26.0, babel-code-frame@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
   dependencies:
@@ -2815,7 +2820,7 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
-concat-stream@1.6.0, concat-stream@^1.5.0, concat-stream@^1.6.0:
+concat-stream@1.6.0, concat-stream@^1.5.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.0.tgz#0aac662fd52be78964d5532f694784e70110acf7"
   dependencies:
@@ -2980,11 +2985,21 @@ create-react-class@^15.5.2, create-react-class@^15.6.2:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
-cross-spawn@5.1.0, cross-spawn@^5.0.1, cross-spawn@^5.1.0:
+cross-spawn@5.1.0, cross-spawn@^5.0.1:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
   dependencies:
     lru-cache "^4.0.1"
+    shebang-command "^1.2.0"
+    which "^1.2.9"
+
+cross-spawn@^6.0.5:
+  version "6.0.5"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
+  dependencies:
+    nice-try "^1.0.4"
+    path-key "^2.0.1"
+    semver "^5.5.0"
     shebang-command "^1.2.0"
     which "^1.2.9"
 
@@ -3843,66 +3858,77 @@ eslint-restricted-globals@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/eslint-restricted-globals/-/eslint-restricted-globals-0.1.1.tgz#35f0d5cbc64c2e3ed62e93b4b1a7af05ba7ed4d7"
 
-eslint-scope@^3.7.1, eslint-scope@~3.7.1:
+eslint-scope@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.0.tgz#50bf3071e9338bcdc43331794a0cb533f0136172"
+  dependencies:
+    esrecurse "^4.1.0"
+    estraverse "^4.1.1"
+
+eslint-scope@~3.7.1:
   version "3.7.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-3.7.1.tgz#3d63c3edfda02e06e01a452ad88caacc7cdcb6e8"
   dependencies:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
+eslint-utils@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.3.1.tgz#9a851ba89ee7c460346f97cf8939c7298827e512"
+
 eslint-visitor-keys@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
 
-eslint@^4.19.1:
-  version "4.19.1"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.19.1.tgz#32d1d653e1d90408854bfb296f076ec7e186a300"
+eslint@^5.0.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-5.4.0.tgz#d068ec03006bb9e06b429dc85f7e46c1b69fac62"
   dependencies:
-    ajv "^5.3.0"
-    babel-code-frame "^6.22.0"
+    ajv "^6.5.0"
+    babel-code-frame "^6.26.0"
     chalk "^2.1.0"
-    concat-stream "^1.6.0"
-    cross-spawn "^5.1.0"
+    cross-spawn "^6.0.5"
     debug "^3.1.0"
     doctrine "^2.1.0"
-    eslint-scope "^3.7.1"
+    eslint-scope "^4.0.0"
+    eslint-utils "^1.3.1"
     eslint-visitor-keys "^1.0.0"
-    espree "^3.5.4"
-    esquery "^1.0.0"
+    espree "^4.0.0"
+    esquery "^1.0.1"
     esutils "^2.0.2"
     file-entry-cache "^2.0.0"
     functional-red-black-tree "^1.0.1"
     glob "^7.1.2"
-    globals "^11.0.1"
-    ignore "^3.3.3"
+    globals "^11.7.0"
+    ignore "^4.0.2"
     imurmurhash "^0.1.4"
-    inquirer "^3.0.6"
-    is-resolvable "^1.0.0"
-    js-yaml "^3.9.1"
+    inquirer "^5.2.0"
+    is-resolvable "^1.1.0"
+    js-yaml "^3.11.0"
     json-stable-stringify-without-jsonify "^1.0.1"
     levn "^0.3.0"
-    lodash "^4.17.4"
-    minimatch "^3.0.2"
+    lodash "^4.17.5"
+    minimatch "^3.0.4"
     mkdirp "^0.5.1"
     natural-compare "^1.4.0"
     optionator "^0.8.2"
     path-is-inside "^1.0.2"
     pluralize "^7.0.0"
     progress "^2.0.0"
-    regexpp "^1.0.1"
+    regexpp "^2.0.0"
     require-uncached "^1.0.3"
-    semver "^5.3.0"
+    semver "^5.5.0"
     strip-ansi "^4.0.0"
-    strip-json-comments "~2.0.1"
-    table "4.0.2"
-    text-table "~0.2.0"
+    strip-json-comments "^2.0.1"
+    table "^4.0.3"
+    text-table "^0.2.0"
 
-espree@^3.5.4:
-  version "3.5.4"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-3.5.4.tgz#b0f447187c8a8bed944b815a660bddf5deb5d1a7"
+espree@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-4.0.0.tgz#253998f20a0f82db5d866385799d912a83a36634"
   dependencies:
-    acorn "^5.5.0"
-    acorn-jsx "^3.0.0"
+    acorn "^5.6.0"
+    acorn-jsx "^4.1.1"
 
 esprima@^2.6.0:
   version "2.7.3"
@@ -3916,9 +3942,9 @@ esprima@^4.0.0, esprima@~4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.0.tgz#4499eddcd1110e0b218bacf2fa7f7f59f55ca804"
 
-esquery@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.0.0.tgz#cfba8b57d7fba93f17298a8a006a04cda13d80fa"
+esquery@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.0.1.tgz#406c51658b1f5991a5f9b62b1dc25b00e3e5c708"
   dependencies:
     estraverse "^4.0.0"
 
@@ -4130,6 +4156,14 @@ external-editor@^2.0.4:
     iconv-lite "^0.4.17"
     tmp "^0.0.33"
 
+external-editor@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-2.2.0.tgz#045511cfd8d133f3846673d1047c154e214ad3d5"
+  dependencies:
+    chardet "^0.4.0"
+    iconv-lite "^0.4.17"
+    tmp "^0.0.33"
+
 extglob@^0.3.1:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/extglob/-/extglob-0.3.2.tgz#2e18ff3d2f49ab2765cec9023f011daa8d8349a1"
@@ -4173,6 +4207,10 @@ faker@^4.1.0:
 fast-deep-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz#96256a3bc975595eb36d82e9929d060d893439ff"
+
+fast-deep-equal@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
 
 fast-diff@^1.1.1:
   version "1.1.2"
@@ -4626,13 +4664,13 @@ global@^4.3.2:
     min-document "^2.19.0"
     process "~0.5.1"
 
-globals@^11.0.1:
-  version "11.3.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-11.3.0.tgz#e04fdb7b9796d8adac9c8f64c14837b2313378b0"
-
 globals@^11.1.0:
   version "11.5.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.5.0.tgz#6bc840de6771173b191f13d3a9c94d441ee92642"
+
+globals@^11.7.0:
+  version "11.7.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-11.7.0.tgz#a583faa43055b1aca771914bf68258e2fc125673"
 
 globals@^9.18.0:
   version "9.18.0"
@@ -5028,9 +5066,9 @@ iferr@^0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/iferr/-/iferr-0.1.5.tgz#c60eed69e6d8fdb6b3104a1fcbca1c192dc5b501"
 
-ignore@^3.3.3:
-  version "3.3.7"
-  resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.7.tgz#612289bfb3c220e186a58118618d5be8c1bab021"
+ignore@^4.0.2:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
 
 immutable@^3.8.1:
   version "3.8.2"
@@ -5088,7 +5126,7 @@ inline-style-prefixer@^3.0.6:
     bowser "^1.7.3"
     css-in-js-utils "^2.0.0"
 
-inquirer@3.3.0, inquirer@^3.0.6:
+inquirer@3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-3.3.0.tgz#9dd2f2ad765dcab1ff0443b491442a20ba227dc9"
   dependencies:
@@ -5103,6 +5141,24 @@ inquirer@3.3.0, inquirer@^3.0.6:
     run-async "^2.2.0"
     rx-lite "^4.0.8"
     rx-lite-aggregates "^4.0.8"
+    string-width "^2.1.0"
+    strip-ansi "^4.0.0"
+    through "^2.3.6"
+
+inquirer@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-5.2.0.tgz#db350c2b73daca77ff1243962e9f22f099685726"
+  dependencies:
+    ansi-escapes "^3.0.0"
+    chalk "^2.0.0"
+    cli-cursor "^2.1.0"
+    cli-width "^2.0.0"
+    external-editor "^2.1.0"
+    figures "^2.0.0"
+    lodash "^4.3.0"
+    mute-stream "0.0.7"
+    run-async "^2.2.0"
+    rxjs "^5.5.2"
     string-width "^2.1.0"
     strip-ansi "^4.0.0"
     through "^2.3.6"
@@ -5373,7 +5429,7 @@ is-regex@^1.0.4:
   dependencies:
     has "^1.0.1"
 
-is-resolvable@^1.0.0:
+is-resolvable@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.1.0.tgz#fb18f87ce1feb925169c9a407c19318a3206ed88"
 
@@ -5868,7 +5924,14 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
-js-yaml@^3.4.3, js-yaml@^3.7.0, js-yaml@^3.9.1, js-yaml@~3.10.0:
+js-yaml@^3.11.0:
+  version "3.12.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
+js-yaml@^3.4.3, js-yaml@^3.7.0, js-yaml@~3.10.0:
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.10.0.tgz#2e78441646bd4682e963f22b6e92823c309c62dc"
   dependencies:
@@ -5978,6 +6041,10 @@ json-parse-better-errors@^1.0.1:
 json-schema-traverse@^0.3.0:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz#349a6d44c53a51de89b40805c5d5e59b417d3340"
+
+json-schema-traverse@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
 
 json-schema@0.2.3:
   version "0.2.3"
@@ -6630,6 +6697,10 @@ nested-object-assign@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/nested-object-assign/-/nested-object-assign-1.0.2.tgz#9a84ef51b5c11298b5476d6c65b26458c9eae82b"
 
+nice-try@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.4.tgz#d93962f6c52f2c1558c0fbda6d512819f1efe1c4"
+
 no-case@^2.2.0:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/no-case/-/no-case-2.3.2.tgz#60b813396be39b3f1288a4c1ed5d1e7d28b464ac"
@@ -7078,7 +7149,7 @@ path-is-inside@^1.0.1, path-is-inside@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
 
-path-key@^2.0.0:
+path-key@^2.0.0, path-key@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
 
@@ -8193,9 +8264,9 @@ regex-not@^1.0.0, regex-not@^1.0.2:
     extend-shallow "^3.0.2"
     safe-regex "^1.1.0"
 
-regexpp@^1.0.1:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-1.1.0.tgz#0e3516dd0b7904f413d2d4193dce4618c3a689ab"
+regexpp@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-2.0.0.tgz#b2a7534a85ca1b033bcf5ce9ff8e56d4e0755365"
 
 regexpu-core@^1.0.0:
   version "1.0.0"
@@ -8453,6 +8524,12 @@ rx-lite@*, rx-lite@^4.0.8:
 rx@2.3.24:
   version "2.3.24"
   resolved "https://registry.yarnpkg.com/rx/-/rx-2.3.24.tgz#14f950a4217d7e35daa71bbcbe58eff68ea4b2b7"
+
+rxjs@^5.5.2:
+  version "5.5.11"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.11.tgz#f733027ca43e3bec6b994473be4ab98ad43ced87"
+  dependencies:
+    symbol-observable "1.0.1"
 
 safe-buffer@5.1.1, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
@@ -8991,7 +9068,7 @@ strip-eof@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
 
-strip-json-comments@~2.0.1:
+strip-json-comments@^2.0.1, strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
@@ -9105,6 +9182,10 @@ svgo@^1.0.5:
     unquote "~1.1.1"
     util.promisify "~1.0.0"
 
+symbol-observable@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.1.tgz#8340fc4702c3122df5d22288f88283f513d3fdd4"
+
 symbol-observable@1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.4.tgz#29bf615d4aa7121bdd898b22d4b3f9bc4e2aa03d"
@@ -9117,12 +9198,12 @@ symbol-tree@^3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.2.tgz#ae27db38f660a7ae2e1c3b7d1bc290819b8519e6"
 
-table@4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/table/-/table-4.0.2.tgz#a33447375391e766ad34d3486e6e2aedc84d2e36"
+table@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/table/-/table-4.0.3.tgz#00b5e2b602f1794b9acaf9ca908a76386a7813bc"
   dependencies:
-    ajv "^5.2.3"
-    ajv-keywords "^2.1.0"
+    ajv "^6.0.1"
+    ajv-keywords "^3.0.0"
     chalk "^2.1.0"
     lodash "^4.17.4"
     slice-ansi "1.0.0"
@@ -9163,7 +9244,7 @@ test-exclude@^4.2.1:
     read-pkg-up "^1.0.1"
     require-main-filename "^1.0.1"
 
-text-table@0.2.0, text-table@~0.2.0:
+text-table@0.2.0, text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
 
@@ -9459,6 +9540,12 @@ upath@^1.0.0:
 upper-case@^1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/upper-case/-/upper-case-1.1.3.tgz#f6b4501c2ec4cdd26ba78be7222961de77621598"
+
+uri-js@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.2.2.tgz#94c540e1ff772956e2299507c010aea6c8838eb0"
+  dependencies:
+    punycode "^2.1.0"
 
 urix@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
<p>This Pull Request updates devDependency <code>eslint</code> (<a href="https://eslint.org">homepage</a>, <a href="https://renovatebot.com/gh/eslint/eslint">source</a>) from <code>^4.19.1</code> to <code>^5.0.0</code></p>
<p><details><br />
<summary>Release Notes</summary></p>
<h3 id="v540httpsgithubcomeslinteslintreleasesv540"><a href="https://renovatebot.com/gh/eslint/eslint/releases/v5.4.0"><code>v5.4.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/eslint/eslint/compare/v5.3.0…v5.4.0">Compare Source</a></p>
<ul>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/a70909f"><code>a70909f</code></a> Docs: Add jscs-dev.github.io links (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10771">#&#8203;10771</a>) (Gustavo Santana)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/034690f"><code>034690f</code></a> Fix: no-invalid-meta crashes for non Object values (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/10750">#&#8203;10750</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10753">#&#8203;10753</a>) (Sandeep Kumar Ranka)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/11a462d"><code>11a462d</code></a> Docs: Broken jscs.info URLs (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/10732">#&#8203;10732</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10770">#&#8203;10770</a>) (Gustavo Santana)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/985567d"><code>985567d</code></a> Chore: rm unused dep string.prototype.matchall (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10756">#&#8203;10756</a>) (薛定谔的猫)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/f3d8454"><code>f3d8454</code></a> Update: Improve no-extra-parens error message (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10748">#&#8203;10748</a>) (Timo Tijhof)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/562a03f"><code>562a03f</code></a> Fix: consistent-docs-url crashes if meta.docs is empty (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/10722">#&#8203;10722</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10749">#&#8203;10749</a>) (Sandeep Kumar Ranka)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/6492233"><code>6492233</code></a> Chore: enable no-prototype-builtins in codebase (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/10660">#&#8203;10660</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10664">#&#8203;10664</a>) (薛定谔的猫)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/137140f"><code>137140f</code></a> Chore: use eslintrc overrides (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10677">#&#8203;10677</a>) (薛定谔的猫)</li>
</ul>
<hr />
<h3 id="v530httpsgithubcomeslinteslintreleasesv530"><a href="https://renovatebot.com/gh/eslint/eslint/releases/v5.3.0"><code>v5.3.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/eslint/eslint/compare/v5.2.0…v5.3.0">Compare Source</a></p>
<ul>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/dd6cb19"><code>dd6cb19</code></a> Docs: Updated no-return-await Rule Documentation (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/9695">#&#8203;9695</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10699">#&#8203;10699</a>) (Marla Foreman)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/6009239"><code>6009239</code></a> Chore: rename utils for consistency (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10727">#&#8203;10727</a>) (薛定谔的猫)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/6eb972c"><code>6eb972c</code></a> New: require-unicode-regexp rule (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/9961">#&#8203;9961</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10698">#&#8203;10698</a>) (Toru Nagashima)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/5c5d64d"><code>5c5d64d</code></a> Fix: ignored-paths for Windows path (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/10687">#&#8203;10687</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10691">#&#8203;10691</a>) (Toru Nagashima)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/5f6a765"><code>5f6a765</code></a> Build: ensure URL fragments remain in documentation links (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/10717">#&#8203;10717</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10720">#&#8203;10720</a>) (Teddy Katz)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/863aa78"><code>863aa78</code></a> Docs: add another example for when not to use no-await-in-loop (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10714">#&#8203;10714</a>) (Valeri Karpov)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/6e78b7d"><code>6e78b7d</code></a> Docs: remove links to terminated jscs.info domain (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10706">#&#8203;10706</a>) (Piotr Kuczynski)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/d56c39d"><code>d56c39d</code></a> Fix: ESLint cache no longer stops autofix (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/10679">#&#8203;10679</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10694">#&#8203;10694</a>) (Kevin Partington)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/2cc3240"><code>2cc3240</code></a> New: add no-misleading-character-class (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/10049">#&#8203;10049</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10511">#&#8203;10511</a>) (Toru Nagashima)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/877f4b8"><code>877f4b8</code></a> Fix: The "../.." folder is always ignored (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/10675">#&#8203;10675</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10682">#&#8203;10682</a>) (Sridhar)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/5984820"><code>5984820</code></a> Chore: Move lib/file-finder.js to lib/util/ (refs <a href="https://renovatebot.com/gh/eslint/eslint/issues/10559">#&#8203;10559</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10695">#&#8203;10695</a>) (Kevin Partington)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/e37a593"><code>e37a593</code></a> Update: Fix incorrect default value for position (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10670">#&#8203;10670</a>) (Iulian Onofrei)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/8084bfc"><code>8084bfc</code></a> Docs: change when not to use object spread (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10621">#&#8203;10621</a>) (Benny Powers)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/7f496e2"><code>7f496e2</code></a> Chore: Update require path for ast-utils (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10693">#&#8203;10693</a>) (Kevin Partington)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/648a33a"><code>648a33a</code></a> Chore: reorganize code structure of utilities (refs <a href="https://renovatebot.com/gh/eslint/eslint/issues/10599">#&#8203;10599</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10680">#&#8203;10680</a>) (薛定谔的猫)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/f026fe1"><code>f026fe1</code></a> Update: Fix 'function' in padding-line-between-statements (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/10487">#&#8203;10487</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10676">#&#8203;10676</a>) (Kevin Partington)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/c2bb8bb"><code>c2bb8bb</code></a> Docs: Remove superfluous object option sample code (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10652">#&#8203;10652</a>) (Iulian Onofrei)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/d34a13b"><code>d34a13b</code></a> Docs: add subheader in configuring/configuring-rules (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10686">#&#8203;10686</a>) (薛定谔的猫)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/d8aea28"><code>d8aea28</code></a> Chore: rm unnecessary plugin in eslint-config-eslint (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10685">#&#8203;10685</a>) (薛定谔的猫)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/9e76be7"><code>9e76be7</code></a> Update: indent comments w/ nearby code if no blank lines (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/9733">#&#8203;9733</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10640">#&#8203;10640</a>) (Kevin Partington)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/9e93d46"><code>9e93d46</code></a> New: add no-async-promise-executor rule (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/10217">#&#8203;10217</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10661">#&#8203;10661</a>) (Teddy Katz)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/5a2538c"><code>5a2538c</code></a> New: require-atomic-updates rule (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/10405">#&#8203;10405</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10655">#&#8203;10655</a>) (Teddy Katz)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/8b83d2b"><code>8b83d2b</code></a> Fix: always resolve default ignore patterns from CWD (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/9227">#&#8203;9227</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10638">#&#8203;10638</a>) (Teddy Katz)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/acb6658"><code>acb6658</code></a> Fix: ESLint crash with prefer-object-spread (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/10646">#&#8203;10646</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10649">#&#8203;10649</a>) (薛定谔的猫)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/99fb7d3"><code>99fb7d3</code></a> Docs: fix misleading no-prototype-builtins description (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10666">#&#8203;10666</a>) (薛定谔的猫)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/005b849"><code>005b849</code></a> Docs: fix outdated description of <code>baseConfig</code> option (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10657">#&#8203;10657</a>) (Teddy Katz)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/15a77c4"><code>15a77c4</code></a> Docs: fix broken links (fixes <a href="https://renovatebot.com/gh/eslint/eslint-jp/issues/6">eslint/eslint-jp#&#8203;6</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10658">#&#8203;10658</a>) (Toru Nagashima)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/87cd344"><code>87cd344</code></a> Docs: Make marking a default option consistent with other rules (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10650">#&#8203;10650</a>) (Iulian Onofrei)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/0cb5e3e"><code>0cb5e3e</code></a> Chore: Replace some function application with spread operators (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10645">#&#8203;10645</a>) (Kevin Partington)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/b6daf0e"><code>b6daf0e</code></a> Docs: Remove superfluous section from no-unsafe-negation (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10648">#&#8203;10648</a>) (Iulian Onofrei)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/e1a3cac"><code>e1a3cac</code></a> Chore: rm deprecated experimentalObjectRestSpread option in tests (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10647">#&#8203;10647</a>) (薛定谔的猫)</li>
</ul>
<hr />
<h3 id="v520httpsgithubcomeslinteslintreleasesv520"><a href="https://renovatebot.com/gh/eslint/eslint/releases/v5.2.0"><code>v5.2.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/eslint/eslint/compare/v5.1.0…v5.2.0">Compare Source</a></p>
<ul>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/81283d0"><code>81283d0</code></a> Update: Cache files that failed linting (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/9948">#&#8203;9948</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10571">#&#8203;10571</a>) (Kevin Partington)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/13cc63e"><code>13cc63e</code></a> Upgrade: ignore@&#8203;4.0.2 (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10619">#&#8203;10619</a>) (Rouven Weßling)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/ac77a80"><code>ac77a80</code></a> Chore: Fixing a call to Object.assign.apply in Linter (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10629">#&#8203;10629</a>) (Kevin Partington)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/761f802"><code>761f802</code></a> Upgrade: eslint-plugin-node to 7.0.1 (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10612">#&#8203;10612</a>) (Toru Nagashima)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/c517b2a"><code>c517b2a</code></a> Build: fix npm run perf failing(fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/10577">#&#8203;10577</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10607">#&#8203;10607</a>) (薛定谔的猫)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/e596939"><code>e596939</code></a> Chore: fix redundant equality check (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10617">#&#8203;10617</a>) (Toru Nagashima)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/9f93d5f"><code>9f93d5f</code></a> Docs: Updated Working with Custom Formatters (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/9950">#&#8203;9950</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10592">#&#8203;10592</a>) (Marla Foreman)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/9aaf195"><code>9aaf195</code></a> Chore: Extract lint result cache logic (refs <a href="https://renovatebot.com/gh/eslint/eslint/issues/9948">#&#8203;9948</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10562">#&#8203;10562</a>) (Kevin Partington)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/80b296e"><code>80b296e</code></a> Build: package.json update for eslint-config-eslint release (ESLint Jenkins)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/e4e7ff2"><code>e4e7ff2</code></a> Chore: fix error message in eslint-config-eslint (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10588">#&#8203;10588</a>) (薛定谔的猫)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/1e88170"><code>1e88170</code></a> Chore: Move lib/logging and lib/timing to lib/util/ (refs <a href="https://renovatebot.com/gh/eslint/eslint/issues/10559">#&#8203;10559</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10579">#&#8203;10579</a>) (Kevin Partington)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/64dfa21"><code>64dfa21</code></a> Build: Fix prerelease logic in blog post generation (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/10578">#&#8203;10578</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10581">#&#8203;10581</a>) (Kevin Partington)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/0faf633"><code>0faf633</code></a> Chore: Simplify helper method in Linter tests (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10580">#&#8203;10580</a>) (Kevin Partington)</li>
</ul>
<hr />
<h3 id="v510httpsgithubcomeslinteslintreleasesv510"><a href="https://renovatebot.com/gh/eslint/eslint/releases/v5.1.0">v5.1.0</a></h3>
<p><a href="https://renovatebot.com/gh/eslint/eslint/compare/v5.0.1…v5.1.0">Compare Source</a></p>
<ul>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/7328f99"><code>7328f99</code></a> Build: package.json update for eslint-config-eslint release (ESLint Jenkins)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/b161f6b"><code>b161f6b</code></a> Build: Include prerelease install info in release blog post (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10463">#&#8203;10463</a>) (Kevin Partington)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/b2df738"><code>b2df738</code></a> Fix: prefer-object-spread duplicated comma (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/10512">#&#8203;10512</a>, fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/10532">#&#8203;10532</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10524">#&#8203;10524</a>) (Toru Nagashima)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/d8c3a25"><code>d8c3a25</code></a> Fix: wrap-regex doesn't work in some expression(fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/10573">#&#8203;10573</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10576">#&#8203;10576</a>) (薛定谔的猫)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/114f42e"><code>114f42e</code></a> Docs: Clarify option defaults in max-lines-per-function docs (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10569">#&#8203;10569</a>) (Chris Harwood)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/63f36f7"><code>63f36f7</code></a> Fix: sort-keys in an object that contains spread (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/10261">#&#8203;10261</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10495">#&#8203;10495</a>) (katerberg)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/601a5c4"><code>601a5c4</code></a> Fix: Prefer-const rule crashing on array destructuring (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/10520">#&#8203;10520</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10527">#&#8203;10527</a>) (Michael Mason)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/143890a"><code>143890a</code></a> Update: Adjust grammar of error/warnings fixable (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10546">#&#8203;10546</a>) (Matt Mischuk)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/8ee39c5"><code>8ee39c5</code></a> Chore: small refactor config-validator (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10565">#&#8203;10565</a>) (薛定谔的猫)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/100f1be"><code>100f1be</code></a> Docs: add note about release issues to readme (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10572">#&#8203;10572</a>) (Teddy Katz)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/02efeac"><code>02efeac</code></a> Fix: do not fail on nested unknown operators (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10561">#&#8203;10561</a>) (Rubén Norte)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/92b19ca"><code>92b19ca</code></a> Chore: use eslintrc overrides(dogfooding) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10566">#&#8203;10566</a>) (薛定谔的猫)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/076a6b6"><code>076a6b6</code></a> Docs: add actionable fix to no-irregular-whitespace (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10558">#&#8203;10558</a>) (Matteo Collina)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/de663ec"><code>de663ec</code></a> Docs: Only successfully linted files are cached (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/9802">#&#8203;9802</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10557">#&#8203;10557</a>) (Kevin Partington)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/f0e22fc"><code>f0e22fc</code></a> Upgrade: globals@&#8203;11.7.0 (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10497">#&#8203;10497</a>) (薛定谔的猫)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/8a2ff2c"><code>8a2ff2c</code></a> Docs:  adding a section about disable rules for some files (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10536">#&#8203;10536</a>) (Wellington Soares)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/f22a3f8"><code>f22a3f8</code></a> Docs: fix a word in no-implied-eval (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10539">#&#8203;10539</a>) (Dan Homola)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/20d8bbd"><code>20d8bbd</code></a> Docs: add missing paragraph about "custom parsers" (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10547">#&#8203;10547</a>) (Pig Fang)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/b7addf6"><code>b7addf6</code></a> Update: deprecate no-catch-shadow (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/10466">#&#8203;10466</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10526">#&#8203;10526</a>) (Toru Nagashima)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/e862dc3"><code>e862dc3</code></a> Fix: Remove autofixer for no-debugger (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/10242">#&#8203;10242</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10509">#&#8203;10509</a>) (Teddy Katz)</li>
</ul>
<hr />
<h3 id="v501httpsgithubcomeslinteslintreleasesv501"><a href="https://renovatebot.com/gh/eslint/eslint/releases/v5.0.1"><code>v5.0.1</code></a></h3>
<p><a href="https://renovatebot.com/gh/eslint/eslint/compare/v5.0.0…v5.0.1">Compare Source</a></p>
<ul>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/196c102"><code>196c102</code></a> Fix: valid-jsdoc should allow optional returns for async (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/10386">#&#8203;10386</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10480">#&#8203;10480</a>) (Mark Banner)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/4c823bd"><code>4c823bd</code></a> Docs: Fix max-lines-per-function correct code's max value (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10513">#&#8203;10513</a>) (Rhys Bower)</li>
</ul>
<hr />
<h3 id="v500httpsgithubcomeslinteslintreleasesv500"><a href="https://renovatebot.com/gh/eslint/eslint/releases/v5.0.0"><code>v5.0.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/eslint/eslint/compare/v4.19.1…v5.0.0">Compare Source</a><br />
<a href="https://eslint.org/blog/2018/06/eslint-v5.0.0-released">Release blogpost</a></p>
<p><a href="https://eslint.org/docs/user-guide/migrating-to-5.0.0">Migration guide</a></p>
<ul>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/0feedfd"><code>0feedfd</code></a> New: Added max-lines-per-function rule (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/9842">#&#8203;9842</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10188">#&#8203;10188</a>) (peteward44)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/daefbdb"><code>daefbdb</code></a> Upgrade: eslint-scope and espree to 4.0.0 (refs <a href="https://renovatebot.com/gh/eslint/eslint/issues/10458">#&#8203;10458</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10500">#&#8203;10500</a>) (Brandon Mills)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/077358b"><code>077358b</code></a> Docs: no-process-exit: recommend process.exitCode (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10478">#&#8203;10478</a>) (Andres Kalle)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/f93d6ff"><code>f93d6ff</code></a> Fix: do not fail on unknown operators from custom parsers (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/10475">#&#8203;10475</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10476">#&#8203;10476</a>) (Rubén Norte)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/05343fd"><code>05343fd</code></a> Fix: add parens for yield statement (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/10432">#&#8203;10432</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10468">#&#8203;10468</a>) (Pig Fang)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/d477c5e"><code>d477c5e</code></a> Fix: check destructuring for "no-shadow-restricted-names" (fixes <a href="https://renovatebot.com/gh/eslint/eslint/issues/10467">#&#8203;10467</a>) (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10470">#&#8203;10470</a>) (Pig Fang)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/7a7580b"><code>7a7580b</code></a> Update: Add considerPropertyDescriptor option to func-name-matching (<a href="https://renovatebot.com/gh/eslint/eslint/issues/9078">#&#8203;9078</a>) (Dieter Luypaert)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/e0a0418"><code>e0a0418</code></a> Fix: crash on optional catch binding (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10429">#&#8203;10429</a>) (Toru Nagashima)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/de4dba9"><code>de4dba9</code></a> Docs: styling team members (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10460">#&#8203;10460</a>) (薛定谔的猫)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/5e453a3"><code>5e453a3</code></a> Docs: display team members in tables. (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10433">#&#8203;10433</a>) (薛定谔的猫)</li>
<li><a href="https://renovatebot.com/gh/eslint/eslint/commit/b1895eb"><code>b1895eb</code></a> Docs: Restore intentional spelling mistake (<a href="https://renovatebot.com/gh/eslint/eslint/issues/10459">#&#8203;10459</a>) (Wilfred Hughes)</li>
</ul>
<hr />
<p></details></p>
<hr />
<p>This PR has been generated by <a href="https://renovatebot.com">Renovate Bot</a>.</p>