### PR TITLE
FIX: ModalFooter string as children

### DIFF
--- a/src/Modal/ModalFooter/index.js
+++ b/src/Modal/ModalFooter/index.js
@@ -83,14 +83,16 @@ class ModalFooter extends React.PureComponent<Props> {
     const { flex = "0 1 auto", children, dataTest } = this.props;
     return (
       <StyledModalFooter data-test={dataTest}>
-        {React.Children.map(children, (item, key) => {
-          if (item) {
-            const childFlex =
-              Array.isArray(flex) && flex.length !== 1 ? flex[key] || flex[0] : flex;
-            return <StyledChild flex={childFlex}>{<item.type {...item.props} />}</StyledChild>;
-          }
-          return null;
-        })}
+        {typeof children === "object"
+          ? React.Children.map(children, (item, key) => {
+              if (item) {
+                const childFlex =
+                  Array.isArray(flex) && flex.length !== 1 ? flex[key] || flex[0] : flex;
+                return <StyledChild flex={childFlex}>{<item.type {...item.props} />}</StyledChild>;
+              }
+              return null;
+            })
+          : children}
       </StyledModalFooter>
     );
   }

--- a/src/Modal/__tests__/index.test.js
+++ b/src/Modal/__tests__/index.test.js
@@ -104,9 +104,7 @@ describe("Modal with ModalSection", () => {
           </Div>
         </Div>
       </Div>
-      <ModalFooter>
-        <Button block>Continue to Payment</Button>
-      </ModalFooter>
+      <ModalFooter>It should render if needed</ModalFooter>
     </Modal>,
   );
   it("should match snapshot", () => {


### PR DESCRIPTION
Added possibility to use a string inside ModalFooter.<br/><br/><br/><url>LiveURL: https://orbit-components-update-modalfooter-string.surge.sh</url>