### PR TITLE
FIX: Circled Button, ButtonLink DOM warning

### DIFF
--- a/src/Button/__snapshots__/Button.stories.storyshot
+++ b/src/Button/__snapshots__/Button.stories.storyshot
@@ -1655,7 +1655,6 @@ exports[`Storyshots Button Circled button 1`] = `
           }
         >
           <button
-            circled={true}
             className="Button__StyledButton-jJDkJK jAOrwt"
             data-test={undefined}
             disabled={undefined}
@@ -2647,7 +2646,6 @@ exports[`Storyshots Button Playground 1`] = `
           }
         >
           <button
-            circled={false}
             className="Button__StyledButton-jJDkJK fjwApn"
             data-test="test"
             disabled={false}

--- a/src/Button/index.js
+++ b/src/Button/index.js
@@ -211,6 +211,7 @@ export const StyledButton = styled(
   ({
     theme,
     component,
+    circled,
     external,
     type,
     icon,

--- a/src/ButtonLink/__snapshots__/ButtonLink.stories.storyshot
+++ b/src/ButtonLink/__snapshots__/ButtonLink.stories.storyshot
@@ -99,7 +99,6 @@ exports[`Storyshots ButtonLink Circled 1`] = `
           }
         >
           <button
-            circled={true}
             className="ButtonLink__StyledButtonLink-eyUiPe fpNoit"
             data-test={undefined}
             onClick={[Function]}

--- a/src/ButtonLink/index.js
+++ b/src/ButtonLink/index.js
@@ -99,6 +99,7 @@ export const StyledButtonLink = styled(
   ({
     onlyIcon,
     component,
+    circled,
     external,
     block,
     type,


### PR DESCRIPTION
Fixed undesirable DOM warning when circled prop has been passed

![image](https://user-images.githubusercontent.com/7850592/46398710-1b797800-c6f6-11e8-9edb-23e36c312be2.png)
