### PR TITLE
FIX: Select and InputFile help/error position

### DIFF
--- a/src/InputFile/__snapshots__/InputFile.stories.storyshot
+++ b/src/InputFile/__snapshots__/InputFile.stories.storyshot
@@ -99,7 +99,7 @@ exports[`Storyshots InputFile Default 1`] = `
           }
         >
           <label
-            className="InputFile__Field-jAueAE dAafTj"
+            className="InputFile__Field-jAueAE erafpp"
             data-test={undefined}
           >
             <input
@@ -488,7 +488,7 @@ exports[`Storyshots InputFile Filled with file 1`] = `
           }
         >
           <label
-            className="InputFile__Field-jAueAE dAafTj"
+            className="InputFile__Field-jAueAE erafpp"
             data-test={undefined}
           >
             <input
@@ -931,7 +931,7 @@ exports[`Storyshots InputFile Playground 1`] = `
           }
         >
           <label
-            className="InputFile__Field-jAueAE dAafTj"
+            className="InputFile__Field-jAueAE erafpp"
             data-test="test"
           >
             <input
@@ -1600,7 +1600,7 @@ exports[`Storyshots InputFile With error 1`] = `
           }
         >
           <label
-            className="InputFile__Field-jAueAE dAafTj"
+            className="InputFile__Field-jAueAE erafpp"
             data-test={undefined}
           >
             <input
@@ -2025,7 +2025,7 @@ exports[`Storyshots InputFile With help 1`] = `
           }
         >
           <label
-            className="InputFile__Field-jAueAE dAafTj"
+            className="InputFile__Field-jAueAE erafpp"
             data-test={undefined}
           >
             <input

--- a/src/InputFile/index.js
+++ b/src/InputFile/index.js
@@ -15,6 +15,7 @@ import type { Props } from "./index";
 const Field = styled.label`
   font-family: ${({ theme }) => theme.orbit.fontfamily};
   display: block;
+  position: relative;
 `;
 
 Field.defaultProps = {

--- a/src/InputGroup/__snapshots__/InputGroup.stories.storyshot
+++ b/src/InputGroup/__snapshots__/InputGroup.stories.storyshot
@@ -148,7 +148,7 @@ exports[`Storyshots InputGroup Date of birth 1`] = `
                 className="InputGroup__StyledChild-bpaCT jLivMh"
               >
                 <label
-                  className="Select__Label-hzoCkw iujhLZ"
+                  className="Select__Label-hzoCkw fshYAU"
                   data-test={undefined}
                 >
                   <div
@@ -1180,7 +1180,7 @@ exports[`Storyshots InputGroup Phone number 1`] = `
                 className="InputGroup__StyledChild-bpaCT iMHnHh"
               >
                 <label
-                  className="Select__Label-hzoCkw iujhLZ"
+                  className="Select__Label-hzoCkw fshYAU"
                   data-test={undefined}
                 >
                   <div
@@ -2082,7 +2082,7 @@ exports[`Storyshots InputGroup Playground 1`] = `
                 className="InputGroup__StyledChild-bpaCT daJJeL"
               >
                 <label
-                  className="Select__Label-hzoCkw iujhLZ"
+                  className="Select__Label-hzoCkw fshYAU"
                   data-test={undefined}
                 >
                   <div
@@ -2161,7 +2161,7 @@ exports[`Storyshots InputGroup Playground 1`] = `
                 className="InputGroup__StyledChild-bpaCT frCGBA"
               >
                 <label
-                  className="Select__Label-hzoCkw iujhLZ"
+                  className="Select__Label-hzoCkw fshYAU"
                   data-test={undefined}
                 >
                   <div

--- a/src/Select/Select.stories.js
+++ b/src/Select/Select.stories.js
@@ -118,11 +118,7 @@ storiesOf("Select", module)
               <Select
                 label="Select box (with help text)"
                 options={objectOptions}
-                help={
-                  <div>
-                    Most common choice is <b>Booking cancellation</b>
-                  </div>
-                }
+                help="Most common choice is Booking cancellation"
                 onChange={action("onChange")}
               />
             ),

--- a/src/Select/__snapshots__/Select.stories.storyshot
+++ b/src/Select/__snapshots__/Select.stories.storyshot
@@ -99,7 +99,7 @@ exports[`Storyshots Select Default 1`] = `
           }
         >
           <label
-            className="Select__Label-hzoCkw iujhLZ"
+            className="Select__Label-hzoCkw fshYAU"
             data-test={undefined}
           >
             <div
@@ -564,7 +564,7 @@ exports[`Storyshots Select Playground 1`] = `
           }
         >
           <label
-            className="Select__Label-hzoCkw iujhLZ"
+            className="Select__Label-hzoCkw fshYAU"
             data-test="test"
           >
             <div
@@ -1226,7 +1226,7 @@ exports[`Storyshots Select With CountryFlag prefix 1`] = `
           }
         >
           <label
-            className="Select__Label-hzoCkw iujhLZ"
+            className="Select__Label-hzoCkw fshYAU"
             data-test={undefined}
           >
             <span
@@ -1778,7 +1778,7 @@ exports[`Storyshots Select With error message 1`] = `
           }
         >
           <label
-            className="Select__Label-hzoCkw iujhLZ"
+            className="Select__Label-hzoCkw fshYAU"
             data-test={undefined}
           >
             <span
@@ -2326,7 +2326,7 @@ exports[`Storyshots Select With help message 1`] = `
           }
         >
           <label
-            className="Select__Label-hzoCkw iujhLZ"
+            className="Select__Label-hzoCkw fshYAU"
             data-test={undefined}
           >
             <span
@@ -2386,12 +2386,7 @@ exports[`Storyshots Select With help message 1`] = `
               className="FormFeedback__StyledFormFeedback-cuFyWp jhMnDG"
               data-test={undefined}
             >
-              <div>
-                Most common choice is 
-                <b>
-                  Booking cancellation
-                </b>
-              </div>
+              Most common choice is Booking cancellation
             </div>
           </label>
         </div>
@@ -2708,18 +2703,17 @@ exports[`Storyshots Select With help message 1`] = `
                           <span
                             style={Object {}}
                           >
-                            <span>
-                              {
-                              <span
-                                style={
-                                  Object {
-                                    "color": "#666",
-                                  }
+                            <span
+                              style={
+                                Object {
+                                  "color": "#22a",
+                                  "wordBreak": "break-word",
                                 }
-                              >
-                                &lt;div /&gt;
-                              </span>
                               }
+                            >
+                              "
+                              Most common choice is Booking cancellation
+                              "
                             </span>
                           </span>
                         </span>
@@ -2877,7 +2871,7 @@ exports[`Storyshots Select With placeholder 1`] = `
           }
         >
           <label
-            className="Select__Label-hzoCkw iujhLZ"
+            className="Select__Label-hzoCkw fshYAU"
             data-test={undefined}
           >
             <span
@@ -3424,7 +3418,7 @@ exports[`Storyshots Select With prefix 1`] = `
           }
         >
           <label
-            className="Select__Label-hzoCkw iujhLZ"
+            className="Select__Label-hzoCkw fshYAU"
             data-test={undefined}
           >
             <span
@@ -3978,7 +3972,7 @@ exports[`Storyshots Select With small size 1`] = `
           }
         >
           <label
-            className="Select__Label-hzoCkw iujhLZ"
+            className="Select__Label-hzoCkw fshYAU"
             data-test={undefined}
           >
             <span

--- a/src/Select/index.js
+++ b/src/Select/index.js
@@ -12,7 +12,8 @@ import SIZE_OPTIONS from "./consts";
 import type { Props } from "./index";
 
 const Label = styled.label`
-  width: 100%;
+  position: relative;
+  display: block;
 `;
 
 const StyledSelect = styled(


### PR DESCRIPTION
Fixed position of help/error in Select and InputFile with `position: relative`.

Closes #436 
Close #449 