### PR TITLE
FIX: Storybook IE 11

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -5,6 +5,22 @@
 // IMPORTANT
 // When you add this file, we won't add the default configurations which is similar
 // to "React Create App". This only has babel loader to load JavaScript.
+const babelOptions = {
+  presets: [
+    "@babel/react",
+    "@babel/flow",
+    ["@babel/env", { modules: false, targets: { browsers: ["last 2 versions", "ie >= 11", "Edge >= 38"] } }],
+  ],
+  plugins: [
+    "@babel/plugin-proposal-class-properties",
+    "@babel/plugin-proposal-object-rest-spread",
+    "@babel/plugin-proposal-nullish-coalescing-operator",
+    "@babel/plugin-proposal-optional-chaining",
+    "babel-plugin-styled-components"
+  ],
+  babelrc: false,
+};
+
 module.exports = {
   resolve: {
     extensions: [".js", ".json"],
@@ -12,8 +28,11 @@ module.exports = {
   module: {
     rules: [{
       test: /\.js?$/,
-      use: "babel-loader",
-      exclude: /node_modules/,
+      use: [{
+        options: babelOptions,
+        loader: "babel-loader"
+      }],
+      exclude: /node_modules\/(?!(loki)\/).*/, // Loki is not transpilled, throws error in IE 11
     }]
   },
   optimization: {


### PR DESCRIPTION
Fixed storybook rendering in IE 11 caused by not transpiled `loki` module<br/><br/><br/><url>LiveURL: https://orbit-components-fix-storybook-ie-11.surge.sh</url>