### PR TITLE
FIX: README.md for Icons

### DIFF
--- a/src/Icon/README.md
+++ b/src/Icon/README.md
@@ -25,10 +25,10 @@ Table below contains all types of the props available for icons in general.
 | `"primary"`   | `"medium"` |
 | `"secondary"` | `"large"`  |
 | `"tertiary"`  |            |
-| `"blue"`      |            |
-| `"green"`     |            |
-| `"orange"`    |            |
-| `"red"`       |            |
+| `"info"`      |            |
+| `"success"`   |            |
+| `"warning"`   |            |
+| `"critical"`  |            |
 
 ## Functional specs
 * If you don't pass `customColor` or `color` prop to Icon, it will inherit color from parent container with `currentColor` by default.


### PR DESCRIPTION
Fixed `README.md` for `Icons`. Wrong colors properties.