### PR TITLE
UPDATE: move dataTest to inputs directly

### DIFF
--- a/src/Checkbox/__snapshots__/Checkbox.stories.storyshot
+++ b/src/Checkbox/__snapshots__/Checkbox.stories.storyshot
@@ -394,11 +394,11 @@ exports[`Storyshots CheckBox Playground 1`] = `
         >
           <label
             className="Checkbox__Label-sc-1x6twh3-5 ccpUEG"
-            data-test="test"
           >
             <input
               checked={true}
               className="Checkbox__Input-sc-1x6twh3-4 dokhnj"
+              data-test="test"
               disabled={true}
               name="name"
               onChange={[Function]}

--- a/src/Checkbox/__tests__/__snapshots__/index.test.js.snap
+++ b/src/Checkbox/__tests__/__snapshots__/index.test.js.snap
@@ -3,7 +3,6 @@
 exports[`Default CheckBox should match snapshot 1`] = `
 <Checkbox__Label
   checked={false}
-  dataTest="test"
   disabled={false}
   hasError={false}
   theme={
@@ -393,6 +392,7 @@ exports[`Default CheckBox should match snapshot 1`] = `
 >
   <Checkbox__Input
     checked={false}
+    data-test="test"
     disabled={false}
     name="name"
     onChange={

--- a/src/Checkbox/__tests__/index.test.js
+++ b/src/Checkbox/__tests__/index.test.js
@@ -23,7 +23,7 @@ describe(`Default CheckBox`, () => {
       tabIndex={tabIndex}
     />,
   );
-
+  const checkbox = component.find("Checkbox__Input");
   it("should contain a label", () => {
     expect(
       component
@@ -33,31 +33,21 @@ describe(`Default CheckBox`, () => {
     ).toBe(label);
   });
   it("inputs value should match", () => {
-    expect(component.find("Checkbox__Input").prop("value")).toBe(value);
+    expect(checkbox.prop("value")).toBe(value);
   });
   it("should have data-test", () => {
-    expect(component.render().prop("data-test")).toBe(dataTest);
+    expect(checkbox.render().prop("data-test")).toBe(dataTest);
   });
 
   it("should have tabindex", () => {
-    expect(
-      component
-        .find("Checkbox__Input")
-        .render()
-        .prop("tabindex"),
-    ).toBe(tabIndex);
+    expect(checkbox.render().prop("tabindex")).toBe(tabIndex);
   });
 
   it("should have name", () => {
-    expect(
-      component
-        .find("Checkbox__Input")
-        .render()
-        .prop("attribs").name,
-    ).toBe(name);
+    expect(checkbox.render().prop("attribs").name).toBe(name);
   });
   it("should execute onChange method", () => {
-    component.find("Checkbox__Input").simulate("change");
+    checkbox.simulate("change");
     expect(onChange).toHaveBeenCalled();
   });
   it("should match snapshot", () => {

--- a/src/Checkbox/index.js
+++ b/src/Checkbox/index.js
@@ -172,8 +172,9 @@ const Checkbox = React.forwardRef((props: Props, ref: Ref) => {
   } = props;
 
   return (
-    <Label disabled={disabled} hasError={hasError} checked={checked} dataTest={dataTest}>
+    <Label disabled={disabled} hasError={hasError} checked={checked}>
       <Input
+        data-test={dataTest}
         value={value}
         type="checkbox"
         disabled={disabled}

--- a/src/InputField/__snapshots__/InputField.stories.storyshot
+++ b/src/InputField/__snapshots__/InputField.stories.storyshot
@@ -2006,7 +2006,6 @@ exports[`Storyshots InputField Playground 1`] = `
         >
           <label
             className="InputField__Field-sc-4opay-0 kCAFyx"
-            data-test="test"
           >
             <span
               className="FormLabel-sc-1927civ-1 iTEGJS"
@@ -2033,6 +2032,7 @@ exports[`Storyshots InputField Playground 1`] = `
               </div>
               <input
                 className="InputField__Input-sc-4opay-6 bqekVA"
+                data-test="test"
                 disabled={false}
                 name="input"
                 onBlur={[Function]}

--- a/src/InputField/__tests__/__snapshots__/index.test.js.snap
+++ b/src/InputField/__tests__/__snapshots__/index.test.js.snap
@@ -1579,7 +1579,6 @@ exports[`InputField number with error and help should match snapshot 1`] = `
 
 exports[`InputField with help, prefix and suffix should match snapshot 1`] = `
 <InputField__Field
-  data-test="test"
   theme={
     Object {
       "orbit": Object {
@@ -2746,6 +2745,7 @@ exports[`InputField with help, prefix and suffix should match snapshot 1`] = `
       <Search />
     </InputField__Prefix>
     <InputField__Input
+      data-test="test"
       maxLength={10}
       minLength={1}
       name="name"

--- a/src/InputField/__tests__/index.test.js
+++ b/src/InputField/__tests__/index.test.js
@@ -48,7 +48,6 @@ describe(`InputField with help, prefix and suffix`, () => {
     />,
   );
   const prefix = component.find("InputField__Prefix");
-  const labelComponent = component.find("InputField__Field");
   const input = component.find("InputField__Input");
   const suffix = component.find("InputField__Suffix");
 
@@ -80,7 +79,7 @@ describe(`InputField with help, prefix and suffix`, () => {
     expect(input.prop("maxLength")).toBe(maxLength);
     expect(input.prop("minLength")).toBe(minLength);
     expect(input.render().prop("tabindex")).toBe(tabIndex);
-    expect(labelComponent.render().prop("data-test")).toBe(dataTest);
+    expect(input.render().prop("data-test")).toBe(dataTest);
   });
   it("should contain a Button as suffix", () => {
     expect(suffix.find("ButtonLink").exists()).toBe(true);

--- a/src/InputField/index.js
+++ b/src/InputField/index.js
@@ -271,7 +271,7 @@ const InputField = React.forwardRef((props: Props, ref: Ref) => {
   } = props;
 
   return (
-    <Field data-test={dataTest}>
+    <Field>
       {label && !inlineLabel && <FormLabel label={label} isFilled={!!value} required={required} />}
       <InputContainer size={size} disabled={disabled} error={error}>
         {prefix && <Prefix size={size}>{prefix}</Prefix>}
@@ -281,6 +281,7 @@ const InputField = React.forwardRef((props: Props, ref: Ref) => {
           </StyledInlineLabel>
         )}
         <Input
+          data-test={dataTest}
           onChange={onChange}
           onFocus={onFocus}
           onBlur={onBlur}

--- a/src/InputFile/__snapshots__/InputFile.stories.storyshot
+++ b/src/InputFile/__snapshots__/InputFile.stories.storyshot
@@ -909,7 +909,6 @@ exports[`Storyshots InputFile Playground 1`] = `
         >
           <label
             className="InputFile__Field-sc-12oq9bq-0 eLePZo"
-            data-test="test"
           >
             <input
               accept={
@@ -919,6 +918,7 @@ exports[`Storyshots InputFile Playground 1`] = `
                 ]
               }
               className="InputFile__Input-sc-12oq9bq-2 jotmqH"
+              data-test="test"
               name="fileInput"
               onBlur={[Function]}
               onChange={[Function]}

--- a/src/InputFile/__tests__/__snapshots__/index.test.js.snap
+++ b/src/InputFile/__tests__/__snapshots__/index.test.js.snap
@@ -1584,7 +1584,6 @@ exports[`InputFiInputFile with error should match snapshot 1`] = `
 
 exports[`InputFile with help should match snapshot 1`] = `
 <InputFile__Field
-  data-test="test"
   theme={
     Object {
       "orbit": Object {
@@ -1978,6 +1977,7 @@ exports[`InputFile with help should match snapshot 1`] = `
         ".pdf",
       ]
     }
+    data-test="test"
     name="name"
     onBlur={
       [MockFunction] {

--- a/src/InputFile/__tests__/index.test.js
+++ b/src/InputFile/__tests__/index.test.js
@@ -39,7 +39,6 @@ describe(`InputFile with help`, () => {
       onRemoveFile={onRemoveFile}
     />,
   );
-  const labelComponent = component.find("InputFile__Field");
   const input = component.find("InputFile__Input");
   const closeButton = component.find("InputFile__CloseButton");
 
@@ -63,7 +62,7 @@ describe(`InputFile with help`, () => {
     ).toBe(name);
     expect(input.prop("accept")).toBe(allowedFileTypes);
     expect(input.render().prop("tabindex")).toBe(tabIndex);
-    expect(labelComponent.render().prop("data-test")).toBe(dataTest);
+    expect(input.render().prop("data-test")).toBe(dataTest);
   });
   it("should contain a input Button", () => {
     expect(component.find("InputFile__InputButton").exists()).toBe(true);

--- a/src/InputFile/index.js
+++ b/src/InputFile/index.js
@@ -112,8 +112,9 @@ const InputFile = React.forwardRef((props: Props, ref: Ref) => {
   const { placeholder = "No file selected", title = "Select file", onRemoveFile, dataTest } = props;
 
   return (
-    <Field data-test={dataTest}>
+    <Field>
       <Input
+        data-test={dataTest}
         type="file"
         name={props.name}
         error={props.error}

--- a/src/InputStepper/__snapshots__/InputStepper.stories.storyshot
+++ b/src/InputStepper/__snapshots__/InputStepper.stories.storyshot
@@ -419,6 +419,7 @@ exports[`Storyshots InputStepper Playground 1`] = `
                 </div>
                 <input
                   className="InputField__Input-sc-4opay-6 iDeTJU"
+                  data-test="test"
                   disabled={false}
                   max={10}
                   min={1}

--- a/src/InputStepper/index.js
+++ b/src/InputStepper/index.js
@@ -103,8 +103,9 @@ class InputStepper extends React.Component<Props & ForwardedRef, State> {
     } = this.props;
     const { value } = this.state;
     return (
-      <StyledInputStepper dataTest={dataTest}>
+      <StyledInputStepper>
         <InputField
+          dataTest={dataTest}
           size={size}
           label={label}
           disabled={disabled}

--- a/src/Radio/__snapshots__/Radio.stories.storyshot
+++ b/src/Radio/__snapshots__/Radio.stories.storyshot
@@ -391,11 +391,11 @@ exports[`Storyshots Radio Playground 1`] = `
           <label
             checked={true}
             className="Radio__Label-sc-5lanou-6 chZGQX"
-            data-test="test"
           >
             <input
               checked={true}
               className="Radio__Input-sc-5lanou-5 juylbO"
+              data-test="test"
               disabled={true}
               name="name"
               onChange={[Function]}

--- a/src/Radio/__tests__/__snapshots__/index.test.js.snap
+++ b/src/Radio/__tests__/__snapshots__/index.test.js.snap
@@ -3,7 +3,6 @@
 exports[`Default Radio should match snapshot 1`] = `
 <Radio__Label
   checked={false}
-  data-test="test"
   disabled={false}
   hasError={false}
   theme={
@@ -393,6 +392,7 @@ exports[`Default Radio should match snapshot 1`] = `
 >
   <Radio__Input
     checked={false}
+    data-test="test"
     disabled={false}
     name="name"
     onChange={

--- a/src/Radio/__tests__/index.test.js
+++ b/src/Radio/__tests__/index.test.js
@@ -23,6 +23,7 @@ describe(`Default Radio`, () => {
       tabIndex={tabIndex}
     />,
   );
+  const radio = component.find("Radio__Input");
   it("should contain a label", () => {
     expect(
       component
@@ -32,30 +33,20 @@ describe(`Default Radio`, () => {
     ).toBe(label);
   });
   it("should have data-test", () => {
-    expect(component.render().prop("data-test")).toBe(dataTest);
+    expect(radio.render().prop("data-test")).toBe(dataTest);
   });
 
   it("should have tabindex", () => {
-    expect(
-      component
-        .find("Radio__Input")
-        .render()
-        .prop("tabindex"),
-    ).toBe(tabIndex);
+    expect(radio.render().prop("tabindex")).toBe(tabIndex);
   });
   it("should have name", () => {
-    expect(
-      component
-        .find("Radio__Input")
-        .render()
-        .prop("attribs").name,
-    ).toBe(name);
+    expect(radio.render().prop("attribs").name).toBe(name);
   });
   it("input value should match", () => {
-    expect(component.find("Radio__Input").prop("value")).toBe(value);
+    expect(radio.prop("value")).toBe(value);
   });
   it("should execute onChange method", () => {
-    component.find("Radio__Input").simulate("change");
+    radio.simulate("change");
     expect(onChange).toHaveBeenCalled();
   });
   it("should match snapshot", () => {

--- a/src/Radio/index.js
+++ b/src/Radio/index.js
@@ -162,8 +162,9 @@ const Radio = React.forwardRef((props: Props, ref: Ref) => {
     dataTest,
   } = props;
   return (
-    <Label disabled={disabled} hasError={hasError} checked={checked} data-test={dataTest}>
+    <Label disabled={disabled} hasError={hasError} checked={checked}>
       <Input
+        data-test={dataTest}
         value={value}
         type="radio"
         disabled={disabled}

--- a/src/Select/__snapshots__/Select.stories.storyshot
+++ b/src/Select/__snapshots__/Select.stories.storyshot
@@ -548,13 +548,13 @@ exports[`Storyshots Select Playground 1`] = `
         >
           <label
             className="Select__Label-sc-6agypz-0 cqbVlc"
-            data-test="test"
           >
             <div
               className="Select__SelectContainer-sc-6agypz-2 zfoUd"
             >
               <select
                 className="Select__StyledSelect-sc-6agypz-1 dxQsPW"
+                data-test="test"
                 disabled={false}
                 name="name"
                 onBlur={[Function]}

--- a/src/Select/__tests__/Select.test.js
+++ b/src/Select/__tests__/Select.test.js
@@ -31,40 +31,20 @@ describe("Select", () => {
       dataTest={dataTest}
     />,
   );
+  const select = component.find("Select__StyledSelect");
   it("should have data-test", () => {
-    expect(component.prop("data-test")).toBe(dataTest);
+    expect(select.render().prop("data-test")).toBe(dataTest);
   });
   it("should have name", () => {
-    expect(
-      component
-        .find("Select__StyledSelect")
-        .render()
-        .prop("attribs").name,
-    ).toBe(name);
+    expect(select.render().prop("attribs").name).toBe(name);
   });
   it("should match snapshot", () => {
     expect(component).toMatchSnapshot();
   });
-
-  it("should have data-test", () => {
-    expect(component.render().prop("data-test")).toBe(dataTest);
-  });
-
   it("should have tabindex", () => {
-    expect(
-      component
-        .find("Select__StyledSelect")
-        .render()
-        .prop("tabindex"),
-    ).toBe(tabIndex);
+    expect(select.render().prop("tabindex")).toBe(tabIndex);
   });
-
   it("should have placeholder", () => {
-    expect(
-      component
-        .find("Select__StyledSelect")
-        .childAt(0)
-        .text(),
-    ).toBe(placeholder);
+    expect(select.childAt(0).text()).toBe(placeholder);
   });
 });

--- a/src/Select/__tests__/__snapshots__/Select.test.js.snap
+++ b/src/Select/__tests__/__snapshots__/Select.test.js.snap
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Select should match snapshot 1`] = `
-<Select__Label
-  data-test="test"
->
+<Select__Label>
   <Select__SelectContainer
     disabled={false}
     theme={
@@ -392,6 +390,7 @@ exports[`Select should match snapshot 1`] = `
     }
   >
     <Select__StyledSelect
+      dataTest="test"
       disabled={false}
       filled={true}
       name="name"

--- a/src/Select/index.js
+++ b/src/Select/index.js
@@ -30,8 +30,12 @@ const Label = styled.label`
 const StyledSelect = styled(
   // $FlowExpected
   React.forwardRef(
-    ({ className, children, value, disabled, name, tabIndex, onChange, onFocus, onBlur }, ref) => (
+    (
+      { className, dataTest, children, value, disabled, name, tabIndex, onChange, onFocus, onBlur },
+      ref,
+    ) => (
       <select
+        data-test={dataTest}
         value={value}
         className={className}
         onChange={onChange}
@@ -200,7 +204,7 @@ const Select = React.forwardRef((props: Props, ref: Ref) => {
   } = props;
   const filled = !!value;
   return (
-    <Label data-test={dataTest}>
+    <Label>
       {label && (
         <FormLabel filled={filled} disabled={disabled}>
           {label}
@@ -213,6 +217,7 @@ const Select = React.forwardRef((props: Props, ref: Ref) => {
           </SelectPrefix>
         )}
         <StyledSelect
+          dataTest={dataTest}
           size={size}
           disabled={disabled}
           error={error}

--- a/src/Textarea/__snapshots__/Textarea.stories.storyshot
+++ b/src/Textarea/__snapshots__/Textarea.stories.storyshot
@@ -373,7 +373,6 @@ exports[`Storyshots Textarea Playground 1`] = `
         >
           <label
             className="Textarea__Field-sc-1ezoqgy-0 zzGLi"
-            data-test="test"
           >
             <span
               className="FormLabel-sc-1927civ-1 iTEGJS"
@@ -384,6 +383,7 @@ exports[`Storyshots Textarea Playground 1`] = `
             </span>
             <textarea
               className="Textarea__StyledTextArea-sc-1ezoqgy-1 iQaAKZ"
+              data-test="test"
               disabled={true}
               onBlur={[Function]}
               onChange={[Function]}

--- a/src/Textarea/__tests__/__snapshots__/index.test.js.snap
+++ b/src/Textarea/__tests__/__snapshots__/index.test.js.snap
@@ -792,7 +792,6 @@ exports[`Textarea number with error and help should match snapshot 1`] = `
 
 exports[`Textarea with help should match snapshot 1`] = `
 <Textarea__Field
-  data-test="test"
   fullHeight={true}
   theme={
     Object {
@@ -1569,6 +1568,7 @@ exports[`Textarea with help should match snapshot 1`] = `
     Label
   </FormLabel>
   <Textarea__StyledTextArea
+    data-test="test"
     fullHeight={true}
     maxLength={200}
     name="name"

--- a/src/Textarea/__tests__/index.test.js
+++ b/src/Textarea/__tests__/index.test.js
@@ -38,7 +38,6 @@ describe(`Textarea with help`, () => {
   );
 
   const area = component.find("Textarea__StyledTextArea");
-  const labelField = component.find("Textarea__Field");
 
   it("should contain a label", () => {
     expect(
@@ -58,7 +57,7 @@ describe(`Textarea with help`, () => {
     expect(area.prop("placeholder")).toBe(placeholder);
     expect(area.prop("maxLength")).toBe(maxLength);
     expect(area.prop("fullHeight")).toBe(fullHeight);
-    expect(labelField.render().prop("data-test")).toBe(dataTest);
+    expect(area.render().prop("data-test")).toBe(dataTest);
     expect(area.render().prop("tabindex")).toBe(tabIndex);
     expect(
       component

--- a/src/Textarea/index.js
+++ b/src/Textarea/index.js
@@ -109,13 +109,14 @@ const Textarea = React.forwardRef((props: Props, ref: Ref) => {
   } = props;
 
   return (
-    <Field data-test={dataTest} fullHeight={props.fullHeight}>
+    <Field fullHeight={props.fullHeight}>
       {props.label && (
         <FormLabel filled={!!props.value} disabled={disabled}>
           {props.label}
         </FormLabel>
       )}
       <StyledTextArea
+        data-test={dataTest}
         name={props.name}
         value={props.value}
         size={size}


### PR DESCRIPTION
Closes #663 <br/><br/><br/><url>LiveURL: https://orbit-components-update-datatest-inputs.surge.sh</url>