### PR TITLE
FIX: CarrierLogo rendered size

### DIFF
--- a/src/CarrierLogo/__snapshots__/CarrierLogo.stories.storyshot
+++ b/src/CarrierLogo/__snapshots__/CarrierLogo.stories.storyshot
@@ -523,7 +523,7 @@ exports[`Storyshots CarrierLogo Non-existing carrier 1`] = `
           }
         >
           <div
-            className="CarrierLogo__StyledCarrierLogo-ieqjqT fhmgrR"
+            className="CarrierLogo__StyledCarrierLogo-ieqjqT kvJfMi"
             data-test={undefined}
             size="large"
           >
@@ -1334,7 +1334,7 @@ exports[`Storyshots CarrierLogo One carrier 1`] = `
           }
         >
           <div
-            className="CarrierLogo__StyledCarrierLogo-ieqjqT fhmgrR"
+            className="CarrierLogo__StyledCarrierLogo-ieqjqT kvJfMi"
             data-test="test"
             size="large"
           >

--- a/src/CarrierLogo/index.js
+++ b/src/CarrierLogo/index.js
@@ -72,10 +72,10 @@ StyledImage.defaultProps = {
 
 export const StyledCarrierLogo = styled.div`
   background-color: ${({ theme }) => theme.orbit.backgroundCarrierLogo};
-  height: ${({ theme, carriers }) =>
-    carriers.length > 1 ? `${theme.orbit.heightIconLarge}` : getRenderSize};
-  width: ${({ theme, carriers }) =>
-    carriers.length > 1 ? `${theme.orbit.widthIconLarge}` : getRenderSize};
+  height: ${({ theme, carriers, size }) =>
+    carriers.length > 1 ? theme.orbit.heightIconLarge : `${getRenderSize({ theme, size })}px`};
+  width: ${({ theme, carriers, size }) =>
+    carriers.length > 1 ? theme.orbit.widthIconLarge : `${getRenderSize({ theme, size })}px`};
   display: flex;
   flex-direction: ${({ carriers }) => (carriers.length > 1 ? "column" : "row")};
   flex-wrap: wrap;

--- a/src/List/__snapshots__/List.stories.storyshot
+++ b/src/List/__snapshots__/List.stories.storyshot
@@ -1855,7 +1855,7 @@ exports[`Storyshots List With carrier 1`] = `
                 className="ListItem__IconContainer-cWSXoS czCkQe"
               >
                 <div
-                  className="CarrierLogo__StyledCarrierLogo-ieqjqT fhmgrR"
+                  className="CarrierLogo__StyledCarrierLogo-ieqjqT kvJfMi"
                   data-test={undefined}
                   size="large"
                 >


### PR DESCRIPTION
Fixed wrong rendered size in `StyledCarrierLogo`.
![img](https://user-images.githubusercontent.com/7254437/47370132-5c592100-d6e5-11e8-992e-6cd6757c2967.png)
<br/><br/><br/><url>LiveURL: https://orbit-components-fix-carrierlogo-size.surge.sh</url>