### PR TITLE
FIX: Remove webkit spin from InputField

### DIFF
--- a/src/InputField/README.md
+++ b/src/InputField/README.md
@@ -33,7 +33,7 @@ Table below contains all types of the props available in InputField component.
 | **prefix**    | `React.Node`      |              | The prefix component for the InputField. 
 | ref           | `func`            |              | Prop for forwarded ref of the InputField. [See Functional specs](#functional-specs)
 | **size**      | [`enum`](#enum)   | `"normal"`   | The size of the InputField.
-| suffix        | `React.Node`      |              | The suffix component for the InputField.
+| suffix        | `React.Node`      |              | The suffix component for the InputField. [See Functional specs](#functional-specs)
 | **type**      | [`enum`](#enum)   | `"text"`     | The type of the InputField.
 | value         | `string`          |              | Specifies the value of the InputField.
 
@@ -53,6 +53,16 @@ Table below contains all types of the props available in InputField component.
 * The color of the label will turn into cloud shade when the InputField has some filled value.
 
 * You can use `string` for currency InputField, or `React.Node` for InputField with icon.
+
+* If you want to use `ButtonLink` as suffix for the `InputField`, use `transparent` prop for the `ButtonLink`, e.g.:
+```jsx
+<InputField
+  placeholder="My placeholder"
+  suffix={
+    <ButtonLink transparent icon={<Visibility />} />
+  }
+/>
+```
 
 * `ref` can be used for example auto-focus the elements immediately after render.
 ```jsx

--- a/src/InputField/__snapshots__/InputField.stories.storyshot
+++ b/src/InputField/__snapshots__/InputField.stories.storyshot
@@ -116,7 +116,7 @@ exports[`Storyshots InputField Compact input 1`] = `
                 </span>
               </div>
               <input
-                className="InputField__Input-sc-4opay-6 ijQzfL"
+                className="InputField__Input-sc-4opay-6 kiVcDD"
                 onChange={[Function]}
                 placeholder="Placeholder"
                 size="normal"
@@ -513,7 +513,7 @@ exports[`Storyshots InputField Default input 1`] = `
               className="InputField__InputContainer-sc-4opay-2 ksKWcl"
             >
               <input
-                className="InputField__Input-sc-4opay-6 iDeTJU"
+                className="InputField__Input-sc-4opay-6 jLeeWm"
                 onChange={[Function]}
                 placeholder="Placeholder"
                 size="normal"
@@ -841,7 +841,7 @@ exports[`Storyshots InputField Email input 1`] = `
               className="InputField__InputContainer-sc-4opay-2 ksKWcl"
             >
               <input
-                className="InputField__Input-sc-4opay-6 iDeTJU"
+                className="InputField__Input-sc-4opay-6 jLeeWm"
                 onChange={[Function]}
                 placeholder="Email"
                 size="normal"
@@ -1243,7 +1243,7 @@ exports[`Storyshots InputField Number input 1`] = `
               className="InputField__InputContainer-sc-4opay-2 ksKWcl"
             >
               <input
-                className="InputField__Input-sc-4opay-6 iDeTJU"
+                className="InputField__Input-sc-4opay-6 jLeeWm"
                 max={3}
                 min={1}
                 onChange={[Function]}
@@ -1660,7 +1660,7 @@ exports[`Storyshots InputField Password input 1`] = `
               className="InputField__InputContainer-sc-4opay-2 ksKWcl"
             >
               <input
-                className="InputField__Input-sc-4opay-6 iDeTJU"
+                className="InputField__Input-sc-4opay-6 jLeeWm"
                 onChange={[Function]}
                 placeholder="Password"
                 size="normal"
@@ -2031,7 +2031,7 @@ exports[`Storyshots InputField Playground 1`] = `
                 </svg>
               </div>
               <input
-                className="InputField__Input-sc-4opay-6 bqekVA"
+                className="InputField__Input-sc-4opay-6 gEuwqy"
                 data-test="test"
                 disabled={false}
                 name="input"
@@ -2891,7 +2891,7 @@ exports[`Storyshots InputField RTL 1`] = `
                 $
               </div>
               <input
-                className="InputField__Input-sc-4opay-6 iDeTJU"
+                className="InputField__Input-sc-4opay-6 jLeeWm"
                 placeholder="Placeholder"
                 size="normal"
                 type="text"
@@ -3296,7 +3296,7 @@ exports[`Storyshots InputField Required field 1`] = `
               className="InputField__InputContainer-sc-4opay-2 ksKWcl"
             >
               <input
-                className="InputField__Input-sc-4opay-6 iDeTJU"
+                className="InputField__Input-sc-4opay-6 jLeeWm"
                 onChange={[Function]}
                 placeholder="Placeholder"
                 size="normal"
@@ -3635,7 +3635,7 @@ exports[`Storyshots InputField Small input 1`] = `
               className="InputField__InputContainer-sc-4opay-2 kXcsVj"
             >
               <input
-                className="InputField__Input-sc-4opay-6 bqekVA"
+                className="InputField__Input-sc-4opay-6 gEuwqy"
                 onChange={[Function]}
                 placeholder="Placeholder"
                 size="small"
@@ -3993,7 +3993,7 @@ exports[`Storyshots InputField With ButtonLink suffix 1`] = `
               className="InputField__InputContainer-sc-4opay-2 ksKWcl"
             >
               <input
-                className="InputField__Input-sc-4opay-6 iDeTJU"
+                className="InputField__Input-sc-4opay-6 jLeeWm"
                 onChange={[Function]}
                 placeholder="Placeholder"
                 size="normal"
@@ -4387,7 +4387,7 @@ exports[`Storyshots InputField With Icon prefix 1`] = `
                 </svg>
               </div>
               <input
-                className="InputField__Input-sc-4opay-6 iDeTJU"
+                className="InputField__Input-sc-4opay-6 jLeeWm"
                 onChange={[Function]}
                 placeholder="Placeholder"
                 size="normal"
@@ -4744,7 +4744,7 @@ exports[`Storyshots InputField With ServiceLogo prefix 1`] = `
               className="InputField__InputContainer-sc-4opay-2 ksKWcl"
             >
               <input
-                className="InputField__Input-sc-4opay-6 iDeTJU"
+                className="InputField__Input-sc-4opay-6 jLeeWm"
                 onChange={[Function]}
                 placeholder="Placeholder"
                 size="normal"
@@ -5116,7 +5116,7 @@ exports[`Storyshots InputField With text prefix 1`] = `
                 $
               </div>
               <input
-                className="InputField__Input-sc-4opay-6 iDeTJU"
+                className="InputField__Input-sc-4opay-6 jLeeWm"
                 onChange={[Function]}
                 placeholder="Placeholder"
                 size="normal"

--- a/src/InputField/index.js
+++ b/src/InputField/index.js
@@ -192,6 +192,12 @@ export const Input = styled.input`
   border-radius: ${({ theme }) => theme.orbit.borderRadiusNormal};
   z-index: 2;
 
+  &::-webkit-inner-spin-button,
+  &::-webkit-outer-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
+
   &:focus {
     outline: none;
     & ~ ${FakeInput} {

--- a/src/InputGroup/__snapshots__/InputGroup.stories.storyshot
+++ b/src/InputGroup/__snapshots__/InputGroup.stories.storyshot
@@ -120,7 +120,7 @@ exports[`Storyshots InputGroup Date of birth 1`] = `
                     className="InputField__InputContainer-sc-4opay-2 ksKWcl"
                   >
                     <input
-                      className="InputField__Input-sc-4opay-6 iDeTJU"
+                      className="InputField__Input-sc-4opay-6 jLeeWm"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onFocus={[Function]}
@@ -244,7 +244,7 @@ exports[`Storyshots InputGroup Date of birth 1`] = `
                     className="InputField__InputContainer-sc-4opay-2 ksKWcl"
                   >
                     <input
-                      className="InputField__Input-sc-4opay-6 iDeTJU"
+                      className="InputField__Input-sc-4opay-6 jLeeWm"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onFocus={[Function]}
@@ -1210,7 +1210,7 @@ exports[`Storyshots InputGroup Phone number 1`] = `
                     className="InputField__InputContainer-sc-4opay-2 ksKWcl"
                   >
                     <input
-                      className="InputField__Input-sc-4opay-6 iDeTJU"
+                      className="InputField__Input-sc-4opay-6 jLeeWm"
                       maxLength={11}
                       onBlur={[Function]}
                       onChange={[Function]}
@@ -2042,7 +2042,7 @@ exports[`Storyshots InputGroup Playground 1`] = `
                     className="InputField__InputContainer-sc-4opay-2 ksKWcl"
                   >
                     <input
-                      className="InputField__Input-sc-4opay-6 iDeTJU"
+                      className="InputField__Input-sc-4opay-6 jLeeWm"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onFocus={[Function]}
@@ -2110,7 +2110,7 @@ exports[`Storyshots InputGroup Playground 1`] = `
                     className="InputField__InputContainer-sc-4opay-2 ksKWcl"
                   >
                     <input
-                      className="InputField__Input-sc-4opay-6 iDeTJU"
+                      className="InputField__Input-sc-4opay-6 jLeeWm"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onFocus={[Function]}
@@ -3250,7 +3250,7 @@ exports[`Storyshots InputGroup RTL 1`] = `
                     className="InputField__InputContainer-sc-4opay-2 ksKWcl"
                   >
                     <input
-                      className="InputField__Input-sc-4opay-6 iDeTJU"
+                      className="InputField__Input-sc-4opay-6 jLeeWm"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onFocus={[Function]}
@@ -3374,7 +3374,7 @@ exports[`Storyshots InputGroup RTL 1`] = `
                     className="InputField__InputContainer-sc-4opay-2 ksKWcl"
                   >
                     <input
-                      className="InputField__Input-sc-4opay-6 iDeTJU"
+                      className="InputField__Input-sc-4opay-6 jLeeWm"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onFocus={[Function]}

--- a/src/InputStepper/__snapshots__/InputStepper.stories.storyshot
+++ b/src/InputStepper/__snapshots__/InputStepper.stories.storyshot
@@ -98,7 +98,7 @@ exports[`Storyshots InputStepper Default 1`] = `
           }
         >
           <div
-            className="InputStepper__StyledInputStepper-sc-1kqzp6i-1 dpErlr"
+            className="InputStepper__StyledInputStepper-sc-1kqzp6i-1 fNaGqE"
           >
             <label
               className="InputField__Field-sc-4opay-0 kCAFyx"
@@ -131,7 +131,7 @@ exports[`Storyshots InputStepper Default 1`] = `
                   </div>
                 </div>
                 <input
-                  className="InputField__Input-sc-4opay-6 iDeTJU"
+                  className="InputField__Input-sc-4opay-6 jLeeWm"
                   onChange={[Function]}
                   onKeyDown={[Function]}
                   size="normal"
@@ -378,7 +378,7 @@ exports[`Storyshots InputStepper Playground 1`] = `
           }
         >
           <div
-            className="InputStepper__StyledInputStepper-sc-1kqzp6i-1 dpErlr"
+            className="InputStepper__StyledInputStepper-sc-1kqzp6i-1 fNaGqE"
           >
             <label
               className="InputField__Field-sc-4opay-0 kCAFyx"
@@ -418,7 +418,7 @@ exports[`Storyshots InputStepper Playground 1`] = `
                   </div>
                 </div>
                 <input
-                  className="InputField__Input-sc-4opay-6 iDeTJU"
+                  className="InputField__Input-sc-4opay-6 jLeeWm"
                   data-test="test"
                   disabled={false}
                   max={10}
@@ -1091,7 +1091,7 @@ exports[`Storyshots InputStepper RTL 1`] = `
           }
         >
           <div
-            className="InputStepper__StyledInputStepper-sc-1kqzp6i-1 dpErlr"
+            className="InputStepper__StyledInputStepper-sc-1kqzp6i-1 fNaGqE"
           >
             <label
               className="InputField__Field-sc-4opay-0 kCAFyx"
@@ -1131,7 +1131,7 @@ exports[`Storyshots InputStepper RTL 1`] = `
                   </div>
                 </div>
                 <input
-                  className="InputField__Input-sc-4opay-6 iDeTJU"
+                  className="InputField__Input-sc-4opay-6 jLeeWm"
                   onChange={[Function]}
                   onKeyDown={[Function]}
                   size="normal"
@@ -1430,7 +1430,7 @@ exports[`Storyshots InputStepper With different size 1`] = `
           }
         >
           <div
-            className="InputStepper__StyledInputStepper-sc-1kqzp6i-1 dpErlr"
+            className="InputStepper__StyledInputStepper-sc-1kqzp6i-1 fNaGqE"
           >
             <label
               className="InputField__Field-sc-4opay-0 kCAFyx"
@@ -1470,7 +1470,7 @@ exports[`Storyshots InputStepper With different size 1`] = `
                   </div>
                 </div>
                 <input
-                  className="InputField__Input-sc-4opay-6 iDeTJU"
+                  className="InputField__Input-sc-4opay-6 jLeeWm"
                   onBlur={[Function]}
                   onChange={[Function]}
                   onFocus={[Function]}
@@ -1840,7 +1840,7 @@ exports[`Storyshots InputStepper With help 1`] = `
           }
         >
           <div
-            className="InputStepper__StyledInputStepper-sc-1kqzp6i-1 dpErlr"
+            className="InputStepper__StyledInputStepper-sc-1kqzp6i-1 fNaGqE"
           >
             <label
               className="InputField__Field-sc-4opay-0 kCAFyx"
@@ -1880,7 +1880,7 @@ exports[`Storyshots InputStepper With help 1`] = `
                   </div>
                 </div>
                 <input
-                  className="InputField__Input-sc-4opay-6 iDeTJU"
+                  className="InputField__Input-sc-4opay-6 jLeeWm"
                   onBlur={[Function]}
                   onChange={[Function]}
                   onFocus={[Function]}

--- a/src/InputStepper/__tests__/__snapshots__/index.test.js.snap
+++ b/src/InputStepper/__tests__/__snapshots__/index.test.js.snap
@@ -299,6 +299,12 @@ exports[`InputStepper with help, prefix and suffix should match snapshot 1`] = `
   z-index: 2;
 }
 
+.c11::-webkit-inner-spin-button,
+.c11::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
 .c11:focus {
   outline: none;
 }
@@ -363,12 +369,6 @@ exports[`InputStepper with help, prefix and suffix should match snapshot 1`] = `
   text-align: center;
 }
 
-.c0 .c10::-webkit-inner-spin-button,
-.c0 .c10::-webkit-outer-spin-button {
-  -webkit-appearance: none;
-  margin: 0;
-}
-
 .c0 .c4 {
   padding: 0;
   pointer-events: auto;
@@ -422,7 +422,7 @@ exports[`InputStepper with help, prefix and suffix should match snapshot 1`] = `
               "rules": Array [
                 "width:100%;",
                 ".c10",
-                "{text-align:center;&::-webkit-inner-spin-button,&::-webkit-outer-spin-button{-webkit-appearance:none;margin:0;}}",
+                "{text-align:center;}",
                 ".c4",
                 "{padding:0;pointer-events:auto;}",
               ],
@@ -11940,7 +11940,7 @@ exports[`InputStepper with help, prefix and suffix should match snapshot 1`] = `
                                       [Function],
                                       ";border-radius:",
                                       [Function],
-                                      ";z-index:2;&:focus{outline:none;& ~ ",
+                                      ";z-index:2;&::-webkit-inner-spin-button,&::-webkit-outer-spin-button{-webkit-appearance:none;margin:0;}&:focus{outline:none;& ~ ",
                                       ".c15",
                                       "{box-shadow:inset 0 0 0 ",
                                       [Function],

--- a/src/InputStepper/index.js
+++ b/src/InputStepper/index.js
@@ -20,12 +20,6 @@ const StyledInputStepper = styled.div`
   width: 100%;
   ${Input} {
     text-align: center;
-
-    &::-webkit-inner-spin-button,
-    &::-webkit-outer-spin-button {
-      -webkit-appearance: none;
-      margin: 0;
-    }
   }
   ${Prefix} {
     padding: 0;

--- a/src/Modal/__snapshots__/Modal.stories.storyshot
+++ b/src/Modal/__snapshots__/Modal.stories.storyshot
@@ -5623,7 +5623,7 @@ exports[`Storyshots Modal With Form 1`] = `
                         className="InputField__InputContainer-sc-4opay-2 ksKWcl"
                       >
                         <input
-                          className="InputField__Input-sc-4opay-6 iDeTJU"
+                          className="InputField__Input-sc-4opay-6 jLeeWm"
                           placeholder="Your email"
                           size="normal"
                           type="text"
@@ -5711,7 +5711,7 @@ exports[`Storyshots Modal With Form 1`] = `
                               className="InputField__InputContainer-sc-4opay-2 ksKWcl"
                             >
                               <input
-                                className="InputField__Input-sc-4opay-6 iDeTJU"
+                                className="InputField__Input-sc-4opay-6 jLeeWm"
                                 onBlur={[Function]}
                                 onChange={[Function]}
                                 onFocus={[Function]}

--- a/src/Stack/__snapshots__/Stack.stories.storyshot
+++ b/src/Stack/__snapshots__/Stack.stories.storyshot
@@ -883,7 +883,7 @@ exports[`Storyshots Stack Components preview 1`] = `
               className="Stack__StyledStack-sc-1t576ow-0 jOHKrp"
             >
               <div
-                className="InputStepper__StyledInputStepper-sc-1kqzp6i-1 dpErlr"
+                className="InputStepper__StyledInputStepper-sc-1kqzp6i-1 fNaGqE"
               >
                 <label
                   className="InputField__Field-sc-4opay-0 kCAFyx"
@@ -923,7 +923,7 @@ exports[`Storyshots Stack Components preview 1`] = `
                       </div>
                     </div>
                     <input
-                      className="InputField__Input-sc-4opay-6 iDeTJU"
+                      className="InputField__Input-sc-4opay-6 jLeeWm"
                       onChange={[Function]}
                       onKeyDown={[Function]}
                       size="normal"
@@ -974,7 +974,7 @@ exports[`Storyshots Stack Components preview 1`] = `
                   className="InputField__InputContainer-sc-4opay-2 ksKWcl"
                 >
                   <input
-                    className="InputField__Input-sc-4opay-6 iDeTJU"
+                    className="InputField__Input-sc-4opay-6 jLeeWm"
                     size="normal"
                     type="text"
                   />
@@ -988,7 +988,7 @@ exports[`Storyshots Stack Components preview 1`] = `
               className="Stack__StyledStack-sc-1t576ow-0 hxYZYN"
             >
               <div
-                className="InputStepper__StyledInputStepper-sc-1kqzp6i-1 dpErlr"
+                className="InputStepper__StyledInputStepper-sc-1kqzp6i-1 fNaGqE"
               >
                 <label
                   className="InputField__Field-sc-4opay-0 kCAFyx"
@@ -1028,7 +1028,7 @@ exports[`Storyshots Stack Components preview 1`] = `
                       </div>
                     </div>
                     <input
-                      className="InputField__Input-sc-4opay-6 iDeTJU"
+                      className="InputField__Input-sc-4opay-6 jLeeWm"
                       onChange={[Function]}
                       onKeyDown={[Function]}
                       size="normal"
@@ -1079,7 +1079,7 @@ exports[`Storyshots Stack Components preview 1`] = `
                   className="InputField__InputContainer-sc-4opay-2 ksKWcl"
                 >
                   <input
-                    className="InputField__Input-sc-4opay-6 iDeTJU"
+                    className="InputField__Input-sc-4opay-6 jLeeWm"
                     size="normal"
                     type="text"
                   />
@@ -1106,7 +1106,7 @@ exports[`Storyshots Stack Components preview 1`] = `
                   className="InputField__InputContainer-sc-4opay-2 ksKWcl"
                 >
                   <input
-                    className="InputField__Input-sc-4opay-6 iDeTJU"
+                    className="InputField__Input-sc-4opay-6 jLeeWm"
                     size="normal"
                     type="text"
                   />
@@ -1187,7 +1187,7 @@ exports[`Storyshots Stack Components preview 1`] = `
                         className="InputField__InputContainer-sc-4opay-2 ksKWcl"
                       >
                         <input
-                          className="InputField__Input-sc-4opay-6 iDeTJU"
+                          className="InputField__Input-sc-4opay-6 jLeeWm"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onFocus={[Function]}
@@ -1272,7 +1272,7 @@ exports[`Storyshots Stack Components preview 1`] = `
                   className="InputField__InputContainer-sc-4opay-2 ksKWcl"
                 >
                   <input
-                    className="InputField__Input-sc-4opay-6 iDeTJU"
+                    className="InputField__Input-sc-4opay-6 jLeeWm"
                     size="normal"
                     type="text"
                   />
@@ -1353,7 +1353,7 @@ exports[`Storyshots Stack Components preview 1`] = `
                         className="InputField__InputContainer-sc-4opay-2 ksKWcl"
                       >
                         <input
-                          className="InputField__Input-sc-4opay-6 iDeTJU"
+                          className="InputField__Input-sc-4opay-6 jLeeWm"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onFocus={[Function]}
@@ -29505,7 +29505,7 @@ exports[`Storyshots Stack Desktop properties 1`] = `
                 className="InputField__InputContainer-sc-4opay-2 ksKWcl"
               >
                 <input
-                  className="InputField__Input-sc-4opay-6 iDeTJU"
+                  className="InputField__Input-sc-4opay-6 jLeeWm"
                   size="normal"
                   type="password"
                 />
@@ -30814,7 +30814,7 @@ exports[`Storyshots Stack Nested example 1`] = `
                   className="InputField__InputContainer-sc-4opay-2 bnDMxw"
                 >
                   <input
-                    className="InputField__Input-sc-4opay-6 iDeTJU"
+                    className="InputField__Input-sc-4opay-6 jLeeWm"
                     size="normal"
                     type="password"
                   />
@@ -31946,7 +31946,7 @@ exports[`Storyshots Stack Playground 1`] = `
                 className="InputField__InputContainer-sc-4opay-2 ksKWcl"
               >
                 <input
-                  className="InputField__Input-sc-4opay-6 iDeTJU"
+                  className="InputField__Input-sc-4opay-6 jLeeWm"
                   size="normal"
                   type="password"
                 />
@@ -32851,7 +32851,7 @@ exports[`Storyshots Stack RTL 1`] = `
                   className="InputField__InputContainer-sc-4opay-2 bnDMxw"
                 >
                   <input
-                    className="InputField__Input-sc-4opay-6 iDeTJU"
+                    className="InputField__Input-sc-4opay-6 jLeeWm"
                     size="normal"
                     type="password"
                   />

--- a/src/Stack/__tests__/__snapshots__/index.test.js.snap
+++ b/src/Stack/__tests__/__snapshots__/index.test.js.snap
@@ -126,6 +126,12 @@ exports[`Default Stack should match snapshot 1`] = `
   z-index: 2;
 }
 
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
 .c4:focus {
   outline: none;
 }
@@ -6670,7 +6676,7 @@ exports[`Default Stack should match snapshot 1`] = `
                                     [Function],
                                     ";border-radius:",
                                     [Function],
-                                    ";z-index:2;&:focus{outline:none;& ~ ",
+                                    ";z-index:2;&::-webkit-inner-spin-button,&::-webkit-outer-spin-button{-webkit-appearance:none;margin:0;}&:focus{outline:none;& ~ ",
                                     ".c5",
                                     "{box-shadow:inset 0 0 0 ",
                                     [Function],
@@ -13681,6 +13687,12 @@ exports[`Stack with enabled flex should match snapshot 1`] = `
   z-index: 2;
 }
 
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
 .c4:focus {
   outline: none;
 }
@@ -20327,7 +20339,7 @@ exports[`Stack with enabled flex should match snapshot 1`] = `
                                       [Function],
                                       ";border-radius:",
                                       [Function],
-                                      ";z-index:2;&:focus{outline:none;& ~ ",
+                                      ";z-index:2;&::-webkit-inner-spin-button,&::-webkit-outer-spin-button{-webkit-appearance:none;margin:0;}&:focus{outline:none;& ~ ",
                                       ".c5",
                                       "{box-shadow:inset 0 0 0 ",
                                       [Function],
@@ -27335,6 +27347,12 @@ exports[`Stack with flex prop should match snapshot 1`] = `
   z-index: 2;
 }
 
+.c4::-webkit-inner-spin-button,
+.c4::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
 .c4:focus {
   outline: none;
 }
@@ -33872,7 +33890,7 @@ exports[`Stack with flex prop should match snapshot 1`] = `
                                     [Function],
                                     ";border-radius:",
                                     [Function],
-                                    ";z-index:2;&:focus{outline:none;& ~ ",
+                                    ";z-index:2;&::-webkit-inner-spin-button,&::-webkit-outer-spin-button{-webkit-appearance:none;margin:0;}&:focus{outline:none;& ~ ",
                                     ".c5",
                                     "{box-shadow:inset 0 0 0 ",
                                     [Function],


### PR DESCRIPTION
Updated docs for usage `ButtonLink` in the `suffix` prop.
Removed webkit spin buttons from `InputField`. The selector was only in the `InputStepper` - removed.
<br/><br/><br/><url>LiveURL: https://orbit-components-fix-inputfield-number-webkit-spin.surge.sh</url>