### PR TITLE
FIX: ModalFooter box-shadow, Close position

### DIFF
--- a/src/Modal/__snapshots__/Modal.stories.storyshot
+++ b/src/Modal/__snapshots__/Modal.stories.storyshot
@@ -111,11 +111,11 @@ exports[`Storyshots Modal Full preview 1`] = `
               size="normal"
             >
               <div
-                className="Modal__ModalWrapperContent-dXDxzA gfJkay"
+                className="Modal__ModalWrapperContent-dXDxzA iSZxZW"
                 size="normal"
               >
                 <div
-                  className="Modal__CloseContainer-ehEpyW cuWRmR"
+                  className="Modal__CloseContainer-ehEpyW erqRLf"
                 >
                   <button
                     className="ButtonLink__StyledButtonLink-eyUiPe DORaW"
@@ -1530,11 +1530,11 @@ exports[`Storyshots Modal Sizes 1`] = `
               size="normal"
             >
               <div
-                className="Modal__ModalWrapperContent-dXDxzA gfJkay"
+                className="Modal__ModalWrapperContent-dXDxzA iSZxZW"
                 size="normal"
               >
                 <div
-                  className="Modal__CloseContainer-ehEpyW cuWRmR"
+                  className="Modal__CloseContainer-ehEpyW erqRLf"
                 >
                   <button
                     className="ButtonLink__StyledButtonLink-eyUiPe DORaW"

--- a/src/Modal/__tests__/__snapshots__/index.test.js.snap
+++ b/src/Modal/__tests__/__snapshots__/index.test.js.snap
@@ -776,7 +776,9 @@ exports[`Large Modal should match snapshot 1`] = `
     }
   >
     <Modal__ModalWrapperContent
+      fixedClose={false}
       fixedFooter={true}
+      fullyScrolled={false}
       innerRef={[Function]}
       scrolled={false}
       size="large"
@@ -1163,6 +1165,7 @@ exports[`Large Modal should match snapshot 1`] = `
       }
     >
       <CloseElement
+        closable={true}
         onClose={[MockFunction]}
       />
       <ModalHeader

--- a/src/Modal/index.js.flow
+++ b/src/Modal/index.js.flow
@@ -7,6 +7,8 @@ import ModalFooter from "./ModalFooter";
 export type State = {|
   scrolled: boolean,
   loaded: boolean,
+  fixedClose: boolean,
+  fullyScrolled: boolean,
 |};
 
 type Size = "small" | "normal" | "large";
@@ -22,6 +24,7 @@ type onClose = (
 
 export type CloseElementType = {
   +onClose?: onClose,
+  +closable?: boolean,
 };
 
 export type Props = {|


### PR DESCRIPTION
Fixed box-shadow in ModalFooter when the Modal is fully scrolled.
Fixed position of CloseContainer during initial animation on Mobile.<br/><br/><br/><url>LiveURL: https://orbit-components-fix-modal-footer-boxshadow.surge.sh</url>