### PR TITLE
UPDATE: ChoiceGroup Heading spaceAfter

### DIFF
--- a/src/ChoiceGroup/__snapshots__/ChoiceGroup.stories.storyshot
+++ b/src/ChoiceGroup/__snapshots__/ChoiceGroup.stories.storyshot
@@ -123,7 +123,7 @@ exports[`Storyshots ChoiceGroup Default 1`] = `
                 className="ChoiceGroup__StyledChoiceGroup-njp29m-0 bcXxKO"
               >
                 <h4
-                  className="Heading__StyledHeading-sc-1b8cso5-0 cyTyQi"
+                  className="Heading__StyledHeading-sc-1b8cso5-0 leAbYN"
                 >
                   What was the reason for your cancellation?
                 </h4>
@@ -751,7 +751,7 @@ exports[`Storyshots ChoiceGroup Multiple 1`] = `
                 className="ChoiceGroup__StyledChoiceGroup-njp29m-0 bcXxKO"
               >
                 <h4
-                  className="Heading__StyledHeading-sc-1b8cso5-0 cyTyQi"
+                  className="Heading__StyledHeading-sc-1b8cso5-0 leAbYN"
                 >
                   What was the reason for your cancellation?
                 </h4>
@@ -1392,7 +1392,7 @@ exports[`Storyshots ChoiceGroup Playground 1`] = `
                 data-test="test"
               >
                 <h4
-                  className="Heading__StyledHeading-sc-1b8cso5-0 cyTyQi"
+                  className="Heading__StyledHeading-sc-1b8cso5-0 leAbYN"
                 >
                   What was the reason for your cancellation?
                 </h4>

--- a/src/ChoiceGroup/__tests__/__snapshots__/index.test.js.snap
+++ b/src/ChoiceGroup/__tests__/__snapshots__/index.test.js.snap
@@ -6,7 +6,7 @@ exports[`RadioGroup should match snapshot 1`] = `
 >
   <Heading
     element="h5"
-    spaceAfter="small"
+    spaceAfter="medium"
     type="title2"
   >
     Label

--- a/src/ChoiceGroup/index.js
+++ b/src/ChoiceGroup/index.js
@@ -40,7 +40,7 @@ class ChoiceGroup extends React.PureComponent<Props> {
     return (
       <StyledChoiceGroup data-test={dataTest}>
         {label && (
-          <Heading type={getHeadingSize(labelSize)} element={labelElement} spaceAfter="small">
+          <Heading type={getHeadingSize(labelSize)} element={labelElement} spaceAfter="medium">
             {label}
           </Heading>
         )}

--- a/src/Stack/__snapshots__/Stack.stories.storyshot
+++ b/src/Stack/__snapshots__/Stack.stories.storyshot
@@ -794,7 +794,7 @@ exports[`Storyshots Stack Components preview 1`] = `
                     className="ChoiceGroup__StyledChoiceGroup-njp29m-0 bcXxKO"
                   >
                     <h4
-                      className="Heading__StyledHeading-sc-1b8cso5-0 cyTyQi"
+                      className="Heading__StyledHeading-sc-1b8cso5-0 leAbYN"
                     >
                       What was the reason for your cancellation?
                     </h4>
@@ -909,7 +909,7 @@ exports[`Storyshots Stack Components preview 1`] = `
                     className="ChoiceGroup__StyledChoiceGroup-njp29m-0 bcXxKO"
                   >
                     <h4
-                      className="Heading__StyledHeading-sc-1b8cso5-0 cyTyQi"
+                      className="Heading__StyledHeading-sc-1b8cso5-0 leAbYN"
                     >
                       What was the reason for your cancellation?
                     </h4>


### PR DESCRIPTION
Changed `spaceAfter` of `Heading` to `medium`.<br/><br/><br/><url>LiveURL: https://orbit-components-update-choicegroup-heading-spaceafter.surge.sh</url>