### PR TITLE
FIX: Multi-line FormFeedback

### DIFF
--- a/src/FormFeedback/index.js
+++ b/src/FormFeedback/index.js
@@ -18,7 +18,12 @@ const StyledFormFeedback = styled(({ theme, type, ...props }) => <div {...props}
   width: 100%;
   margin-top: 2px;
   position: absolute;
-  bottom: -${({ theme }) => Math.floor(theme.orbit.lineHeightText * parseInt(theme.orbit.fontSizeFormFeedback, 10)) + 2}px;
+  top: 100%;
+  max-height: ${({ theme }) =>
+    Math.floor(theme.orbit.lineHeightText * parseInt(theme.orbit.fontSizeFormFeedback, 10))}px;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 
   & a {
     color: ${({ theme, type }) =>

--- a/src/InputField/__snapshots__/InputField.stories.storyshot
+++ b/src/InputField/__snapshots__/InputField.stories.storyshot
@@ -875,7 +875,7 @@ exports[`Storyshots InputField Email input 1`] = `
               />
             </div>
             <div
-              className="FormFeedback__StyledFormFeedback-cuFyWp jhMnDG"
+              className="FormFeedback__StyledFormFeedback-cuFyWp hVyVwg"
               data-test={undefined}
             >
               <div>

--- a/src/InputFile/__snapshots__/InputFile.stories.storyshot
+++ b/src/InputFile/__snapshots__/InputFile.stories.storyshot
@@ -994,7 +994,7 @@ exports[`Storyshots InputFile Playground 1`] = `
               </div>
             </div>
             <div
-              className="FormFeedback__StyledFormFeedback-cuFyWp ebyAhw"
+              className="FormFeedback__StyledFormFeedback-cuFyWp cFaoou"
               data-test={undefined}
             >
               No file has been selected yet
@@ -1658,7 +1658,7 @@ exports[`Storyshots InputFile With error 1`] = `
               </div>
             </div>
             <div
-              className="FormFeedback__StyledFormFeedback-cuFyWp ebyAhw"
+              className="FormFeedback__StyledFormFeedback-cuFyWp cFaoou"
               data-test={undefined}
             >
               Error message (explain how to solve it)
@@ -2083,7 +2083,7 @@ exports[`Storyshots InputFile With help 1`] = `
               </div>
             </div>
             <div
-              className="FormFeedback__StyledFormFeedback-cuFyWp jhMnDG"
+              className="FormFeedback__StyledFormFeedback-cuFyWp hVyVwg"
               data-test={undefined}
             >
               <div>

--- a/src/Select/__snapshots__/Select.stories.storyshot
+++ b/src/Select/__snapshots__/Select.stories.storyshot
@@ -1835,7 +1835,7 @@ exports[`Storyshots Select With error message 1`] = `
               </div>
             </div>
             <div
-              className="FormFeedback__StyledFormFeedback-cuFyWp ebyAhw"
+              className="FormFeedback__StyledFormFeedback-cuFyWp cFaoou"
               data-test={undefined}
             >
               <div>
@@ -2383,7 +2383,7 @@ exports[`Storyshots Select With help message 1`] = `
               </div>
             </div>
             <div
-              className="FormFeedback__StyledFormFeedback-cuFyWp jhMnDG"
+              className="FormFeedback__StyledFormFeedback-cuFyWp hVyVwg"
               data-test={undefined}
             >
               Most common choice is Booking cancellation

--- a/src/Stack/__snapshots__/Stack.stories.storyshot
+++ b/src/Stack/__snapshots__/Stack.stories.storyshot
@@ -602,7 +602,7 @@ exports[`Storyshots Stack Desktop properties 1`] = `
                 />
               </div>
               <div
-                className="FormFeedback__StyledFormFeedback-cuFyWp jhMnDG"
+                className="FormFeedback__StyledFormFeedback-cuFyWp hVyVwg"
                 data-test={undefined}
               >
                 You need some help!
@@ -1891,7 +1891,7 @@ exports[`Storyshots Stack Nested example 1`] = `
                   />
                 </div>
                 <div
-                  className="FormFeedback__StyledFormFeedback-cuFyWp ebyAhw"
+                  className="FormFeedback__StyledFormFeedback-cuFyWp cFaoou"
                   data-test={undefined}
                 >
                   You need some help!

--- a/src/Stack/__tests__/__snapshots__/index.test.js.snap
+++ b/src/Stack/__tests__/__snapshots__/index.test.js.snap
@@ -120,7 +120,11 @@ exports[`Default Stack should match snapshot 1`] = `
   width: 100%;
   margin-top: 2px;
   position: absolute;
-  bottom: -18px;
+  top: 100%;
+  max-height: 16px;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 
 .c7 a {
@@ -6671,7 +6675,11 @@ exports[`Stack with enabled flex should match snapshot 1`] = `
   width: 100%;
   margin-top: 2px;
   position: absolute;
-  bottom: -18px;
+  top: 100%;
+  max-height: 16px;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 
 .c7 a {

--- a/src/Textarea/__snapshots__/Textarea.stories.storyshot
+++ b/src/Textarea/__snapshots__/Textarea.stories.storyshot
@@ -398,7 +398,7 @@ exports[`Storyshots Textarea Playground 1`] = `
               value=""
             />
             <div
-              className="FormFeedback__StyledFormFeedback-cuFyWp ebyAhw"
+              className="FormFeedback__StyledFormFeedback-cuFyWp cFaoou"
               data-test={undefined}
             >
               Something went wrong.
@@ -1287,7 +1287,7 @@ exports[`Storyshots Textarea With error 1`] = `
               value="Something"
             />
             <div
-              className="FormFeedback__StyledFormFeedback-cuFyWp ebyAhw"
+              className="FormFeedback__StyledFormFeedback-cuFyWp cFaoou"
               data-test={undefined}
             >
               Something went wrong.
@@ -1607,7 +1607,7 @@ exports[`Storyshots Textarea With help 1`] = `
               value="Something"
             />
             <div
-              className="FormFeedback__StyledFormFeedback-cuFyWp jhMnDG"
+              className="FormFeedback__StyledFormFeedback-cuFyWp hVyVwg"
               data-test={undefined}
             >
               Everything is fine.


### PR DESCRIPTION
Too much long text for `help` or `error` will be now hidden with a displayed ellipsis. 

Closes #458 