### PR TITLE
ADD: ChinaUnionPay logo

### DIFF
--- a/src/ServiceLogo/README.md
+++ b/src/ServiceLogo/README.md
@@ -25,6 +25,7 @@ Table below contains all types of the props available in ServiceLogo component.
 | `"Alipay"`        | `"medium"`  |
 | `"Amex"`          | `"large"`   |
 | `"AxaAssistance"` |
+| `"ChinaUnionPay"` |
 | `"DinersClub"`    |
 | `"Discover"`      |
 | `"JCB"`           |

--- a/src/ServiceLogo/consts.js
+++ b/src/ServiceLogo/consts.js
@@ -4,6 +4,7 @@ export const NAME_OPTIONS = {
   ALIPAY: "Alipay",
   AMEX: "Amex",
   AXAASSISTANCE: "AxaAssistance",
+  CHINAUNIONPAY: "ChinaUnionPay",
   DINERSCLUB: "DinersClub",
   DISCOVER: "Discover",
   JCB: "JCB",

--- a/src/ServiceLogo/index.js.flow
+++ b/src/ServiceLogo/index.js.flow
@@ -8,6 +8,7 @@ export type Name =
   | "Alipay"
   | "Amex"
   | "AxaAssistance"
+  | "ChinaUnionPay"
   | "DinersClub"
   | "Discover"
   | "JCB"


### PR DESCRIPTION
Added missing service logo for `ChinaUnionPay`<br/><br/><br/><url>LiveURL: https://orbit-components-add-chinaunionpay-servicelogo.surge.sh</url>