### PR TITLE
UPDATE: Add size to TextLink

### DIFF
--- a/src/Checkbox/__snapshots__/Checkbox.stories.storyshot
+++ b/src/Checkbox/__snapshots__/Checkbox.stories.storyshot
@@ -881,7 +881,7 @@ exports[`Storyshots CheckBox RTL 1`] = `
                 >
                   I instruct Kiwi.com to cancel this booking under the herein specified conditions and to process a refund in accordance with Kiwi.com’ 
                   <a
-                    className="TextLink__StyledTextLink-sc-1bvlje4-1 naMEP"
+                    className="TextLink__StyledTextLink-sc-1bvlje4-1 gjnkGq"
                     rel=""
                   >
                     Terms and Conditions
@@ -1259,7 +1259,7 @@ exports[`Storyshots CheckBox With TextLink in label 1`] = `
                 >
                   I instruct Kiwi.com to cancel this booking under the herein specified conditions and to process a refund in accordance with Kiwi.com’ 
                   <a
-                    className="TextLink__StyledTextLink-sc-1bvlje4-1 naMEP"
+                    className="TextLink__StyledTextLink-sc-1bvlje4-1 gjnkGq"
                     rel=""
                   >
                     Terms and Conditions

--- a/src/InputField/__snapshots__/InputField.stories.storyshot
+++ b/src/InputField/__snapshots__/InputField.stories.storyshot
@@ -858,7 +858,7 @@ exports[`Storyshots InputField Email input 1`] = `
               <div>
                 Did you mean 
                 <a
-                  className="TextLink__StyledTextLink-sc-1bvlje4-1 naMEP"
+                  className="TextLink__StyledTextLink-sc-1bvlje4-1 gjnkGq"
                   onClick={[Function]}
                   rel=""
                 >

--- a/src/Radio/__snapshots__/Radio.stories.storyshot
+++ b/src/Radio/__snapshots__/Radio.stories.storyshot
@@ -869,7 +869,7 @@ exports[`Storyshots Radio RTL 1`] = `
                 >
                   Lorem ipsum dolor sit 
                   <a
-                    className="TextLink__StyledTextLink-sc-1bvlje4-1 naMEP"
+                    className="TextLink__StyledTextLink-sc-1bvlje4-1 gjnkGq"
                     rel=""
                   >
                     amet
@@ -1243,7 +1243,7 @@ exports[`Storyshots Radio With TextLink in label 1`] = `
                 >
                   Lorem ipsum dolor sit 
                   <a
-                    className="TextLink__StyledTextLink-sc-1bvlje4-1 naMEP"
+                    className="TextLink__StyledTextLink-sc-1bvlje4-1 gjnkGq"
                     rel=""
                   >
                     amet

--- a/src/Stack/__snapshots__/Stack.stories.storyshot
+++ b/src/Stack/__snapshots__/Stack.stories.storyshot
@@ -2675,7 +2675,7 @@ exports[`Storyshots Stack Components preview 1`] = `
                       </div>
                       Transfer protected by the 
                       <a
-                        className="TextLink__StyledTextLink-sc-1bvlje4-1 daTvTO"
+                        className="TextLink__StyledTextLink-sc-1bvlje4-1 fdRcJC"
                         rel=""
                       >
                         Kiwi.com Guarantee
@@ -2876,7 +2876,7 @@ exports[`Storyshots Stack Components preview 1`] = `
                       </div>
                       Transfer protected by the 
                       <a
-                        className="TextLink__StyledTextLink-sc-1bvlje4-1 daTvTO"
+                        className="TextLink__StyledTextLink-sc-1bvlje4-1 fdRcJC"
                         rel=""
                       >
                         Kiwi.com Guarantee
@@ -3059,7 +3059,7 @@ exports[`Storyshots Stack Components preview 1`] = `
                       </div>
                       Transfer protected by the 
                       <a
-                        className="TextLink__StyledTextLink-sc-1bvlje4-1 daTvTO"
+                        className="TextLink__StyledTextLink-sc-1bvlje4-1 fdRcJC"
                         rel=""
                       >
                         Kiwi.com Guarantee
@@ -3455,7 +3455,7 @@ exports[`Storyshots Stack Components preview 1`] = `
                       </div>
                       Transfer protected by the 
                       <a
-                        className="TextLink__StyledTextLink-sc-1bvlje4-1 daTvTO"
+                        className="TextLink__StyledTextLink-sc-1bvlje4-1 fdRcJC"
                         rel=""
                       >
                         Kiwi.com Guarantee
@@ -30844,7 +30844,7 @@ exports[`Storyshots Stack Nested example 1`] = `
               className="Text__StyledText-sc-19qtt4y-0 efCYLv"
             >
               <a
-                className="TextLink__StyledTextLink-sc-1bvlje4-1 daTvTO"
+                className="TextLink__StyledTextLink-sc-1bvlje4-1 fdRcJC"
                 rel=""
               >
                 Forgot password?
@@ -32881,7 +32881,7 @@ exports[`Storyshots Stack RTL 1`] = `
               className="Text__StyledText-sc-19qtt4y-0 hsoaey"
             >
               <a
-                className="TextLink__StyledTextLink-sc-1bvlje4-1 daTvTO"
+                className="TextLink__StyledTextLink-sc-1bvlje4-1 fdRcJC"
                 rel=""
               >
                 Forgot password?

--- a/src/TextLink/README.md
+++ b/src/TextLink/README.md
@@ -19,14 +19,18 @@ Table below contains all types of the props available in TextLink component.
 | icon          | `React.Node`          |                 | The displayed icon.
 | onClick       | `func`                |                 | Function for handling onClick event.
 | rel           | `string`              |                 | The rel of the TextLink. [See Functional specs](#functional-specs)
+| size          | [`enum`](#enum)       |                 | The size of the TextLink. [See Functional specs](#functional-specs)
 | **type**      | [`enum`](#enum)       | `"primary"`     | The color type of the TextLink.
 
 ### enum
 
-| type          |
-| :------------ |
-| `"primary"`   |
-| `"secondary"` |
+| size          | type          |
+| :------------ | :------------ |
+| `"small"`     | `"primary"`   |
+| `"normal"`    | `"secondary"` |
+| `"large"`     |
 
 ## Functional specs
 * When the `external` is specified, `noopener` and `noreferrer` values will automatically added to attribute `rel` for security reason.
+
+* The default size of the `TextLink` is inherited from parent element, e.g. `TextLink` is wrapped in `Text` component. Use `size` prop only when you need to set it explicitly.

--- a/src/TextLink/TextLink.stories.js
+++ b/src/TextLink/TextLink.stories.js
@@ -7,7 +7,7 @@ import styles from "@sambego/storybook-styles";
 import chaptersAddon from "react-storybook-addon-chapters";
 import { withKnobs, text, boolean, select } from "@storybook/addon-knobs";
 
-import TYPE_OPTIONS from "./consts";
+import { TYPE_OPTIONS, SIZE_OPTIONS } from "./consts";
 import * as Icons from "../icons";
 import RenderInRtl from "../utils/rtl/RenderInRtl";
 
@@ -109,6 +109,7 @@ storiesOf("TextLink", module)
   .addWithChapters("Playground", () => {
     const href = text("Href", "https://kiwi.com");
     const type = select("Type", Object.values(TYPE_OPTIONS), TYPE_OPTIONS.SECONDARY);
+    const size = select("Size", Object.values(SIZE_OPTIONS), SIZE_OPTIONS.SMALL);
     const external = boolean("External", true);
     const title = text("Text", "Custom link");
     const rel = text("Rel", undefined);
@@ -128,6 +129,7 @@ storiesOf("TextLink", module)
                   onClick={action("clicked")}
                   href={href}
                   type={type}
+                  size={size}
                   rel={validate(rel)}
                   icon={Icon && <Icon />}
                   dataTest={dataTest}

--- a/src/TextLink/__snapshots__/TextLink.stories.storyshot
+++ b/src/TextLink/__snapshots__/TextLink.stories.storyshot
@@ -98,14 +98,14 @@ exports[`Storyshots TextLink Link with icon 1`] = `
           }
         >
           <a
-            className="TextLink__StyledTextLink-sc-1bvlje4-1 naMEP"
+            className="TextLink__StyledTextLink-sc-1bvlje4-1 gjnkGq"
             href="https://kiwi.com"
             onClick={[Function]}
             rel=""
           >
             TextLink with icon
             <span
-              className="TextLink__IconContainer-sc-1bvlje4-0 evHoym"
+              className="TextLink__IconContainer-sc-1bvlje4-0 hvVwEI"
             >
               <svg
                 className="Icon__StyledIcon-sc-1pnzn3g-0 geWqaO"
@@ -421,16 +421,17 @@ exports[`Storyshots TextLink Playground 1`] = `
           }
         >
           <a
-            className="TextLink__StyledTextLink-sc-1bvlje4-1 daTvTO"
+            className="TextLink__StyledTextLink-sc-1bvlje4-1 hiklAr"
             data-test="test"
             href="https://kiwi.com"
             onClick={[Function]}
             rel="noopener noreferrer"
+            size="small"
             target="_blank"
           >
             Custom link
             <span
-              className="TextLink__IconContainer-sc-1bvlje4-0 iaiTzP"
+              className="TextLink__IconContainer-sc-1bvlje4-0 dwbANF"
             >
               <svg
                 className="Icon__StyledIcon-sc-1pnzn3g-0 geWqaO"
@@ -580,6 +581,36 @@ exports[`Storyshots TextLink Playground 1`] = `
                                   }
                                 >
                                   secondary
+                                </span>
+                                "
+                              </span>
+                            </span>
+                          </span>
+                          <span>
+                            <span>
+                              <br />
+                                
+                            </span>
+                            <span
+                              style={Object {}}
+                            >
+                              size
+                            </span>
+                            <span>
+                              =
+                              <span
+                                style={Object {}}
+                              >
+                                "
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#22a",
+                                      "wordBreak": "break-word",
+                                    }
+                                  }
+                                >
+                                  small
                                 </span>
                                 "
                               </span>
@@ -855,7 +886,7 @@ exports[`Storyshots TextLink Primary link 1`] = `
           }
         >
           <a
-            className="TextLink__StyledTextLink-sc-1bvlje4-1 naMEP"
+            className="TextLink__StyledTextLink-sc-1bvlje4-1 gjnkGq"
             href="https://kiwi.com"
             onClick={[Function]}
             rel=""
@@ -1204,14 +1235,14 @@ exports[`Storyshots TextLink RTL 1`] = `
           }
         >
           <a
-            className="TextLink__StyledTextLink-sc-1bvlje4-1 naMEP"
+            className="TextLink__StyledTextLink-sc-1bvlje4-1 gjnkGq"
             href="#"
             onClick={[Function]}
             rel=""
           >
             Link
             <span
-              className="TextLink__IconContainer-sc-1bvlje4-0 evHoym"
+              className="TextLink__IconContainer-sc-1bvlje4-0 hvVwEI"
             >
               <svg
                 className="Icon__StyledIcon-sc-1pnzn3g-0 geWqaO"
@@ -1578,7 +1609,7 @@ exports[`Storyshots TextLink Secondary link 1`] = `
           }
         >
           <a
-            className="TextLink__StyledTextLink-sc-1bvlje4-1 daTvTO"
+            className="TextLink__StyledTextLink-sc-1bvlje4-1 fdRcJC"
             href="https://kiwi.com"
             onClick={[Function]}
             rel=""

--- a/src/TextLink/consts.js
+++ b/src/TextLink/consts.js
@@ -1,7 +1,11 @@
 // @flow
-const TYPE_OPTIONS = {
+export const TYPE_OPTIONS = {
   PRIMARY: "primary",
   SECONDARY: "secondary",
 };
 
-export default TYPE_OPTIONS;
+export const SIZE_OPTIONS = {
+  SMALL: "small",
+  NORMAL: "normal",
+  LARGE: "large",
+};

--- a/src/TextLink/index.js
+++ b/src/TextLink/index.js
@@ -3,7 +3,7 @@ import * as React from "react";
 import styled from "styled-components";
 
 import defaultTokens from "../defaultTokens";
-import TYPE_OPTIONS from "./consts";
+import { TYPE_OPTIONS, SIZE_OPTIONS } from "./consts";
 
 import type { Props } from "./index";
 
@@ -16,10 +16,20 @@ const getColor = ({ theme, type }) => {
   return tokens[type];
 };
 
+const getSizeToken = () => ({ theme, size }) => {
+  const sizeTokens = {
+    [SIZE_OPTIONS.LARGE]: theme.orbit.fontSizeTextLarge,
+    [SIZE_OPTIONS.NORMAL]: theme.orbit.fontSizeTextNormal,
+    [SIZE_OPTIONS.SMALL]: theme.orbit.fontSizeTextSmall,
+  };
+  return size && sizeTokens[size];
+};
+
 const IconContainer = styled(({ children, className }) => (
   <span className={className}>{children}</span>
 ))`
-  display: block;
+  display: flex;
+  align-items: center;
   color: ${getColor};
   transition: color ${({ theme }) => theme.orbit.durationFast} ease-in-out;
 
@@ -39,6 +49,7 @@ export const StyledTextLink = styled(({ theme, type, ...props }) => (
   color: ${getColor};
   font-family: ${({ theme }) => theme.orbit.fontFamily};
   font-weight: ${({ theme }) => theme.orbit.fontWeightLinks};
+  font-size: ${getSizeToken};
   text-decoration: ${({ theme, type }) =>
     type === TYPE_OPTIONS.SECONDARY
       ? theme.orbit.textDecorationTextLinkSecondary
@@ -76,6 +87,7 @@ StyledTextLink.defaultProps = {
 
 const TextLink = ({
   type = TYPE_OPTIONS.PRIMARY,
+  size,
   children,
   href,
   external = false,
@@ -100,6 +112,7 @@ const TextLink = ({
   return (
     <StyledTextLink
       type={type}
+      size={size}
       href={href}
       target={external ? "_blank" : undefined}
       rel={relValues && relValues.join(" ")}

--- a/src/TextLink/index.js.flow
+++ b/src/TextLink/index.js.flow
@@ -5,6 +5,8 @@ import type { Globals } from "../common/common.js.flow";
 
 type Type = "primary" | "secondary";
 
+type Size = "large" | "normal" | "small";
+
 export type Props = {|
   +children: React$Node,
   +href?: string,
@@ -12,6 +14,7 @@ export type Props = {|
   +onClick?: (SyntheticEvent<HTMLLinkElement>) => void | Promise<any>,
   +external?: boolean,
   +type?: Type,
+  +size?: Size,
   +rel?: string,
   +tabIndex?: string,
   ...Globals,

--- a/src/TripSector/__snapshots__/TripSector.stories.storyshot
+++ b/src/TripSector/__snapshots__/TripSector.stories.storyshot
@@ -315,7 +315,7 @@ exports[`Storyshots TripSector Multiple days 1`] = `
                   </div>
                   Transfer protected by the 
                   <a
-                    className="TextLink__StyledTextLink-sc-1bvlje4-1 daTvTO"
+                    className="TextLink__StyledTextLink-sc-1bvlje4-1 fdRcJC"
                     rel=""
                   >
                     Kiwi.com Guarantee
@@ -516,7 +516,7 @@ exports[`Storyshots TripSector Multiple days 1`] = `
                   </div>
                   Transfer protected by the 
                   <a
-                    className="TextLink__StyledTextLink-sc-1bvlje4-1 daTvTO"
+                    className="TextLink__StyledTextLink-sc-1bvlje4-1 fdRcJC"
                     rel=""
                   >
                     Kiwi.com Guarantee
@@ -699,7 +699,7 @@ exports[`Storyshots TripSector Multiple days 1`] = `
                   </div>
                   Transfer protected by the 
                   <a
-                    className="TextLink__StyledTextLink-sc-1bvlje4-1 daTvTO"
+                    className="TextLink__StyledTextLink-sc-1bvlje4-1 fdRcJC"
                     rel=""
                   >
                     Kiwi.com Guarantee
@@ -6178,7 +6178,7 @@ exports[`Storyshots TripSector RTL 1`] = `
                   </div>
                   Transfer protected by the 
                   <a
-                    className="TextLink__StyledTextLink-sc-1bvlje4-1 daTvTO"
+                    className="TextLink__StyledTextLink-sc-1bvlje4-1 fdRcJC"
                     rel=""
                   >
                     Kiwi.com Guarantee
@@ -6379,7 +6379,7 @@ exports[`Storyshots TripSector RTL 1`] = `
                   </div>
                   Transfer protected by the 
                   <a
-                    className="TextLink__StyledTextLink-sc-1bvlje4-1 daTvTO"
+                    className="TextLink__StyledTextLink-sc-1bvlje4-1 fdRcJC"
                     rel=""
                   >
                     Kiwi.com Guarantee
@@ -6562,7 +6562,7 @@ exports[`Storyshots TripSector RTL 1`] = `
                   </div>
                   Transfer protected by the 
                   <a
-                    className="TextLink__StyledTextLink-sc-1bvlje4-1 daTvTO"
+                    className="TextLink__StyledTextLink-sc-1bvlje4-1 fdRcJC"
                     rel=""
                   >
                     Kiwi.com Guarantee


### PR DESCRIPTION
Added optional `size` prop for TextLink. The default behavior is still `inherit` from a parent element.<br/><br/><br/><url>LiveURL: https://orbit-components-update-textlink-size.surge.sh</url>