### PR TITLE
FIX: CheckBox DOM rendering

### DIFF
--- a/src/Checkbox/__snapshots__/Checkbox.stories.storyshot
+++ b/src/Checkbox/__snapshots__/Checkbox.stories.storyshot
@@ -99,10 +99,8 @@ exports[`Storyshots CheckBox Default 1`] = `
           }
         >
           <label
-            checked={false}
             className="Checkbox__Label-gCTMrH bPokpO"
             data-test={undefined}
-            hasError={false}
           >
             <input
               checked={false}
@@ -396,10 +394,8 @@ exports[`Storyshots CheckBox Playground 1`] = `
           }
         >
           <label
-            checked={true}
             className="Checkbox__Label-gCTMrH cOjsRL"
             data-test="test"
-            hasError={false}
           >
             <input
               checked={true}
@@ -819,10 +815,8 @@ exports[`Storyshots CheckBox With help 1`] = `
           }
         >
           <label
-            checked={false}
             className="Checkbox__Label-gCTMrH bPokpO"
             data-test={undefined}
-            hasError={false}
           >
             <input
               checked={false}

--- a/src/Checkbox/__tests__/__snapshots__/index.test.js.snap
+++ b/src/Checkbox/__tests__/__snapshots__/index.test.js.snap
@@ -3,7 +3,7 @@
 exports[`Default CheckBox should match snapshot 1`] = `
 <Checkbox__Label
   checked={false}
-  data-test="test"
+  dataTest="test"
   disabled={false}
   hasError={false}
   theme={

--- a/src/Checkbox/index.js
+++ b/src/Checkbox/index.js
@@ -98,8 +98,10 @@ Input.defaultProps = {
   theme: defaultTokens,
 };
 
-const Label = styled(({ disabled, theme, type, ...props }) => (
-  <label {...props}>{props.children}</label>
+const Label = styled(({ className, children, dataTest }) => (
+  <label className={className} data-test={dataTest}>
+    {children}
+  </label>
 ))`
   font-family: ${({ theme }) => theme.orbit.fontFamily};
   display: flex;
@@ -151,7 +153,7 @@ const Checkbox = (props: Props) => {
   } = props;
 
   return (
-    <Label disabled={disabled} hasError={hasError} checked={checked} data-test={dataTest}>
+    <Label disabled={disabled} hasError={hasError} checked={checked} dataTest={dataTest}>
       <Input
         value={value}
         type="checkbox"


### PR DESCRIPTION
Fixed: an unnecessary render of prop `hasError` to the DOM of  `label` element.