### PR TITLE
FIX: Tile icon shrink

### DIFF
--- a/src/Tile/TileHeader/index.js
+++ b/src/Tile/TileHeader/index.js
@@ -33,6 +33,7 @@ StyledTileTitle.defaultProps = {
 const StyledTileIcon = styled.div`
   color: ${({ theme }) => theme.orbit.colorHeading};
   display: flex;
+  flex-shrink: 0;
   align-items: center;
   margin: ${({ theme }) => `0 ${theme.orbit.spaceXSmall} 0 0`};
 `;

--- a/src/Tile/__snapshots__/Tile.stories.storyshot
+++ b/src/Tile/__snapshots__/Tile.stories.storyshot
@@ -379,7 +379,7 @@ exports[`Storyshots Tile Expandable 1`] = `
                 className="TileHeader__StyledTileTitle-xOuee gOhPdy"
               >
                 <div
-                  className="TileHeader__StyledTileIcon-hVIutj jXWBrJ"
+                  className="TileHeader__StyledTileIcon-hVIutj hbqFEr"
                 >
                   <svg
                     className="Icon__StyledIcon-ckyxIP fvqkFf"
@@ -779,7 +779,7 @@ exports[`Storyshots Tile Playground 1`] = `
                 className="TileHeader__StyledTileTitle-xOuee gOhPdy"
               >
                 <div
-                  className="TileHeader__StyledTileIcon-hVIutj jXWBrJ"
+                  className="TileHeader__StyledTileIcon-hVIutj hbqFEr"
                 >
                   <svg
                     className="Icon__StyledIcon-ckyxIP fvqkFf"


### PR DESCRIPTION
Icon in Tile was shrinking if the title is too long. Only in IE 11.
<br/><br/><br/><url>LiveURL: https://orbit-components-fix-tile-icon-shrink.surge.sh</url>