### PR TITLE
FIX: getSpacingToken README

### DIFF
--- a/src/Alert/README.md
+++ b/src/Alert/README.md
@@ -17,7 +17,7 @@ Table below contains all types of the props available in Alert component.
 | dataTest      | `string`                        |                 | Optional prop for testing purposes.
 | icon          | `React.Element<any> \| boolean` |                 | The displayed icon. [See Functional specs](#functional-specs)
 | onClose       | `func`                          |                 | Function for handling Alert onClose.
-| spaceAfter    | `enum`                          |                 | Additional `margin-bottom` after component. [See this docs](../common/getSpacingToken)
+| spaceAfter    | `enum`                          |                 | Additional `margin-bottom` after component. [See this docs](https://github.com/kiwicom/orbit-components/tree/master/src/common/getSpacingToken)
 | title         | `string` \| `React.Node`        |                 | The title of the Alert.
 | **type**      | [`enum`](#enum)                 | `"info"`        | The type of Alert.
 

--- a/src/Card/README.md
+++ b/src/Card/README.md
@@ -21,7 +21,7 @@ Table below contains all types of the props available in ButtonLink component.
 | closable      | `boolean`             | `false`         | If `true`, the Close icon will be displayed. [See Functional specs](#functional-specs)
 | dataTest      | `string`              |                 | Optional prop for testing purposes.
 | onClose       | `func`                |                 | Function for handling onClick event.
-| spaceAfter    | `enum`                |                 | Additional `margin-bottom` after component. [See this docs](../common/getSpacingToken)
+| spaceAfter    | `enum`                |                 | Additional `margin-bottom` after component. [See this docs](https://github.com/kiwicom/orbit-components/tree/master/src/common/getSpacingToken)
 
 ## Functional specs
 * By passing the `closable` prop into Card, you will be able to handle `onClose` function and Close icon will be displayed.

--- a/src/Heading/README.md
+++ b/src/Heading/README.md
@@ -16,7 +16,7 @@ Table below contains all types of the props available in Heading component.
 | dataTest      | `string`              |            | Optional prop for testing purposes.
 | **element**   | [`enum`](#enum)       | `"h1"`     | The element used for the root node.
 | inverted      | `boolean`             |            | The `true`, the Heading color will be white.
-| spaceAfter    | `enum`                |            | Additional `margin-bottom` after component. [See this docs](../common/getSpacingToken)
+| spaceAfter    | `enum`                |            | Additional `margin-bottom` after component. [See this docs](https://github.com/kiwicom/orbit-components/tree/master/src/common/getSpacingToken)
 | **type**      | [`enum`](#enum)       | `"title1"` | The size type of Heading.
 
 ### enum

--- a/src/Illustration/README.md
+++ b/src/Illustration/README.md
@@ -15,7 +15,7 @@ Table below contains all types of the props available in CarrierLogo component.
 | dataTest      | `string`                         |                 | Optional prop for testing purposes.
 | **name**      | [`enum`](#enum)                  |                 | Name for the displayed illustration.
 | size          | [`enum`](#enum)                  | `"medium"`      | The size of the Illustration.
-| spaceAfter    | `enum`                           |                 | Additional `margin-bottom` after component. [See this docs](../common/getSpacingToken)
+| spaceAfter    | `enum`                           |                 | Additional `margin-bottom` after component. [See this docs](https://github.com/kiwicom/orbit-components/tree/master/src/common/getSpacingToken)
 ### enum
 
 | name                        | size           |

--- a/src/List/README.md
+++ b/src/List/README.md
@@ -18,7 +18,7 @@ Table below contains all types of the props available in List component.
 | children      | `Array<ListItem>`  |             | The content of the List.
 | dataTest      | `string`           |             | Optional prop for testing purposes.
 | size          | [`enum`](#enum)    | `"normal"`  | The size of the List.
-| spaceAfter    | `enum`             |             | Additional `margin-bottom` after component. [See this docs](../common/getSpacingToken)
+| spaceAfter    | `enum`             |             | Additional `margin-bottom` after component. [See this docs](https://github.com/kiwicom/orbit-components/tree/master/src/common/getSpacingToken)
 | type          | [`enum`](#enum)    | `"primary"` | The color type of the List.
 
 ### ListItem Props

--- a/src/Text/README.md
+++ b/src/Text/README.md
@@ -18,7 +18,7 @@ Table below contains all types of the props available in the Text component.
 | element       | [`enum`](#enum) | `"p"`       | The element used for the root node.
 | italic        | `boolean`       | `false`     | If `true`, the Text will be in italic style.
 | **size**      | [`enum`](#enum) | `"normal"`  | The size of the Text.
-| spaceAfter    | `enum`          |             | Additional `margin-bottom` after component. [See this docs](../common/getSpacingToken)
+| spaceAfter    | `enum`          |             | Additional `margin-bottom` after component. [See this docs](https://github.com/kiwicom/orbit-components/tree/master/src/common/getSpacingToken)
 | **type**      | [`enum`](#enum) | `"primary"` | The color type of the Text.
 | uppercase     | `boolean`       | `false`     | If `true`, the Text will be in uppercase style.
 | **weight**    | [`enum`](#enum) | `"regular"` | The weight of the Text.

--- a/src/common/getSpacingToken/README.md
+++ b/src/common/getSpacingToken/README.md
@@ -1,0 +1,41 @@
+# getSpacingToken
+The function `getSpacingToken` is used for additional `margin-bottom` for some components.
+
+## Usage with styled-components
+```jsx
+import styled from "styled-components";
+
+import getSpacingToken from "@kiwicom/orbit-components/lib/common/getSpacingToken";
+
+const MyComponent = styled.div`
+  margin-bottom: ${getSpacingToken};
+  // It's not necessary do destructure props
+  // margin-bottom: ${() => getSpacingToken({ spaceAfter, theme }};
+`
+
+MyComponent.defaultProps = {
+  theme: defaultTokens,
+};
+
+const App = () => <MyComponent spaceAfter="small" />
+```
+
+## Parameter
+This function receives one parameter - object. With usage in `styled-components` it can receive it *automatically*.
+
+| Name         | Type                     | Description                      |
+| :-------     | :----------------------- | :------------------------------- |
+| spaceAfter   | [`enum`](#enum)          | The value to be applied.
+| theme        | `typeof defaultTokens`   | Object with theme tokens.
+
+> Please note that the *token value* in the documentation may not be up to date. Check [orbit.kiwi](https://orbit.kiwi/design-tokens/).
+
+### enum
+| name              | used token      | token value |
+| :---------------- | :-------------- | :---------- |
+| `"smallest"`      | `spaceXXSmall`  | `4px`       |
+| `"small"`         | `spaceXSmall`   | `8px`       |
+| `"normal"`        | `spaceSmall`    | `12px`      |
+| `"medium"`        | `spaceMedium`   | `16px`      |
+| `"large"`         | `spaceLarge`    | `24px`      |
+| `"largest"`       | `spaceXLarge`   | `32px`      |


### PR DESCRIPTION
Links inside components on orbit.kiwi to the function `getSpacingToken` which handles additional `margin-bottom` was broken, fixed.
Documentation of this function was missing, fixed.