### PR TITLE
UDATE: storybooknative .gitignore

### DIFF
--- a/storybooknative/.gitignore
+++ b/storybooknative/.gitignore
@@ -41,6 +41,9 @@ buck-out/
 \.buckd/
 *.keystore
 
+# Storybook build/
+storybook-static
+
 # fastlane
 #
 # It is recommended to not store the screenshots in the git repo. Instead, use fastlane to re-generate the


### PR DESCRIPTION
Add the storybook build `./storybook-static` to the `.gitignore` file.