### PR TITLE
DOCS: Add styled-components to installation guide

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -27,6 +27,8 @@ npm install @kiwicom/orbit-components
 yarn add @kiwicom/orbit-components
 ```
 
+Don't forget to install the [styled-components](https://github.com/styled-components/styled-components/) `^4.0.0` also.
+
 ## Usage
 1. Import fonts that are used in orbit-components:
 


### PR DESCRIPTION
Added `styled-components` to the installation guide for clarity.<br/><br/><br/><url>LiveURL: https://orbit-components-docs-readme-styled-components.surge.sh</url>