### PR TITLE
DOCS: Better typing for call backs

### DIFF
--- a/src/Alert/README.md
+++ b/src/Alert/README.md
@@ -16,7 +16,7 @@ Table below contains all types of the props available in Alert component.
 | closable      | `boolean`                       | `false`         | If `true`, the Close icon will be displayed. [See Functional specs](#functional-specs)
 | dataTest      | `string`                        |                 | Optional prop for testing purposes.
 | icon          | `React.Element<any> \| boolean` |                 | The displayed icon. [See Functional specs](#functional-specs)
-| onClose       | `func`                          |                 | Function for handling Alert onClose.
+| onClose       | `() => void`                    |                 | Function for handling Alert onClose.
 | spaceAfter    | `enum`                          |                 | Additional `margin-bottom` after component. [See this docs](https://github.com/kiwicom/orbit-components/tree/master/src/common/getSpacingToken)
 | title         | `Translation`                   |                 | The title of the Alert.
 | **type**      | [`enum`](#enum)                 | `"info"`        | The type of Alert.

--- a/src/Breadcrumbs/README.md
+++ b/src/Breadcrumbs/README.md
@@ -43,4 +43,4 @@ Table below contains all types of the props available in BreadcrumbsItem compone
 | dataTest      | `string`                                |                 | Optional prop for testing purposes.
 | **children**  | `string`                                |                 | The content of the BreadcrumbsItem.
 | **href**      | `string`                                |                 | The URL to link when the BreadcrumbsItem is clicked..
-| onClick       | `func`                                  |                 | Function for handling the onClick event.
+| onClick       | `event => void \| Promise`              |                 | Function for handling the onClick event.

--- a/src/Button/README.md
+++ b/src/Button/README.md
@@ -10,26 +10,26 @@ After adding import into your project you can use it simply like:
 ## Props
 Table below contains all types of the props available in Button component.
 
-| Name          | Type                  | Default         | Description                      |
-| :------------ | :---------------------| :-------------- | :------------------------------- |
-| block         | `boolean`             | `false`         | If `true`, the Button will grow up to the full width of its container.
-| bordered      | `boolean`             | `false`         | If `true`, the Button will have a lighter version, with border and light background.
-| circled       | `boolean`             | `false`         | If `true`, the Button will have circular shape.
-| children      | `React.Node`          |                 | The content of the Button. [See Functional specs](#functional-specs)
-| **component** | `string \| React.Node`| `"button"`      | The component used for the root node. Either a string to use a DOM element or a component.
-| dataTest      | `string`              |                 | Optional prop for testing purposes.
-| disabled      | `boolean`             | `false`         | If `true`, the Button will be disabled.
-| external      | `boolean`             | `false`         | If `true`, the Button opens link in a new tab. [See Functional specs](#functional-specs)
-| href          | `string`              |                 | The URL of the link to open when Button is clicked. [See Functional specs](#functional-specs)
-| icon          | `React.Node`          |                 | The displayed icon (will be removed in the future, use iconLeft instead).
-| iconLeft      | `React.Node`          |                 | The displayed icon on the left.
-| iconRight     | `React.Node`          |                 | The displayed icon on the right.
-| loading       | `boolean`             | `false`         | If `true`, the loading glyph will be displayed.
-| onClick       | `func`                |                 | Function for handling onClick event.
-| **size**      | [`enum`](#enum)       | `"normal"`      | The size of the Button.
-| submit        | `boolean`             | `false`         | If `true`, the Button will have `type="submit"` attribute, otherwise `type="button"`.
-| **type**      | [`enum`](#enum)       | `"primary"`     | The type of Button.
-| width         | `number`              | `0`             | The width of the Button. Number is defined in `px`.
+| Name          | Type                              | Default         | Description                      |
+| :------------ | :-------------------------------- | :-------------- | :------------------------------- |
+| block         | `boolean`                         | `false`         | If `true`, the Button will grow up to the full width of its container.
+| bordered      | `boolean`                         | `false`         | If `true`, the Button will have a lighter version, with border and light background.
+| circled       | `boolean`                         | `false`         | If `true`, the Button will have circular shape.
+| children      | `React.Node`                      |                 | The content of the Button. [See Functional specs](#functional-specs)
+| **component** | `string \| React.Node`            | `"button"`      | The component used for the root node. Either a string to use a DOM element or a component.
+| dataTest      | `string`                          |                 | Optional prop for testing purposes.
+| disabled      | `boolean`                         | `false`         | If `true`, the Button will be disabled.
+| external      | `boolean`                         | `false`         | If `true`, the Button opens link in a new tab. [See Functional specs](#functional-specs)
+| href          | `string`                          |                 | The URL of the link to open when Button is clicked. [See Functional specs](#functional-specs)
+| icon          | `React.Node`                      |                 | The displayed icon (will be removed in the future, use iconLeft instead).
+| iconLeft      | `React.Node`                      |                 | The displayed icon on the left.
+| iconRight     | `React.Node`                      |                 | The displayed icon on the right.
+| loading       | `boolean`                         | `false`         | If `true`, the loading glyph will be displayed.
+| onClick       | `event => void \| Promise`        |                 | Function for handling onClick event.
+| **size**      | [`enum`](#enum)                   | `"normal"`      | The size of the Button.
+| submit        | `boolean`                         | `false`         | If `true`, the Button will have `type="submit"` attribute, otherwise `type="button"`.
+| **type**      | [`enum`](#enum)                   | `"primary"`     | The type of Button.
+| width         | `number`                          | `0`             | The width of the Button. Number is defined in `px`.
 
 ### enum
 

--- a/src/ButtonLink/README.md
+++ b/src/ButtonLink/README.md
@@ -10,25 +10,25 @@ After adding import into your project you can use it simply like:
 ## Props
 Table below contains all types of the props available in ButtonLink component.
 
-| Name          | Type                  | Default         | Description                      |
-| :------------ | :---------------------| :-------------- | :------------------------------- |
-| block         | `boolean`             | `false`         | If `true`, the ButtonLink will grow up to the full width of its container.
-| circled       | `boolean`             | `false`         | If `true`, the ButtonLink will have circular shape.
-| children      | `React.Node`          |                 | The content of the ButtonLink. [See Functional specs](#functional-specs)
-| **component** | `string \| React.Node`| `"button"`      | The component used for the root node. Either a string to use a DOM element or a component.
-| disabled      | `boolean`             | `false`         | If `true`, the ButtonLink will be disabled.
-| dataTest      | `string`              |                 | Optional prop for testing purposes.
-| external      | `boolean`             | `false`         | If `true`, the ButtonLink opens link in a new tab. [See Functional specs](#functional-specs)
-| href          | `string`              |                 | The URL of link to open when ButtonLink is clicked. [See Functional specs](#functional-specs)
-| icon          | `React.Node`          |                 | The displayed icon on the left (will be removed in the future, use iconLeft instead).
-| iconLeft      | `React.Node`          |                 | The displayed icon on the left.
-| iconRight     | `React.Node`          |                 | The displayed icon on the right.
-| onClick       | `func`                |                 | Function for handling onClick event.
-| **size**      | [`enum`](#enum)       | `"normal"`      | The size of the ButtonLink.
-| submit        | `boolean`             | `false`         | If `true`, the Button will have `type="submit"` attribute, otherwise `type="button"`.
-| transparent   | `boolean`             | `false`         | If `true`, the ButtonLink will not have `:hover` and `:active` state.
-| **type**      | [`enum`](#enum)       | `"primary"`     | The type of ButtonLink.
-| width         | `number`              | `0`             | The width of the ButtonLink. Number is defined in `px`.
+| Name          | Type                            | Default         | Description                      |
+| :------------ | :------------------------------ | :-------------- | :------------------------------- |
+| block         | `boolean`                       | `false`         | If `true`, the ButtonLink will grow up to the full width of its container.
+| circled       | `boolean`                       | `false`         | If `true`, the ButtonLink will have circular shape.
+| children      | `React.Node`                    |                 | The content of the ButtonLink. [See Functional specs](#functional-specs)
+| **component** | `string \| React.Node`          | `"button"`      | The component used for the root node. Either a string to use a DOM element or a component.
+| disabled      | `boolean`                       | `false`         | If `true`, the ButtonLink will be disabled.
+| dataTest      | `string`                        |                 | Optional prop for testing purposes.
+| external      | `boolean`                       | `false`         | If `true`, the ButtonLink opens link in a new tab. [See Functional specs](#functional-specs)
+| href          | `string`                        |                 | The URL of link to open when ButtonLink is clicked. [See Functional specs](#functional-specs)
+| icon          | `React.Node`                    |                 | The displayed icon on the left (will be removed in the future, use iconLeft instead).
+| iconLeft      | `React.Node`                    |                 | The displayed icon on the left.
+| iconRight     | `React.Node`                    |                 | The displayed icon on the right.
+| onClick       | `event => void \| Promise`      |                 | Function for handling onClick event.
+| **size**      | [`enum`](#enum)                 | `"normal"`      | The size of the ButtonLink.
+| submit        | `boolean`                       | `false`         | If `true`, the Button will have `type="submit"` attribute, otherwise `type="button"`.
+| transparent   | `boolean`                       | `false`         | If `true`, the ButtonLink will not have `:hover` and `:active` state.
+| **type**      | [`enum`](#enum)                 | `"primary"`     | The type of ButtonLink.
+| width         | `number`                        | `0`             | The width of the ButtonLink. Number is defined in `px`.
 
 ### enum
 

--- a/src/Card/CardSection/CardSectionContent/index.js.flow
+++ b/src/Card/CardSection/CardSectionContent/index.js.flow
@@ -6,11 +6,11 @@ export type Props = {|
   expanded?: boolean,
   expandable?: boolean,
   visible?: boolean,
-|}
+|};
 
 export type State = {|
   contentHeight: number,
-|}
+|};
 
 declare export var StyledCardSectionContent: ReactComponentStyled<any>;
 

--- a/src/Card/CardSection/CardSectionHeader/index.js.flow
+++ b/src/Card/CardSection/CardSectionHeader/index.js.flow
@@ -4,7 +4,7 @@ import type { ReactComponentStyled } from "styled-components";
 export type Props = {|
   children: React$Node,
   actions?: React$Node,
-|}
+|};
 
 declare export var StyledCardSectionHeader: ReactComponentStyled<any>;
 

--- a/src/Card/README.md
+++ b/src/Card/README.md
@@ -15,13 +15,13 @@ After adding import into your project you can use it simply like:
 ## Props
 Table below contains all types of the props available in the Card component.
 
-| Name          | Type                  | Default         | Description                      |
-| :------------ | :---------------------| :-------------- | :------------------------------- |
-| children      | `React.Node`          |                 | The content of the Card. [See Subcomponents](#sub-components)
-| closable      | `boolean`             | `false`         | If `true`, the Close icon will be displayed. [See Functional specs](#functional-specs)
-| dataTest      | `string`              |                 | Optional prop for testing purposes.
-| onClose       | `func`                |                 | Function for handling onClick event.
-| spaceAfter    | `enum`                |                 | Additional `margin-bottom` after component. [See this docs](https://github.com/kiwicom/orbit-components/tree/master/src/common/getSpacingToken)
+| Name          | Type                          | Default         | Description                      |
+| :------------ | :---------------------------- | :-------------- | :------------------------------- |
+| children      | `React.Node`                  |                 | The content of the Card. [See Subcomponents](#sub-components)
+| closable      | `boolean`                     | `false`         | If `true`, the Close icon will be displayed. [See Functional specs](#functional-specs)
+| dataTest      | `string`                      |                 | Optional prop for testing purposes.
+| onClose       | `event => void \| Promise`    |                 | Function for handling onClick event.
+| spaceAfter    | `enum`                        |                 | Additional `margin-bottom` after component. [See this docs](https://github.com/kiwicom/orbit-components/tree/master/src/common/getSpacingToken)
 
 ## Functional specs
 * By passing the `closable` prop into Card, you will be able to handle `onClose` function and Close icon will be displayed. Also, if you want to select the Close Button element for testing purposes, use [data-test="CardCloseButton"] selector.
@@ -75,8 +75,8 @@ Table below contains all types of the props in CardSection component.
 | **children**    | `React.Node`          |                 | The content of the CardSection.
 | expandable      | `boolean`             |                 | CardSection could be expandable
 | initialExpanded | `boolean`             |                 | CardSection is expanded by default
-| onClose         | `func`                |                 | Callback after close
-| onExpand        | `func`                |                 | Callback after expand
+| onClose         | `() => void`          |                 | Callback after close
+| onExpand        | `() => void`          |                 | Callback after expand
 | dataTest        | `string`              |                 | Optional prop for testing purposes.
 
 

--- a/src/Checkbox/README.md
+++ b/src/Checkbox/README.md
@@ -10,18 +10,18 @@ After adding import into your project you can use it simply like:
 ## Props
 Table below contains all types of the props available in Checkbox component.
 
-| Name         | Type         | Default | Description                      |
-| :-------     | :----------- | :------ | :------------------------------- |
-| checked      | `boolean`    | `false` | If `true`, the Checkbox will be checked.
-| disabled     | `boolean`    | `false` | If `true`, the Checkbox will be set up as disabled.
-| dataTest     | `string`     |         | Optional prop for testing purposes.
-| hasError     | `boolean`    | `false` | If `true`, the border of the Checkbox will turn red. [See Functional specs](#functional-specs)
-| info         | `React.Node` |         | The additional info about the Checkbox.
-| label        | `string`     |         | The label of the Checkbox.
-| name         | `string`     |         | The name for the Checkbox.
-| onChange     | `func`       |         | Function for handling onChange event.
-| ref          | `func`       |         | Prop for forwarded ref of the Checkbox. [See Functional specs](#functional-specs)
-| value        | `string`     |         | The value of the Checkbox.
+| Name         | Type                         | Default | Description                      |
+| :-------     | :--------------------------- | :------ | :------------------------------- |
+| checked      | `boolean`                    | `false` | If `true`, the Checkbox will be checked.
+| disabled     | `boolean`                    | `false` | If `true`, the Checkbox will be set up as disabled.
+| dataTest     | `string`                     |         | Optional prop for testing purposes.
+| hasError     | `boolean`                    | `false` | If `true`, the border of the Checkbox will turn red. [See Functional specs](#functional-specs)
+| info         | `React.Node`                 |         | The additional info about the Checkbox.
+| label        | `string`                     |         | The label of the Checkbox.
+| name         | `string`                     |         | The name for the Checkbox.
+| onChange     | `event => void \| Promise`   |         | Function for handling onChange event.
+| ref          | `func`                       |         | Prop for forwarded ref of the Checkbox. [See Functional specs](#functional-specs)
+| value        | `string`                     |         | The value of the Checkbox.
 
 ## Functional specs
 * The `hasError` prop will be visible only when the Checkbox has `checked` or `disabled` prop set on **false**.

--- a/src/ChoiceGroup/README.md
+++ b/src/ChoiceGroup/README.md
@@ -23,7 +23,7 @@ Table below contains all types of the props available in the ChoiceGroup compone
 | label               | `Translation`              |             | Heading text of `<ChoiceGroup />`
 | labelSize           | [`enum`](#enum)            | `"normal"`  | The size type of Heading.
 | labelElement        | [`enum`](#enum)            | `"h4"`      | The element used to render the label into.
-| **onChange**        | `func`                     |             | Function for handling onChange event. [See Functional specs](#functional-specs)
+| **onChange**        | `event => void \| Promise` |             | Function for handling onChange event. [See Functional specs](#functional-specs)
   
 ### enum
 | labelElement  | labelSize   |

--- a/src/InputField/README.md
+++ b/src/InputField/README.md
@@ -10,33 +10,33 @@ After adding import into your project you can use it simply like:
 ## Props
 Table below contains all types of the props available in InputField component.
 
-| Name          | Type              | Default      | Description                      |
-| :------------ | :---------------- | :----------- | :------------------------------- |
-| disabled      | `boolean`         |              | If `true`, the InputField will be disabled.
-| dataTest      | `string`          |              | Optional prop for testing purposes.
-| error         | `React.Node`      |              | The error to display beneath the InputField. [See Functional specs](#functional-specs)
-| help          | `React.Node`      |              | The help to display beneath the InputField.
-| label         | `Translation`     |              | The label for the InputField. [See Functional specs](#functional-specs)
-| inlineLabel   | `boolean`         |              | If true the label renders on the left side of input
-| maxLength     | `number`          |              | Specifies the maximum number of characters allowed.
-| maxValue      | `number`          |              | Specifies the maximum value for the InputField.
-| minLength     | `number`          |              | Specifies the minimum number of characters allowed.
-| minValue      | `number`          |              | Specifies the minimum value for the InputField.
-| required      | `boolean`         |              | If true, the label is displayed as required.
-| name          | `string`          |              | The name for the InputField.
-| onBlur        | `func`            |              | Function for handling onBlur event.
-| onChange      | `func`            |              | Function for handling onChange event.
-| onFocus       | `func`            |              | Function for handling onFocus event.
-| onKeyDown     | `func`            |              | Function for handling onKeyDown event.
-| onKeyUp       | `func`            |              | Function for handling onKeyUp event.
-| placeholder   | `Translation`     |              | The placeholder of the InputField.
-| **prefix**    | `React.Node`      |              | The prefix component for the InputField. 
-| readOnly      | `boolean`         | `"false"`    | If `true`, the InputField be readOnly.
-| ref           | `func`            |              | Prop for forwarded ref of the InputField. [See Functional specs](#functional-specs)
-| **size**      | [`enum`](#enum)   | `"normal"`   | The size of the InputField.
-| suffix        | `React.Node`      |              | The suffix component for the InputField. [See Functional specs](#functional-specs)
-| **type**      | [`enum`](#enum)   | `"text"`     | The type of the InputField.
-| value         | `string`          |              | Specifies the value of the InputField.
+| Name          | Type                          | Default      | Description                      |
+| :------------ | :---------------------------- | :----------- | :------------------------------- |
+| disabled      | `boolean`                     |              | If `true`, the InputField will be disabled.
+| dataTest      | `string`                      |              | Optional prop for testing purposes.
+| error         | `React.Node`                  |              | The error to display beneath the InputField. [See Functional specs](#functional-specs)
+| help          | `React.Node`                  |              | The help to display beneath the InputField.
+| label         | `Translation`                 |              | The label for the InputField. [See Functional specs](#functional-specs)
+| inlineLabel   | `boolean`                     |              | If true the label renders on the left side of input
+| maxLength     | `number`                      |              | Specifies the maximum number of characters allowed.
+| maxValue      | `number`                      |              | Specifies the maximum value for the InputField.
+| minLength     | `number`                      |              | Specifies the minimum number of characters allowed.
+| minValue      | `number`                      |              | Specifies the minimum value for the InputField.
+| required      | `boolean`                     |              | If true, the label is displayed as required.
+| name          | `string`                      |              | The name for the InputField.
+| onBlur        | `event => void \| Promise`    |              | Function for handling onBlur event.
+| onChange      | `event => void \| Promise`    |              | Function for handling onChange event.
+| onFocus       | `event => void \| Promise`    |              | Function for handling onFocus event.
+| onKeyDown     | `event => void \| Promise`    |              | Function for handling onKeyDown event.
+| onKeyUp       | `event => void \| Promise`    |              | Function for handling onKeyUp event.
+| placeholder   | `Translation`                 |              | The placeholder of the InputField.
+| **prefix**    | `React.Node`                  |              | The prefix component for the InputField. 
+| readOnly      | `boolean`                     | `"false"`    | If `true`, the InputField be readOnly.
+| ref           | `func`                        |              | Prop for forwarded ref of the InputField. [See Functional specs](#functional-specs)
+| **size**      | [`enum`](#enum)               | `"normal"`   | The size of the InputField.
+| suffix        | `React.Node`                  |              | The suffix component for the InputField. [See Functional specs](#functional-specs)
+| **type**      | [`enum`](#enum)               | `"text"`     | The type of the InputField.
+| value         | `string`                      |              | Specifies the value of the InputField.
 
 ### enum
 

--- a/src/InputFile/README.md
+++ b/src/InputFile/README.md
@@ -10,22 +10,22 @@ After adding import into your project you can use it simply like:
 ## Props
 Table below contains all types of the props available in the InputFile component.
 
-| Name                | Type                  | Default              | Description                      |
-| :------------------ | :-------------------- | :------------------- | :------------------------------- |
-| allowedFileTypes    | `string` | `string[]` |                      | You can specify allow file types. [See W3S](#functional-specs)
-| dataTest            | `string`              |                      | Optional prop for testing purposes.
-| error               | `React.Node`          |                      | The error message for the Select. [See Functional specs](#functional-specs)
-| fileName            | `string`              |                      | The name of selected file.
-| help                | `React.Node`          |                      | The help message for the InputFile.
-| label               | `Translation`         |                      | The label for the InputFile.
-| name                | `string`              |                      | The name for the InputFile.
-| onBlur              | `func`                |                      | Function for handling onBlur event.
-| onChange            | `func`                |                      | Function for handling onChange event.
-| onFocus             | `func`                |                      | Function for handling onFocus event.
-| onRemoveFile        | `func`                |                      | Function for handling file name removing.
-| placeholder         | `Translation`         | `"No file selected"` | The placeholder for the InputFile. [See Functional specs](#functional-specs)
-| ref                 | `func`                |                      | Prop for forwarded ref of the InputFile. [See Functional specs](#functional-specs)
-| title               | `Translation`         | `"Select file"`      | The title for the InputFile. [See Functional specs](#functional-specs)
+| Name                | Type                        | Default              | Description                      |
+| :------------------ | :-------------------------- | :------------------- | :------------------------------- |
+| allowedFileTypes    | `string` | `string[]`       |                      | You can specify allow file types. [See W3S](#functional-specs)
+| dataTest            | `string`                    |                      | Optional prop for testing purposes.
+| error               | `React.Node`                |                      | The error message for the Select. [See Functional specs](#functional-specs)
+| fileName            | `string`                    |                      | The name of selected file.
+| help                | `React.Node`                |                      | The help message for the InputFile.
+| label               | `Translation`               |                      | The label for the InputFile.
+| name                | `string`                    |                      | The name for the InputFile.
+| onBlur              | `event => void \| Promise`  |                      | Function for handling onBlur event.
+| onChange            | `event => void \| Promise`  |                      | Function for handling onChange event.
+| onFocus             | `event => void \| Promise`  |                      | Function for handling onFocus event.
+| onRemoveFile        | `() => void \| Promise`     |                      | Function for handling file name removing.
+| placeholder         | `Translation`               | `"No file selected"` | The placeholder for the InputFile. [See Functional specs](#functional-specs)
+| ref                 | `func`                      |                      | Prop for forwarded ref of the InputFile. [See Functional specs](#functional-specs)
+| title               | `Translation`               | `"Select file"`      | The title for the InputFile. [See Functional specs](#functional-specs)
 
 ## Functional specs
 * The `error` prop overwrites the `help` prop, due to higher priority.

--- a/src/InputGroup/README.md
+++ b/src/InputGroup/README.md
@@ -23,9 +23,9 @@ Table below contains all types of the props available in InputGroup component.
 | flex          | `string` or `Array<string>`   | `"0 1 auto"` | The flex attribute(s) for children of the InputGroup. [See Functional specs](#functional-specs)
 | help          | `React.Node`                  |              | The help to display beneath the InputGroup.
 | label         | `Translation`                 |              | The label for the InputGroup. [See Functional specs](#functional-specs)
-| onChange      | `func`                        |              | Function for handling onClick event. [See Functional specs](#functional-specs)
-| onFocus       | `func`                        |              | Function for handling onFocus event. [See Functional specs](#functional-specs)
-| onBlur        | `func`                        |              | Function for handling onBlur event. [See Functional specs](#functional-specs)
+| onChange      | `event => void \| Promise`    |              | Function for handling onClick event. [See Functional specs](#functional-specs)
+| onFocus       | `event => void \| Promise`    |              | Function for handling onFocus event. [See Functional specs](#functional-specs)
+| onBlur        | `event => void \| Promise`    |              | Function for handling onBlur event. [See Functional specs](#functional-specs)
 | size          | [`enum`](#enum)               | `"normal"`   | The size of the InputField. [See Functional specs](#functional-specs)
 
 ### enum

--- a/src/InputStepper/README.md
+++ b/src/InputStepper/README.md
@@ -16,23 +16,23 @@ After adding import into your project you can use it simply like:
 
 Table below contains all types of the props available in InputStepper component.
 
-| Name            | Type             | Default     | Description                                        |
-| :-------------- | :--------------- | :---------- | :------------------------------------------------- |
-| defaultValue    | `number`         | `0`         | Specifies the value of the InputStepper. [See Functional specs](#functional-specs)
-| disabled        | `boolean`        | `false`     | If `true`, the InputStepper will be disabled.
-| error           | `React.Node`     |             | The error to display beneath the InputStepper. [See Functional specs](#functional-specs)
-| help            | `React.Node`     |             | The help to display beneath the InputStepper.
-| label           | `Translation`    |             | The label for the InputStepper. [See Functional specs](#functional-specs)
-| maxValue        | `number`         | `∞`         | Specifies the maximum value for the InputStepper.
-| minValue        | `number`         | `-∞`        | Specifies the minimum value for the InputStepper.
-| name            | `string`         |             | The name for the InputStepper.
-| required        | `boolean`        | `false`     | If `true`, the label is displayed as required.
-| onBlur          | `func`           |             | Function for handling onBlur event.
-| onChange        | `func`           |             | Function for handling onClick event.
-| onFocus         | `func`           |             | Function for handling onFocus event.
-| ref             | `func`           |             | Prop for forwarded ref of the InputStepper. [See Functional specs](#functional-specs)
-| size            | [`enum`](#enum)  | `"normal"`  | The size of the InputStepper.
-| step            | `number`         | `1`         | Specifies the value of step to increment and decrement.
+| Name            | Type                        | Default     | Description                                        |
+| :-------------- | :-------------------------- | :---------- | :------------------------------------------------- |
+| defaultValue    | `number`                    | `0`         | Specifies the value of the InputStepper. [See Functional specs](#functional-specs)
+| disabled        | `boolean`                   | `false`     | If `true`, the InputStepper will be disabled.
+| error           | `React.Node`                |             | The error to display beneath the InputStepper. [See Functional specs](#functional-specs)
+| help            | `React.Node`                |             | The help to display beneath the InputStepper.
+| label           | `Translation`               |             | The label for the InputStepper. [See Functional specs](#functional-specs)
+| maxValue        | `number`                    | `∞`         | Specifies the maximum value for the InputStepper.
+| minValue        | `number`                    | `-∞`        | Specifies the minimum value for the InputStepper.
+| name            | `string`                    |             | The name for the InputStepper.
+| required        | `boolean`                   | `false`     | If `true`, the label is displayed as required.
+| onBlur          | `event => void \| Promise`  |             | Function for handling onBlur event.
+| onChange        | `number => void \| Promise` |             | Function for handling onClick event.
+| onFocus         | `event => void \| Promise`  |             | Function for handling onFocus event.
+| ref             | `func`                      |             | Prop for forwarded ref of the InputStepper. [See Functional specs](#functional-specs)
+| size            | [`enum`](#enum)             | `"normal"`  | The size of the InputStepper.
+| step            | `number`                    | `1`         | Specifies the value of step to increment and decrement.
 
 ### enum
 

--- a/src/ListChoice/README.md
+++ b/src/ListChoice/README.md
@@ -10,12 +10,12 @@ After adding import into your project you can use it simply like:
 ## Props
 Table below contains all types of the props available in the ListChoice component.
 
-| Name              | Type          | Default | Description                      |
-| :---------------- | :------------ | :------ | :------------------------------- |
-| dataTest          | `string`      |         | Optional prop for testing purposes.
-| description       | `Translation` |         | The additional info about the ListChoice.
-| icon              | `React.Node`  |         | The icon on the left of the ListChoice.
-| onClick           | `func`        |         | Function for handling onClick event.
-| selectable        | `boolean`     | `false` | If `true`, the check box glyph appears on the right size and it will be possible to select the ListChoice.
-| selected          | `boolean`     | `false` | If `true`, the check box glyph will be checked.
-| **title**         | `Translation` |         | The title of the ListChoice.
+| Name              | Type                        | Default | Description                      |
+| :---------------- | :-------------------------- | :------ | :------------------------------- |
+| dataTest          | `string`                    |         | Optional prop for testing purposes.
+| description       | `Translation`               |         | The additional info about the ListChoice.
+| icon              | `React.Node`                |         | The icon on the left of the ListChoice.
+| onClick           | `event => void \| Promise`  |         | Function for handling onClick event.
+| selectable        | `boolean`                   | `false` | If `true`, the check box glyph appears on the right size and it will be possible to select the ListChoice.
+| selected          | `boolean`                   | `false` | If `true`, the check box glyph will be checked.
+| **title**         | `Translation`               |         | The title of the ListChoice.

--- a/src/Modal/README.md
+++ b/src/Modal/README.md
@@ -20,13 +20,13 @@ The Modal component has big variety of usage, please check examples for usage [b
 ## Props
 Table below contains all types of the props available in the Modal component.
 
-| Name          | Type                    | Default         | Description                      |
-| :------------ | :---------------------- | :-------------- | :------------------------------- |
-| children      | `React.Node`            |                 | The content of the Modal. [See Subcomponents](#sub-components)
-| dataTest      | `string`                |                 | Optional prop for testing purposes.
-| fixedFooter   | `boolean`               | `false`         | If `true` the ModalFooter will be fixed to the bottom of window.
-| size          | [`enum`](#modal-enum)   | `"normal"`      | The maximum width of the Modal on desktop viewport.
-| onClose       | `func \| Promise<any>`  |                 | Function for handling onClose event. If you don't pass any function the Close button will not be displayed and it will not be possible to close the Modal. [See Functional specs](#functional-specs)
+| Name          | Type                        | Default         | Description                      |
+| :------------ | :-------------------------- | :-------------- | :------------------------------- |
+| children      | `React.Node`                |                 | The content of the Modal. [See Subcomponents](#sub-components)
+| dataTest      | `string`                    |                 | Optional prop for testing purposes.
+| fixedFooter   | `boolean`                   | `false`         | If `true` the ModalFooter will be fixed to the bottom of window.
+| size          | [`enum`](#modal-enum)       | `"normal"`      | The maximum width of the Modal on desktop viewport.
+| onClose       | `event => void \| Promise`  |                 | Function for handling onClose event. If you don't pass any function the Close button will not be displayed and it will not be possible to close the Modal. [See Functional specs](#functional-specs)
 
 ### Modal enum
 

--- a/src/Radio/README.md
+++ b/src/Radio/README.md
@@ -10,18 +10,18 @@ After adding import into your project you can use it simply like:
 ## Props
 Table below contains all types of the props available in Radio component.
 
-| Name         | Type         | Default | Description                      |
-| :-------     | :----------- | :------ | :------------------------------- |
-| checked      | `boolean`    | `false` | If `true`, the Radio will be checked.
-| dataTest     | `string`     |         | Optional prop for testing purposes.
-| disabled     | `boolean`    | `false` | If `true`, the Radio will be set up as disabled.
-| hasError     | `boolean`    | `false` | If `true`, the border of the Radio will turn red. [See Functional specs](#functional-specs)
-| info         | `React.Node` |         | The additional info about the Radio.
-| label        | `string`     |         | The label of the Radio.
-| name         | `string`     |         | The name for the Radio.
-| onChange     | `func`       |         | Function for handling onChange event.
-| ref          | `func`       |         | Prop for forwarded ref of the Radio. [See Functional specs](#functional-specs)
-| value        | `string`     |         | The value of the Radio.
+| Name         | Type                       | Default | Description                      |
+| :-------     | :------------------------- | :------ | :------------------------------- |
+| checked      | `boolean`                  | `false` | If `true`, the Radio will be checked.
+| dataTest     | `string`                   |         | Optional prop for testing purposes.
+| disabled     | `boolean`                  | `false` | If `true`, the Radio will be set up as disabled.
+| hasError     | `boolean`                  | `false` | If `true`, the border of the Radio will turn red. [See Functional specs](#functional-specs)
+| info         | `React.Node`               |         | The additional info about the Radio.
+| label        | `string`                   |         | The label of the Radio.
+| name         | `string`                   |         | The name for the Radio.
+| onChange     | `event => void \| Promise` |         | Function for handling onChange event.
+| ref          | `func`                     |         | Prop for forwarded ref of the Radio. [See Functional specs](#functional-specs)
+| value        | `string`                   |         | The value of the Radio.
 
 ## Functional specs
 * The`hasError` prop will be visible only when the Radio has `checked` or `disabled` prop set on false.

--- a/src/Select/README.md
+++ b/src/Select/README.md
@@ -18,9 +18,9 @@ Table below contains all types of the props available in the Select component.
 | help        | `React.Node`                      |            | The help message for the Select.
 | label       | `Translation`                     |            | The label for the Select.
 | name        | `string`                          |            | The name for the Select.
-| onBlur      | `func`                            |            | Function for handling onBlur event.
-| onChange    | `func`                            |            | Function for handling onChange event.
-| onFocus     | `func`                            |            | Function for handling onFocus event.
+| onBlur      | `event => void \| Promise`        |            | Function for handling onBlur event.
+| onChange    | `event => void \| Promise`        |            | Function for handling onChange event.
+| onFocus     | `event => void \| Promise`        |            | Function for handling onFocus event.
 | **options** | [`Option[]`](#option)             |            | The content of the Select, passed as array of objects.
 | placeholder | `Translation`                     |            | The placeholder for the Select. 
 | prefix      | `React.Node`                      |            | The prefix component for the Select. [See Functional specs](#functional-specs)

--- a/src/Stepper/README.md
+++ b/src/Stepper/README.md
@@ -12,18 +12,18 @@ After adding import into your project you can use it simply like:
 
 Table below contains all types of the props available in Stepper component.
 
-| Name            | Type             | Default     | Description                                        |
-| :-------------- | :--------------- | :---------- | :------------------------------------------------- |
-| dataTest        | `string`         |             | Optional prop for testing purposes.
-| defaultValue    | `number`         | `0`         | Specifies the value of the Stepper. [See Functional specs](#functional-specs)
-| disabled        | `boolean`        | `false`     | If `true`, the Stepper will be disabled.
-| maxValue        | `number`         | `∞`         | Specifies the maximum value for the Stepper.
-| minValue        | `number`         | `-∞`        | Specifies the minimum value for the Stepper.
-| name            | `string`         |             | The name for the Stepper.
-| onBlur          | `func`           |             | Function for handling onBlur event.
-| onChange        | `func`           |             | Function for handling onClick event.
-| onFocus         | `func`           |             | Function for handling onFocus event.
-| step            | `number`         | `1`         | Specifies the value of step to increment and decrement.
+| Name            | Type                          | Default     | Description                                        |
+| :-------------- | :---------------------------- | :---------- | :------------------------------------------------- |
+| dataTest        | `string`                      |             | Optional prop for testing purposes.
+| defaultValue    | `number`                      | `0`         | Specifies the value of the Stepper. [See Functional specs](#functional-specs)
+| disabled        | `boolean`                     | `false`     | If `true`, the Stepper will be disabled.
+| maxValue        | `number`                      | `∞`         | Specifies the maximum value for the Stepper.
+| minValue        | `number`                      | `-∞`        | Specifies the minimum value for the Stepper.
+| name            | `string`                      |             | The name for the Stepper.
+| onBlur          | `event => void \| Promise`    |             | Function for handling onBlur event.
+| onChange        | `number => void \| Promise`   |             | Function for handling onClick event.
+| onFocus         | `event => void \| Promise`    |             | Function for handling onFocus event.
+| step            | `number`                      | `1`         | Specifies the value of step to increment and decrement.
 
 ## Functional specs
 * The prop `defaultValue` sets up the default value when component mounts. If you need to get the current value of Stepper, use arrow function for it. The second parameter `name` is optional. The code may look like this:

--- a/src/Tag/README.md
+++ b/src/Tag/README.md
@@ -10,15 +10,15 @@ After adding import into your project you can use it simply like:
 ## Props
 Table below contains all types of the props available in the Tag component.
 
-| Name          | Type                  | Default         | Description                      |
-| :------------ | :---------------------| :-------------- | :------------------------------- |
-| **children**  | `React.Node`          |                 | The content of the Tag.
-| dataTest      | `string`              |                 | Optional prop for testing purposes.
-| onClick       | `func`                |                 | Function for handling the onClick event.
-| onRemove      | `func`                |                 | Function for handling the onClick event of the close icon.  [See Functional specs](#functional-specs)
-| selected      | `boolean`             | `false`         | If `true`, the Tag will have selected styles.  [See Functional specs](#functional-specs)
-| size          | [`enum`](#enum)       | `small`         | Size of the Tag.
-| icon          | `React.Node`          |                 | The displayed icon on the left.
+| Name          | Type                      | Default         | Description                      |
+| :------------ | :------------------------ | :-------------- | :------------------------------- |
+| **children**  | `React.Node`              |                 | The content of the Tag.
+| dataTest      | `string`                  |                 | Optional prop for testing purposes.
+| onClick       | `() => void \| Promise`   |                 | Function for handling the onClick event.
+| onRemove      | `() => void  \| Promise`  |                 | Function for handling the onClick event of the close icon.  [See Functional specs](#functional-specs)
+| selected      | `boolean`                 | `false`         | If `true`, the Tag will have selected styles.  [See Functional specs](#functional-specs)
+| size          | [`enum`](#enum)           | `small`         | Size of the Tag.
+| icon          | `React.Node`              |                 | The displayed icon on the left.
 
 ### enum
 

--- a/src/TextLink/README.md
+++ b/src/TextLink/README.md
@@ -10,17 +10,17 @@ After adding import into your project you can use it simply like:
 ## Props
 Table below contains all types of the props available in TextLink component.
 
-| Name          | Type                  | Default         | Description                      |
-| :------------ | :---------------------| :-------------- | :------------------------------- |
-| children      | `React.Node`          |                 | The content of the TextLink.
-| dataTest      | `string`              |                 | Optional prop for testing purposes.
-| external      | `boolean`             | `false`         | If `true`, the TextLink opens link in a new tab.
-| href          | `string`              |                 | The URL to link when the TextLink is clicked.
-| icon          | `React.Node`          |                 | The displayed icon.
-| onClick       | `func`                |                 | Function for handling onClick event.
-| rel           | `string`              |                 | The rel of the TextLink. [See Functional specs](#functional-specs)
-| size          | [`enum`](#enum)       |                 | The size of the TextLink. [See Functional specs](#functional-specs)
-| **type**      | [`enum`](#enum)       | `"primary"`     | The color type of the TextLink.
+| Name          | Type                        | Default         | Description                      |
+| :------------ | :-------------------------- | :-------------- | :------------------------------- |
+| children      | `React.Node`                |                 | The content of the TextLink.
+| dataTest      | `string`                    |                 | Optional prop for testing purposes.
+| external      | `boolean`                   | `false`         | If `true`, the TextLink opens link in a new tab.
+| href          | `string`                    |                 | The URL to link when the TextLink is clicked.
+| icon          | `React.Node`                |                 | The displayed icon.
+| onClick       | `event => void \| Promise`  |                 | Function for handling onClick event.
+| rel           | `string`                    |                 | The rel of the TextLink. [See Functional specs](#functional-specs)
+| size          | [`enum`](#enum)             |                 | The size of the TextLink. [See Functional specs](#functional-specs)
+| **type**      | [`enum`](#enum)             | `"primary"`     | The color type of the TextLink.
 
 ### enum
 

--- a/src/Textarea/README.md
+++ b/src/Textarea/README.md
@@ -10,24 +10,24 @@ After adding import into your project you can use it simply like:
 ## Props
 Table below contains all types of the props available in Textarea component.
 
-| Name          | Type              | Default      | Description                      |
-| :------------ | :---------------- | :----------- | :------------------------------- |
-| dataTest      | `string`          |              | Optional prop for testing purposes.
-| disabled      | `boolean`         |              | If `true`, the Textarea will be disabled.
-| error         | `React.Node`      |              | The error to display beneath the Textarea. [See Functional specs](#functional-specs)
-| fullHeight    | `boolean`         | `false`      | If `true`, the Textarea will take 100 % of parent's height.
-| help          | `React.Node`      |              | The help to display beneath the Textarea.
-| label         | `Translation`     |              | The label for the Textarea. [See Functional specs](#functional-specs)
-| maxLength     | `number`          |              | Specifies the maximum number of characters allowed.
-| name          | `string`          |              | The name for the Textarea.
-| onChange      | `func`            |              | Function for handling onClick event.
-| onFocus       | `func`            |              | Function for handling onFocus event.
-| onBlur        | `func`            |              | Function for handling onBlur event.
-| placeholder   | `Translation`     |              | The placeholder of the Textarea.
-| ref           | `func`            |              | Prop for forwarded ref of the Textarea. [See Functional specs](#functional-specs)
-| resize        | [`enum`](#enum)   | `"vertical"` | The resize option for Textarea.
-| size          | [`enum`](#enum)   | `"normal"`   | The size of the Textarea.
-| value         | `string`          |              | Specifies the value of the Textarea.
+| Name          | Type                        | Default      | Description                      |
+| :------------ | :-------------------------- | :----------- | :------------------------------- |
+| dataTest      | `string`                    |              | Optional prop for testing purposes.
+| disabled      | `boolean`                   |              | If `true`, the Textarea will be disabled.
+| error         | `React.Node`                |              | The error to display beneath the Textarea. [See Functional specs](#functional-specs)
+| fullHeight    | `boolean`                   | `false`      | If `true`, the Textarea will take 100 % of parent's height.
+| help          | `React.Node`                |              | The help to display beneath the Textarea.
+| label         | `Translation`               |              | The label for the Textarea. [See Functional specs](#functional-specs)
+| maxLength     | `number`                    |              | Specifies the maximum number of characters allowed.
+| name          | `string`                    |              | The name for the Textarea.
+| onChange      | `event => void \| Promise`  |              | Function for handling onClick event.
+| onFocus       | `event => void \| Promise`  |              | Function for handling onFocus event.
+| onBlur        | `event => void \| Promise`  |              | Function for handling onBlur event.
+| placeholder   | `Translation`               |              | The placeholder of the Textarea.
+| ref           | `func`                      |              | Prop for forwarded ref of the Textarea. [See Functional specs](#functional-specs)
+| resize        | [`enum`](#enum)             | `"vertical"` | The resize option for Textarea.
+| size          | [`enum`](#enum)             | `"normal"`   | The size of the Textarea.
+| value         | `string`                    |              | Specifies the value of the Textarea.
 
 ### enum
 

--- a/src/Tile/README.md
+++ b/src/Tile/README.md
@@ -10,16 +10,16 @@ After adding import into your project you can use it simply like:
 ## Props
 Table below contains all types of the props available in Tile component.
 
-| Name          | Type                  | Default         | Description                      |
-| :------------ | :---------------------| :-------------- | :------------------------------- |
-| description   | `string`              |                 | The content of the Tile.
-| external      | `boolean`             | `false`         | If `true`, the Tile opens link in a new tab.  [See Functional specs](#functional-specs)
-| href          | `string`              |                 | The URL of the link to open when Tile is clicked. [See Functional specs](#functional-specs)
-| icon          | `React.Node`          |                 | Displayed icon on the left side of the Tile.
-| onClick       | `func`                |                 | Function for handling onClick event.
-| title         | `React.Node`          |                 | The title of the Tile.
-| children      | `React.Node`          |                 | Content of expanded tile
-| expanded      | `boolean`             |                 | Default state of expandable. [See Functional specs](#functional-specs)
+| Name          | Type                          | Default         | Description                      |
+| :------------ | :---------------------------- | :-------------- | :------------------------------- |
+| description   | `string`                      |                 | The content of the Tile.
+| external      | `boolean`                     | `false`         | If `true`, the Tile opens link in a new tab.  [See Functional specs](#functional-specs)
+| href          | `string`                      |                 | The URL of the link to open when Tile is clicked. [See Functional specs](#functional-specs)
+| icon          | `React.Node`                  |                 | Displayed icon on the left side of the Tile.
+| onClick       | `event => void \| Promise`    |                 | Function for handling onClick event.
+| title         | `React.Node`                  |                 | The title of the Tile.
+| children      | `React.Node`                  |                 | Content of expanded tile
+| expanded      | `boolean`                     |                 | Default state of expandable. [See Functional specs](#functional-specs)
 
 ## Functional specs
 * When the `external` is specified, `noopener` and `noreferrer` values will automatically added to attribute `rel` for security reason.

--- a/src/TripSegment/README.md
+++ b/src/TripSegment/README.md
@@ -35,4 +35,4 @@ Table below contains all types of the props available in TripSegment component.
 | **departureTime** | `string`                |             | The departure time.
 | **duration**      | `string \| number`      |             | The flight duration.
 | initialExpanded   | `boolean`               | `false`     | If `true`, the children will be displayed by default.
-| onClick           | `func \| Promise<any>`  |             | Function for handling onClick event.
+| onClick           | `() => void \| Promise` |             | Function for handling onClick event.


### PR DESCRIPTION
Just better typing for docs for callbacks.
<br/><br/><br/><url>LiveURL: https://orbit-components-docs-better-callbacks.surge.sh</url>