### PR TITLE
Update dependency polished to v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@kiwicom/orbit-design-tokens": "^0.1.3",
     "@sambego/storybook-styles": "^1.0.0",
     "classnames": "^2.2.5",
-    "polished": "^1.9.2",
+    "polished": "^2.0.0",
     "react-create-component-from-tag-prop": "^1.3.1",
     "react-icon-base": "^2.1.2",
     "react-icons": "^2.2.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7187,9 +7187,9 @@ podda@^1.2.2:
     babel-runtime "^6.11.6"
     immutable "^3.8.1"
 
-polished@^1.9.2:
-  version "1.9.2"
-  resolved "https://registry.yarnpkg.com/polished/-/polished-1.9.2.tgz#d705cac66f3a3ed1bd38aad863e2c1e269baf6b6"
+polished@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/polished/-/polished-2.0.0.tgz#f9f34a6efe1dd66eca540bb41a6b7058ae9b4fa7"
 
 posix-character-classes@^0.1.0:
   version "0.1.1"


### PR DESCRIPTION
<p>This Pull Request updates dependency <code>polished</code> (<a href="https://renovatebot.com/gh/styled-components/polished">source</a>) from <code>^1.9.2</code> to <code>^2.0.0</code></p>
<p><details><br />
<summary>Release Notes</summary></p>
<h3 id="v200httpsgithubcomstyled-componentspolishedreleasesv200"><a href="https://renovatebot.com/gh/styled-components/polished/releases/v2.0.0">v2.0.0</a></h3>
<p><a href="https://renovatebot.com/gh/styled-components/polished/compare/v1.9.3…v2.0.0">Compare Source</a><br />
This is a major release that introduces new modules, improvements to existing modules, bug fixes, improved TypeScript and Flow Support, and some deprecations.</p>
<h4 id="breaking-changes">Breaking Changes</h4>
<p>We introduced one necessary breaking change in this release. In the future, we will warn a full major version ahead of time, but this one necessitated an immediate fix. (Un)luckily, it was never working properly in the first place.</p>
<ul>
<li><code>mix</code> color module now requires a ratio in order to work. It originally tried to default to <code>.5</code> but this broke in most cases. </li>
</ul>
<h4 id="deprecations">Deprecations</h4>
<p>These items have been marked for deprecation in v3 of <code>polished</code>.</p>
<ul>
<li><code>placeholder</code> mixin is no longer required to address gaps in vendor prefixing in major CSS-in-JS libraries.</li>
<li><code>selection</code> mixin is no longer required to address gaps in vendor prefixing in major CSS-in-JS libraries.</li>
</ul>
<p>These items have been deprecated immediately as the change doesn't introduce any breaking changes. However, you will want to update your code accordingly.</p>
<ul>
<li><code>normalize</code> no longer accepts <code>excludeOpinionated</code> as a parameter, as opinionated rules have been removed in the latest versions of normalize.css.</li>
</ul>
<h4 id="new-modules">New Modules</h4>
<p>This release addresses our most popular feature requests as voted on by users. If something you were hoping for didn't make it, you can make your voice heard by 👍a module request in our issues.</p>
<h5 id="mixins">Mixins</h5>
<ul>
<li><code>between</code> mixin added to return a CSS calc formula for linear interpolation of a property between two values.</li>
<li><code>cover</code> mixin added to return CSS to fully cover an area similar to <code>background-image: cover</code>.</li>
<li><code>fluidRange</code> mixin added to returns a set of media queries that resizes a property (or set of properties) between a provided fromSize and toSize linearly.</li>
</ul>
<h5 id="shorthands">Shorthands</h5>
<ul>
<li><code>border</code> shorthand added to return shorthand for the border property that splits out individual properties for use with tools like Fela and Styletron.</li>
</ul>
<h5 id="helpers">Helpers</h5>
<ul>
<li><code>getValueAndUnit</code> helper added returns a given CSS value and its unit as elements of an array.</li>
</ul>
<h4 id="new-features">New Features</h4>
<p>We have made a variety of improvements to existing modules as well.</p>
<h5 id="mixins-1">Mixins</h5>
<ul>
<li><code>fontFace</code> now supports <code>font-display</code>, <code>font-variation-settings</code>, and <code>font-feature-settings</code>.</li>
<li><code>triangle</code> now supports any unit of measure instead of just <code>px</code>. (Thanks <a href="https://renovatebot.com/gh/lifeiscontent">@&#8203;lifeiscontent</a>)</li>
<li><code>normalize</code> has been upgraded to use normalize.css 8.0.</li>
</ul>
<h5 id="color-modules">Color Modules</h5>
<ul>
<li><p><strong>All color modules</strong> now support hex color values with alpha values (commonly referred to as 8-Digit hex colors).</p></li>
<li><p><strong>All color modules</strong> now support string values for all parameters.</p></li>
<li><p><code>mix</code> fixed an issue where mix would not curry properly. </p></li>
</ul>
<h5 id="shorthands-1">Shorthands</h5>
<ul>
<li><code>transitions</code> now supports applying the same transition to multiple properties in one call.</li>
</ul>
<h4 id="bug-fixes">Bug Fixes</h4>
<h5 id="mixins-2">Mixins</h5>
<ul>
<li><code>ellipsis</code> - fixed a bug to avoid potential white-space issues with <code>display: inline-block</code>.</li>
<li><code>normalize</code> - fixed an issue where vendor prefixed values were not properly camel-cased.</li>
<li><code>retinaImage</code>- fixed a bug that was causing background-image to be set to <code>undefined</code> (instead of not set at all) when a background image is not passed.</li>
</ul>
<h5 id="flow">Flow</h5>
<ul>
<li><code>mix</code> now properly passes flow tests in all cases, including when curried.</li>
<li><strong>All Modules</strong> now uses the <code>Styles</code> type for better compatibility with CSS-In-JS libraries and their Flow type definitions. (Thanks <a href="https://renovatebot.com/gh/vhfmag">@&#8203;vhfmag</a>)</li>
<li><strong>All Modules</strong> - fixed various issues with typings including improperly declared optional parameters, too loose array definitions, and inadequate object property strictness.</li>
<li>All custom types are now exported separately for use elsewhere instead of being embedded with specific modules.</li>
</ul>
<h5 id="typescript-thanks-8203forbeslindesayhttpsgithubcomforbeslindesay">TypeScript (Thanks <a href="https://renovatebot.com/gh/ForbesLindesay">@&#8203;ForbesLindesay</a>)</h5>
<ul>
<li>TypeScript build now works properly in Windows</li>
<li>Added additional TypeScript tests for all modules.</li>
<li>TypeScript definitions properly generate regardless of module export policy.</li>
<li><strong>All Modules</strong> now uses the <code>Styles</code> type for better compatibility with CSS-In-JS libraries and their TypeScript definitions. (Thanks <a href="https://renovatebot.com/gh/vhfmag">@&#8203;vhfmag</a>)</li>
</ul>
<h5 id="documentation">Documentation</h5>
<ul>
<li>Docs have been upgraded to the latest version of <code>documentation.js</code> and generation should no longer randomly break for contributors.</li>
<li><code>triangle</code> documentation now properly displays.</li>
<li><code>toColorString</code> documentation now properly displays.</li>
<li>Variety of clarifications and typo fixes.</li>
</ul>
<hr />
<p></details></p>
<hr />
<p>This PR has been generated by <a href="https://renovatebot.com">Renovate Bot</a>.</p>