### PR TITLE
FIX: Radio and CheckBox label type

### DIFF
--- a/src/Checkbox/README.md
+++ b/src/Checkbox/README.md
@@ -16,7 +16,7 @@ Table below contains all types of the props available in Checkbox component.
 | disabled     | `boolean`    | `false` | If `true`, the Checkbox will be set up as disabled.
 | hasError     | `boolean`    | `false` | If `true`, the border of the Checkbox will turn red. [See Functional specs](#functional-specs)
 | info         | `React.Node` |         | The additional info about the Checkbox.
-| **label**    | `string`     |         | The label of the Checkbox.
+| **label**    | `React.Node` |         | The label of the Checkbox.
 | onChange     | `func`       |         | Function for handling onChange event.
 | value        | `string`     |         | The value of the Checkbox.
 

--- a/src/Checkbox/index.js.flow
+++ b/src/Checkbox/index.js.flow
@@ -2,7 +2,7 @@
 import defaultTokens from "../defaultTokens";
 
 export type Props = {|
-  +label: string,
+  +label: React$Node,
   +value?: string,
   +hasError?: boolean,
   +disabled?: boolean,

--- a/src/Radio/README.md
+++ b/src/Radio/README.md
@@ -16,7 +16,7 @@ Table below contains all types of the props available in Radio component.
 | disabled     | `boolean`    | `false` | If `true`, the Radio will be set up as disabled.
 | hasError     | `boolean`    | `false` | If `true`, the border of the Radio will turn red. [See Functional specs](#functional-specs)
 | info         | `React.Node` |         | The additional info about the Radio.
-| **label**    | `string`     |         | The label of the Radio.
+| **label**    | `React.Node` |         | The label of the Radio.
 | onChange     | `func`       |         | Function for handling onChange event.
 | value        | `string`     |         | The value of the Radio.
 

--- a/src/Radio/index.js.flow
+++ b/src/Radio/index.js.flow
@@ -2,7 +2,7 @@
 import defaultTokens from "../defaultTokens";
 
 export type Props = {|
-  +label: string,
+  +label: React$Node,
   +value?: string,
   +hasError?: boolean,
   +disabled?: boolean,


### PR DESCRIPTION
`label` prop now accepts `React.Node`

Closes #331 
