### PR TITLE
FIX: Modal height on desktop

### DIFF
--- a/src/Modal/__snapshots__/Modal.stories.storyshot
+++ b/src/Modal/__snapshots__/Modal.stories.storyshot
@@ -111,7 +111,7 @@ exports[`Storyshots Modal Full preview 1`] = `
               size="normal"
             >
               <div
-                className="Modal__ModalWrapperContent-dXDxzA knMpbO"
+                className="Modal__ModalWrapperContent-dXDxzA gTyJWw"
                 size="normal"
               >
                 <div
@@ -1530,7 +1530,7 @@ exports[`Storyshots Modal Sizes 1`] = `
               size="normal"
             >
               <div
-                className="Modal__ModalWrapperContent-dXDxzA knMpbO"
+                className="Modal__ModalWrapperContent-dXDxzA gTyJWw"
                 size="normal"
               >
                 <div

--- a/src/Modal/index.js
+++ b/src/Modal/index.js
@@ -165,6 +165,7 @@ const ModalWrapperContent = styled.div`
     position: relative;
     border-radius: ${({ theme }) => theme.orbit.borderRadiusNormal};
     padding-bottom: 0;
+    height: auto;
     ${StyledModalSection}:last-of-type {
       padding-bottom: ${({ theme }) => theme.orbit.spaceXXLarge};
       margin-bottom: 0;


### PR DESCRIPTION
<img width="503" alt="snimek obrazovky 2018-10-03 v 14 47 52" src="https://user-images.githubusercontent.com/7254437/46411159-580b9a80-c71b-11e8-8815-06ce1b1e2cf8.png">

It was working on our Storybook, but not in the other projects.
