### PR TITLE
FIX: Text wrong weight value

### DIFF
--- a/src/Text/README.md
+++ b/src/Text/README.md
@@ -27,7 +27,7 @@ Table below contains all types of the props available in the Text component.
 
 | type            | align      | element  | size       | weight      |
 | :-------------- | :--------- | :------- | :--------- | :---------- |
-| `"attention"`   | `"left"`   | `"p"`    | `"small"`  | `"regular"` |
+| `"attention"`   | `"left"`   | `"p"`    | `"small"`  | `"normal"`  |
 | `"primary"`     | `"center"` | `"span"` | `"normal"` | `"bold"`    |
 | `"secondary"`   | `"right"`  | `"div"`  | `"large"`  |             |
 | `"info"`        |            |          |            |             |

--- a/src/Text/index.js
+++ b/src/Text/index.js
@@ -46,14 +46,11 @@ const getSizeToken = () => ({ theme, size }) => {
   return sizeTokens[size];
 };
 
-export const StyledText = styled(({ element, children, className, dataTest }) => {
-  const TextElement = element;
-  return (
-    <TextElement className={className} data-test={dataTest}>
-      {children}
-    </TextElement>
-  );
-})`
+export const StyledText = styled(({ element: TextElement, children, className, dataTest }) => (
+  <TextElement className={className} data-test={dataTest}>
+    {children}
+  </TextElement>
+))`
   font-family: ${({ theme }) => theme.orbit.fontFamily};
   font-size: ${getSizeToken()};
   font-weight: ${getWeightToken()};

--- a/src/Text/index.js.flow
+++ b/src/Text/index.js.flow
@@ -16,7 +16,7 @@ type Type =
   | "critical"
   | "white";
 type Size = "large" | "normal" | "small";
-type Weight = "regular" | "bold";
+type Weight = "normal" | "bold";
 
 export type Props = {|
   +type?: Type,


### PR DESCRIPTION
Small possibility of breaking change - if someone explicitly used `weight=regular`.

Closes #651 <br/><br/><br/><url>LiveURL: https://orbit-components-fix-text-wrong-weight.surge.sh</url>