### PR TITLE
FIX: Tile external security

### DIFF
--- a/src/Tile/__tests__/__snapshots__/index.test.js.snap
+++ b/src/Tile/__tests__/__snapshots__/index.test.js.snap
@@ -4,6 +4,7 @@ exports[`Tile Default should match snapshot 1`] = `
 <Tile__StyledTile
   data-test="test"
   href="https://www.kiwi.com/"
+  rel="noopener noreferrer"
   target="_blank"
   theme={
     Object {

--- a/src/Tile/__tests__/index.test.js
+++ b/src/Tile/__tests__/index.test.js
@@ -43,6 +43,10 @@ describe("Tile Default", () => {
     ).toBe(true);
   });
 
+  it("should render rel when external", () => {
+    expect(shallowedComponent.render().prop("rel")).toBe("noopener noreferrer");
+  });
+
   it("should render proper element", () => {
     expect(shallowedComponent.render().prop("name")).toBe("a");
   });

--- a/src/Tile/index.js
+++ b/src/Tile/index.js
@@ -75,6 +75,7 @@ class Tile extends React.PureComponent<Props, State> {
     return (
       <StyledTile
         target={!isExpandable && external ? "_blank" : undefined}
+        rel={!isExpandable && external ? "noopener noreferrer" : undefined}
         href={!isExpandable ? href : undefined}
         data-test={dataTest}
       >


### PR DESCRIPTION
Closes #675 <br/><br/><br/><url>LiveURL: https://orbit-components-tile-tile-external-security.surge.sh</url>