### PR TITLE
FIX: Modal docs default size

### DIFF
--- a/src/Modal/README.md
+++ b/src/Modal/README.md
@@ -25,7 +25,7 @@ Table below contains all types of the props available in the Modal component.
 | children      | `React.Node`            |                 | The content of the Modal. [See Subcomponents](#sub-components)
 | dataTest      | `string`                |                 | Optional prop for testing purposes.
 | fixedFooter   | `boolean`               | `false`         | If `true` the ModalFooter will be fixed to the bottom of window.
-| size          | [`enum`](#modal-enum)    | `"medium"`      | The maximum width of the Modal on desktop viewport.
+| size          | [`enum`](#modal-enum)   | `"normal"`      | The maximum width of the Modal on desktop viewport.
 | onClose       | `func \| Promise<any>`  |                 | Function for handling onClose event. If you don't pass any function the Close button will not be displayed and it will not be possible to close the Modal. [See Functional specs](#functional-specs)
 
 ### Modal enum


### PR DESCRIPTION
Fixed wrong default value for prop `size`.<br/><br/><br/><url>LiveURL: https://orbit-components-fix-modal-docs-size.surge.sh</url>