### PR TITLE
Update dependency eslint-config-prettier to v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "enzyme-to-json": "^3.3.3",
     "eslint": "^4.19.1",
     "eslint-config-airbnb": "^16.1.0",
-    "eslint-config-prettier": "^2.9.0",
+    "eslint-config-prettier": "^3.0.0",
     "eslint-plugin-flowtype": "^2.46.3",
     "eslint-plugin-import": "^2.11.0",
     "eslint-plugin-jest": "^21.15.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3766,11 +3766,11 @@ eslint-config-airbnb@^16.1.0:
   dependencies:
     eslint-config-airbnb-base "^12.1.0"
 
-eslint-config-prettier@^2.9.0:
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-2.9.0.tgz#5ecd65174d486c22dff389fe036febf502d468a3"
+eslint-config-prettier@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-3.0.1.tgz#479214f64c1a4b344040924bfb97543db334b7b1"
   dependencies:
-    get-stdin "^5.0.1"
+    get-stdin "^6.0.0"
 
 eslint-import-resolver-node@^0.3.1:
   version "0.3.2"
@@ -4508,6 +4508,10 @@ get-caller-file@^1.0.1:
 get-stdin@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-5.0.1.tgz#122e161591e21ff4c52530305693f20e6393a398"
+
+get-stdin@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-6.0.0.tgz#9e09bf712b360ab9225e812048f71fde9c89657b"
 
 get-stream@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
<p>This Pull Request updates devDependency <code>eslint-config-prettier</code> (<a href="https://renovatebot.com/gh/prettier/eslint-config-prettier">source</a>) from <code>^2.9.0</code> to <code>^3.0.0</code></p>
<p><details><br />
<summary>Release Notes</summary></p>
<h3 id="v301httpsgithubcomprettiereslint-config-prettierblobmasterchangelogmdversion-301-2018-08-13"><a href="https://renovatebot.com/gh/prettier/eslint-config-prettier/blob/master/CHANGELOG.md#Version-301-2018-08-13"><code>v3.0.1</code></a></h3>
<p><a href="https://renovatebot.com/gh/prettier/eslint-config-prettier/compare/v3.0.0…v3.0.1">Compare Source</a></p>
<ul>
<li>Improved: <code>eslint --print-config</code> usage instructions.</li>
</ul>
<hr />
<h3 id="v300httpsgithubcomprettiereslint-config-prettierblobmasterchangelogmdversion-300-2018-08-13"><a href="https://renovatebot.com/gh/prettier/eslint-config-prettier/blob/master/CHANGELOG.md#Version-300-2018-08-13"><code>v3.0.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/prettier/eslint-config-prettier/compare/v2.10.0…v3.0.0">Compare Source</a></p>
<ul>
<li>Breaking change: Dropped Node.js 4 support.</li>
</ul>
<hr />
<p></details></p>
<hr />
<p>This PR has been generated by <a href="https://renovatebot.com">Renovate Bot</a>.</p>