### PR TITLE
UPDATE: FLOW: Restricted Translation in some components

### DIFF
--- a/src/Alert/index.js.flow
+++ b/src/Alert/index.js.flow
@@ -1,13 +1,13 @@
 // @flow
 import type { spaceAfter } from "../common/getSpacingToken/index";
-import type { Globals } from "../common/common.js.flow";
+import type { Globals, Translation } from "../common/common.js.flow";
 
 type Type = "info" | "success" | "warning" | "critical";
 
 export type Props = {|
   +type?: Type,
   +children?: React$Node,
-  +title?: string | React$Node,
+  +title?: Translation,
   +icon?: React$Element<any> | boolean,
   +closable?: boolean,
   +onClose?: () => void,

--- a/src/Badge/index.js.flow
+++ b/src/Badge/index.js.flow
@@ -1,5 +1,6 @@
 // @flow
 import type { Globals } from "../common/common.js.flow";
+
 export type Type = "neutral" | "dark" | "info" | "success" | "warning" | "critical" | "white";
 
 export type Props = {|

--- a/src/ChoiceGroup/index.js.flow
+++ b/src/ChoiceGroup/index.js.flow
@@ -1,5 +1,5 @@
 // @flow
-import type { Globals } from "../common/common.js.flow";
+import type { Globals, Translation } from "../common/common.js.flow";
 import Radio from "../Radio";
 import Checkbox from "../Checkbox";
 
@@ -12,7 +12,7 @@ type Children = React$Element<typeof Radio> | React$Element<typeof Checkbox>
 export type Props = {|
   ...Globals,
   children: Children | Children[],
-  label?: string,
+  label?: Translation,
   labelSize?: LabelSize,
   labelElement?: LabelElement,
   hasError?: boolean,

--- a/src/InputField/index.js
+++ b/src/InputField/index.js
@@ -8,7 +8,7 @@ import FormFeedback from "../FormFeedback";
 import DefaultFormLabel from "../FormLabel";
 import { StyledServiceLogo } from "../ServiceLogo";
 import { rtlSpacing } from "../utils/rtl";
-import type { Ref } from "../common/common.js.flow";
+import type { Ref, Translation } from "../common/common.js.flow";
 
 import type { Props } from "./index";
 
@@ -253,7 +253,7 @@ const FormLabel = ({
   isFilled,
   required,
 }: {
-  label: string,
+  label: Translation,
   isFilled: boolean,
   required?: boolean,
 }) => (

--- a/src/InputField/index.js.flow
+++ b/src/InputField/index.js.flow
@@ -1,7 +1,7 @@
 // @flow
 import type { ReactComponentStyled } from "styled-components";
 
-import type { Globals, Ref } from "../common/common.js.flow";
+import type { Globals, Ref, Translation } from "../common/common.js.flow";
 
 export type Size = "small" | "normal";
 
@@ -9,10 +9,10 @@ export type Props = {|
   +size?: Size,
   +type?: "text" | "number" | "email" | "password" | "passportid",
   +name?: string,
-  +label?: string,
+  +label?: Translation,
   +inlineLabel?: boolean,
   +value?: string | number,
-  +placeholder?: string,
+  +placeholder?: Translation,
   +prefix?: React$Node,
   +suffix?: React$Node,
   +help?: React$Node,

--- a/src/InputFile/index.js.flow
+++ b/src/InputFile/index.js.flow
@@ -1,12 +1,12 @@
 // @flow
-import type { Globals, Ref } from "../common/common.js.flow";
+import type { Globals, Translation, Ref } from "../common/common.js.flow";
 
 export type Props = {|
   ...Globals,
-  +label?: string,
-  +title?: string,
+  +label?: Translation,
+  +title?: React$Node,
   +name?: string,
-  +placeholder?: string,
+  +placeholder?: Translation,
   +fileName?: string,
   +allowedFileTypes?: string | string[],
   +help?: React$Node,

--- a/src/InputGroup/index.js.flow
+++ b/src/InputGroup/index.js.flow
@@ -1,10 +1,10 @@
 // @flow
-import type { Globals } from "../common/common.js.flow";
+import type { Globals, Translation } from "../common/common.js.flow";
 import InputField from "../InputField";
 import Select from "../Select";
 
 export type Props = {|
-  +label?: string,
+  +label?: Translation,
   +flex?: string | Array<string>,
   +size?: "small" | "normal",
   +help?: React$Node,

--- a/src/InputStepper/index.js.flow
+++ b/src/InputStepper/index.js.flow
@@ -1,12 +1,12 @@
 // @flow
-import type { Globals, Ref, RefType } from "../common/common.js.flow";
+import type { Globals, Ref, RefType, Translation } from "../common/common.js.flow";
 import type { Size } from "../InputField/index";
 
 export type Props = {|
   ...Globals,
   ...Ref,
   +size?: Size,
-  +label?: string,
+  +label?: Translation,
   +defaultValue?: number,
   +step?: number,
   +help?: React$Node,

--- a/src/ListChoice/index.js.flow
+++ b/src/ListChoice/index.js.flow
@@ -1,10 +1,10 @@
 // @flow
-import type { Globals } from "../common/common.js.flow";
+import type { Globals, Translation } from "../common/common.js.flow";
 
 export type Props = {|
   ...Globals,
-  +title: string,
-  +description?: string,
+  +title: Translation,
+  +description?: Translation,
   +selectable?: boolean,
   +selected?: boolean,
   +icon: React$Node,

--- a/src/Loading/index.js.flow
+++ b/src/Loading/index.js.flow
@@ -1,7 +1,7 @@
 // @flow
 import type { ReactComponentStyled } from "styled-components";
 
-import type { Globals } from "../common/common.js.flow";
+import type { Globals, Translation } from "../common/common.js.flow";
 
 type Type = "buttonLoader" | "boxLoader" | "searchLoader" | "pageLoader" | "inlineLoader";
 
@@ -9,7 +9,7 @@ export type Props = {|
   +children?: React$Node,
   +loading?: boolean,
   +type?: Type,
-  +text?: string,
+  +text?: Translation,
   ...Globals,
 |};
 

--- a/src/Select/index.js.flow
+++ b/src/Select/index.js.flow
@@ -1,7 +1,7 @@
 // @flow
 import type { ReactComponentStyled } from "styled-components";
 
-import type { Globals, Ref } from "../common/common.js.flow";
+import type { Globals, Ref, Translation } from "../common/common.js.flow";
 
 type Option = {|
   +value: string | number,
@@ -13,8 +13,8 @@ type Size = "small" | "normal";
 
 export type Props = {|
   +size?: Size,
-  +label?: string,
-  +placeholder?: string,
+  +label?: Translation,
+  +placeholder?: Translation,
   +value?: string | number,
   +disabled?: boolean,
   +name?: string,

--- a/src/Textarea/index.js.flow
+++ b/src/Textarea/index.js.flow
@@ -1,13 +1,13 @@
 // @flow
-import type { Globals } from "../common/common.js.flow";
+import type { Globals, Translation } from "../common/common.js.flow";
 
 export type Props = {|
   +size?: "small" | "normal",
   +name?: string,
-  +label?: string,
+  +label?: Translation,
   +value?: string,
   +fullHeight?: boolean,
-  +placeholder?: string,
+  +placeholder?: Translation,
   +help?: React$Node,
   +error?: React$Node,
   +resize?: "vertical" | "none",

--- a/src/Tile/TileHeader/index.js.flow
+++ b/src/Tile/TileHeader/index.js.flow
@@ -4,7 +4,7 @@ import type { ReactComponentStyled } from "styled-components";
 
 export type Props = {
   +icon?: React$Node,
-  +title?: string,
+  +title?: React$Node,
   +description?: React$Node,
   +external?: boolean,
   +onClick?: (ev: SyntheticEvent<HTMLDivElement>) => void,

--- a/src/Tile/index.js.flow
+++ b/src/Tile/index.js.flow
@@ -8,7 +8,7 @@ export type State = {
 };
 
 export type Props = {|
-  +title?: string,
+  +title?: React$Node,
   +description?: React$Node,
   +icon?: React$Node,
   +children?: React$Node,

--- a/src/common/common.js.flow
+++ b/src/common/common.js.flow
@@ -8,3 +8,5 @@ export type RefType = () => { current: ?HTMLElement };
 export type Ref = {|
   +ref?: RefType,
 |};
+
+export type Translation = React$Element<React$ComponentType<any>> | string;


### PR DESCRIPTION
Added flow restriction to some props which can receive only translation via component or string

Closes #371
Closes #343 
Closes #331 
Closes #711 <br/><br/><br/><url>LiveURL: https://orbit-components-restrict-flow-to-translation.surge.sh</url>