### PR TITLE
FIX: InputField suffix text overflow

### DIFF
--- a/src/InputField/InputField.stories.js
+++ b/src/InputField/InputField.stories.js
@@ -220,6 +220,35 @@ storiesOf("InputField", module)
       ],
     };
   })
+  .addWithChapters("With text suffix", () => {
+    const label = text("Label", "Label");
+    const value = text("Value", "");
+    const placeholder = text("Placeholder", "Placeholder");
+    const suffix = text("Suffix", "Some long text");
+
+    return {
+      info: "Some description about this type of InputField in general.",
+      chapters: [
+        {
+          sections: [
+            {
+              sectionFn: () => (
+                <InputField
+                  label={label}
+                  value={value}
+                  placeholder={placeholder}
+                  suffix={
+                    <div style={{ paddingRight: "12px", whiteSpace: "nowrap" }}>{suffix}</div>
+                  }
+                  onChange={action("change")}
+                />
+              ),
+            },
+          ],
+        },
+      ],
+    };
+  })
 
   .addWithChapters("Compact input", () => {
     const value = text("Value", "");

--- a/src/InputField/__snapshots__/InputField.stories.storyshot
+++ b/src/InputField/__snapshots__/InputField.stories.storyshot
@@ -123,7 +123,7 @@ exports[`Storyshots InputField Compact input 1`] = `
                 className="InputField__Field-sc-4opay-0 kCAFyx"
               >
                 <div
-                  className="InputField__InputContainer-sc-4opay-2 ksKWcl"
+                  className="InputField__InputContainer-sc-4opay-2 kccDHe"
                 >
                   <div
                     className="InputField__StyledInlineLabel-sc-4opay-3 YrOpk"
@@ -543,7 +543,7 @@ exports[`Storyshots InputField Default input 1`] = `
                   </span>
                 </span>
                 <div
-                  className="InputField__InputContainer-sc-4opay-2 ksKWcl"
+                  className="InputField__InputContainer-sc-4opay-2 kccDHe"
                 >
                   <input
                     className="InputField__Input-sc-4opay-6 ceKwqb"
@@ -882,7 +882,7 @@ exports[`Storyshots InputField Email input 1`] = `
                   </span>
                 </span>
                 <div
-                  className="InputField__InputContainer-sc-4opay-2 ksKWcl"
+                  className="InputField__InputContainer-sc-4opay-2 kccDHe"
                 >
                   <input
                     className="InputField__Input-sc-4opay-6 ceKwqb"
@@ -1295,7 +1295,7 @@ exports[`Storyshots InputField Number input 1`] = `
                   </span>
                 </span>
                 <div
-                  className="InputField__InputContainer-sc-4opay-2 ksKWcl"
+                  className="InputField__InputContainer-sc-4opay-2 kccDHe"
                 >
                   <input
                     className="InputField__Input-sc-4opay-6 ceKwqb"
@@ -1723,7 +1723,7 @@ exports[`Storyshots InputField Passport or ID Input 1`] = `
                   </span>
                 </span>
                 <div
-                  className="InputField__InputContainer-sc-4opay-2 ksKWcl"
+                  className="InputField__InputContainer-sc-4opay-2 kccDHe"
                 >
                   <input
                     className="InputField__Input-sc-4opay-6 lcdLxL"
@@ -2061,7 +2061,7 @@ exports[`Storyshots InputField Password input 1`] = `
                   </span>
                 </span>
                 <div
-                  className="InputField__InputContainer-sc-4opay-2 ksKWcl"
+                  className="InputField__InputContainer-sc-4opay-2 kccDHe"
                 >
                   <input
                     className="InputField__Input-sc-4opay-6 ceKwqb"
@@ -2430,7 +2430,7 @@ exports[`Storyshots InputField Playground 1`] = `
                   </span>
                 </span>
                 <div
-                  className="InputField__InputContainer-sc-4opay-2 kXcsVj"
+                  className="InputField__InputContainer-sc-4opay-2 kisjWq"
                 >
                   <div
                     className="InputField__Prefix-sc-4opay-4 cnqfau"
@@ -2459,7 +2459,7 @@ exports[`Storyshots InputField Playground 1`] = `
                     value=""
                   />
                   <div
-                    className="InputField__Suffix-sc-4opay-5 cOwOrH"
+                    className="InputField__Suffix-sc-4opay-5 egyXVI"
                   >
                     <button
                       className="ButtonLink__StyledButtonLink-sc-14jv5cl-1 ilpdWM"
@@ -3339,7 +3339,7 @@ exports[`Storyshots InputField RTL 1`] = `
                   </span>
                 </span>
                 <div
-                  className="InputField__InputContainer-sc-4opay-2 ksKWcl"
+                  className="InputField__InputContainer-sc-4opay-2 kccDHe"
                 >
                   <div
                     className="InputField__Prefix-sc-4opay-4 gBJmTs"
@@ -3352,7 +3352,7 @@ exports[`Storyshots InputField RTL 1`] = `
                     type="text"
                   />
                   <div
-                    className="InputField__Suffix-sc-4opay-5 gxwjvO"
+                    className="InputField__Suffix-sc-4opay-5 exEPdy"
                   >
                     <button
                       className="ButtonLink__StyledButtonLink-sc-14jv5cl-1 deBnZa"
@@ -3760,7 +3760,7 @@ exports[`Storyshots InputField Required field 1`] = `
                   </span>
                 </span>
                 <div
-                  className="InputField__InputContainer-sc-4opay-2 ksKWcl"
+                  className="InputField__InputContainer-sc-4opay-2 kccDHe"
                 >
                   <input
                     className="InputField__Input-sc-4opay-6 ceKwqb"
@@ -4110,7 +4110,7 @@ exports[`Storyshots InputField Small input 1`] = `
                   </span>
                 </span>
                 <div
-                  className="InputField__InputContainer-sc-4opay-2 kXcsVj"
+                  className="InputField__InputContainer-sc-4opay-2 kisjWq"
                 >
                   <input
                     className="InputField__Input-sc-4opay-6 ceKwqb"
@@ -4479,7 +4479,7 @@ exports[`Storyshots InputField With ButtonLink suffix 1`] = `
                   </span>
                 </span>
                 <div
-                  className="InputField__InputContainer-sc-4opay-2 ksKWcl"
+                  className="InputField__InputContainer-sc-4opay-2 kccDHe"
                 >
                   <input
                     className="InputField__Input-sc-4opay-6 ceKwqb"
@@ -4489,7 +4489,7 @@ exports[`Storyshots InputField With ButtonLink suffix 1`] = `
                     value=""
                   />
                   <div
-                    className="InputField__Suffix-sc-4opay-5 kCvrXk"
+                    className="InputField__Suffix-sc-4opay-5 kANGZa"
                   >
                     <button
                       className="ButtonLink__StyledButtonLink-sc-14jv5cl-1 mwSQA"
@@ -4871,7 +4871,7 @@ exports[`Storyshots InputField With Icon prefix 1`] = `
                   </span>
                 </span>
                 <div
-                  className="InputField__InputContainer-sc-4opay-2 ksKWcl"
+                  className="InputField__InputContainer-sc-4opay-2 kccDHe"
                 >
                   <div
                     className="InputField__Prefix-sc-4opay-4 iNucwo"
@@ -5252,7 +5252,7 @@ exports[`Storyshots InputField With ServiceLogo prefix 1`] = `
                   </span>
                 </span>
                 <div
-                  className="InputField__InputContainer-sc-4opay-2 ksKWcl"
+                  className="InputField__InputContainer-sc-4opay-2 kccDHe"
                 >
                   <input
                     className="InputField__Input-sc-4opay-6 ceKwqb"
@@ -5262,7 +5262,7 @@ exports[`Storyshots InputField With ServiceLogo prefix 1`] = `
                     value=""
                   />
                   <div
-                    className="InputField__Suffix-sc-4opay-5 kCvrXk"
+                    className="InputField__Suffix-sc-4opay-5 kANGZa"
                   >
                     <img
                       alt="AirHelp"
@@ -5630,7 +5630,7 @@ exports[`Storyshots InputField With text prefix 1`] = `
                   </span>
                 </span>
                 <div
-                  className="InputField__InputContainer-sc-4opay-2 ksKWcl"
+                  className="InputField__InputContainer-sc-4opay-2 kccDHe"
                 >
                   <div
                     className="InputField__Prefix-sc-4opay-4 iNucwo"
@@ -5818,6 +5818,388 @@ exports[`Storyshots InputField With text prefix 1`] = `
                                 $
                               </span>
                               "
+                            </span>
+                          </span>
+                        </span>
+                        <span>
+                          <span>
+                            <br />
+                              
+                          </span>
+                          <span
+                            style={Object {}}
+                          >
+                            onChange
+                          </span>
+                          <span>
+                            =
+                            <span
+                              style={Object {}}
+                            >
+                              {
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#170",
+                                  }
+                                }
+                              >
+                                change
+                              </span>
+                              }
+                            </span>
+                          </span>
+                          <br />
+                        </span>
+                      </span>
+                      <span
+                        style={
+                          Object {
+                            "color": "#444",
+                          }
+                        }
+                      >
+                        /&gt;
+                      </span>
+                    </div>
+                  </pre>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots InputField With text suffix 1`] = `
+<div
+  style={
+    Object {
+      "padding": "20px",
+    }
+  }
+>
+  <div
+    className="story"
+    style={
+      Object {
+        "WebkitFontSmoothing": "antialiased",
+        "color": "#444",
+        "fontFamily": "-apple-system, \\".SFNSText-Regular\\", \\"San Francisco\\", BlinkMacSystemFont, \\"Segoe UI\\", \\"Roboto\\", \\"Oxygen\\", \\"Ubuntu\\", \\"Cantarell\\", \\"Fira Sans\\", \\"Droid Sans\\", \\"Helvetica Neue\\", \\"Lucida Grande\\", \\"Arial\\", sans-serif",
+      }
+    }
+  >
+    <div
+      className="story-header"
+      style={
+        Object {
+          "color": "#565d6b",
+          "fontSize": 14,
+          "lineHeight": 1.5,
+        }
+      }
+    >
+      <div>
+        <h1
+          className="story-title"
+          style={
+            Object {
+              "color": "#363a45",
+              "fontSize": 36,
+              "marginBottom": 10,
+            }
+          }
+        >
+          With text suffix
+        </h1>
+        
+        <span
+          className="story-subtitle"
+          style={
+            Object {
+              "color": "#898d97",
+              "fontSize": 18,
+              "marginBottom": 20,
+              "marginTop": 0,
+            }
+          }
+        >
+          <div>
+            <div
+              style={
+                Object {
+                  "WebkitFontSmoothing": "antialiased",
+                  "color": "#444",
+                  "fontFamily": "-apple-system, \\".SFNSText-Regular\\", \\"San Francisco\\", BlinkMacSystemFont, \\"Segoe UI\\", \\"Roboto\\", \\"Oxygen\\", \\"Ubuntu\\", \\"Cantarell\\", \\"Fira Sans\\", \\"Droid Sans\\", \\"Helvetica Neue\\", \\"Lucida Grande\\", \\"Arial\\", sans-serif",
+                  "fontSize": "15px",
+                }
+              }
+            >
+              Some description about this type of InputField in general.
+            </div>
+          </div>
+        </span>
+      </div>
+    </div>
+    <div
+      className="story-chapters"
+    >
+      <div
+        className="chapter"
+      >
+        <div
+          className="chapter-header"
+          style={
+            Object {
+              "marginBottom": 60,
+            }
+          }
+        >
+          <div>
+            
+            
+            
+            
+          </div>
+        </div>
+        <div
+          className="chapter-sections"
+        >
+          <div
+            className="section-container"
+            style={
+              Object {
+                "marginBottom": 100,
+              }
+            }
+          >
+            <div
+              className="section-header"
+              style={Object {}}
+            >
+              <div>
+                
+                
+              </div>
+            </div>
+            <div
+              className="section-component-container"
+              style={
+                Object {
+                  "marginBottom": 60,
+                }
+              }
+            >
+              <label
+                className="InputField__Field-sc-4opay-0 kCAFyx"
+              >
+                <span
+                  className="FormLabel-sc-1927civ-1 iTEGJS"
+                >
+                  <span>
+                    Label
+                  </span>
+                </span>
+                <div
+                  className="InputField__InputContainer-sc-4opay-2 kccDHe"
+                >
+                  <input
+                    className="InputField__Input-sc-4opay-6 ceKwqb"
+                    onChange={[Function]}
+                    placeholder="Placeholder"
+                    type="text"
+                    value=""
+                  />
+                  <div
+                    className="InputField__Suffix-sc-4opay-5 kANGZa"
+                  >
+                    <div
+                      style={
+                        Object {
+                          "paddingRight": "12px",
+                          "whiteSpace": "nowrap",
+                        }
+                      }
+                    >
+                      Some long text
+                    </div>
+                  </div>
+                  <div
+                    className="InputField__FakeInput-sc-4opay-1 ipxhgc"
+                  />
+                </div>
+              </label>
+            </div>
+            <div
+              className="section-additional"
+              style={Object {}}
+            >
+              <div>
+                
+                <div
+                  className="section-subsection"
+                  style={
+                    Object {
+                      "marginBottom": 60,
+                    }
+                  }
+                >
+                  <h4
+                    className="section-subsection-title"
+                  >
+                    Source
+                  </h4>
+                  <pre
+                    className="section-pre"
+                    style={
+                      Object {
+                        "backgroundColor": "rgb(250, 250, 250)",
+                        "fontFamily": "Menlo, Monaco, \\"Courier New\\", monospace",
+                        "fontSize": ".88em",
+                        "lineHeight": "1.5",
+                        "overflowX": "scroll",
+                        "padding": "0.5rem",
+                      }
+                    }
+                  >
+                    <div
+                      style={
+                        Object {
+                          "paddingLeft": 18,
+                          "paddingRight": 3,
+                        }
+                      }
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#444",
+                          }
+                        }
+                      >
+                        &lt;
+                        InputField
+                      </span>
+                      <span>
+                        <span>
+                          <span>
+                            <br />
+                              
+                          </span>
+                          <span
+                            style={Object {}}
+                          >
+                            label
+                          </span>
+                          <span>
+                            =
+                            <span
+                              style={Object {}}
+                            >
+                              "
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#22a",
+                                    "wordBreak": "break-word",
+                                  }
+                                }
+                              >
+                                Label
+                              </span>
+                              "
+                            </span>
+                          </span>
+                        </span>
+                        <span>
+                          <span>
+                            <br />
+                              
+                          </span>
+                          <span
+                            style={Object {}}
+                          >
+                            value
+                          </span>
+                          <span>
+                            =
+                            <span
+                              style={Object {}}
+                            >
+                              "
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#22a",
+                                    "wordBreak": "break-word",
+                                  }
+                                }
+                              >
+                                
+                              </span>
+                              "
+                            </span>
+                          </span>
+                        </span>
+                        <span>
+                          <span>
+                            <br />
+                              
+                          </span>
+                          <span
+                            style={Object {}}
+                          >
+                            placeholder
+                          </span>
+                          <span>
+                            =
+                            <span
+                              style={Object {}}
+                            >
+                              "
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#22a",
+                                    "wordBreak": "break-word",
+                                  }
+                                }
+                              >
+                                Placeholder
+                              </span>
+                              "
+                            </span>
+                          </span>
+                        </span>
+                        <span>
+                          <span>
+                            <br />
+                              
+                          </span>
+                          <span
+                            style={Object {}}
+                          >
+                            suffix
+                          </span>
+                          <span>
+                            =
+                            <span
+                              style={Object {}}
+                            >
+                              {
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#666",
+                                  }
+                                }
+                              >
+                                &lt;div /&gt;
+                              </span>
+                              }
                             </span>
                           </span>
                         </span>

--- a/src/InputField/index.js
+++ b/src/InputField/index.js
@@ -94,7 +94,6 @@ export const InputContainer = styled(({ children, className }) => (
   align-items: center;
   justify-content: space-between;
   box-sizing: border-box;
-  width: 100%;
   height: ${getToken(TOKENS.heightInput)};
   border-radius: ${({ theme }) => theme.orbit.borderRadiusNormal};
   color: ${({ disabled, theme }) =>
@@ -161,7 +160,7 @@ Prefix.defaultProps = {
 
 const Suffix = styled(({ children, className }) => <div className={className}>{children}</div>)`
   height: ${getToken(TOKENS.heightInput)};
-  color: ${({ theme }) => theme.orbit.colorIconInput};
+  color: ${({ theme }) => theme.orbit.colorTextInputPrefix};
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/InputGroup/__snapshots__/InputGroup.stories.storyshot
+++ b/src/InputGroup/__snapshots__/InputGroup.stories.storyshot
@@ -139,7 +139,7 @@ exports[`Storyshots InputGroup Date of birth 1`] = `
                       className="InputField__Field-sc-4opay-0 kCAFyx"
                     >
                       <div
-                        className="InputField__InputContainer-sc-4opay-2 ksKWcl"
+                        className="InputField__InputContainer-sc-4opay-2 kccDHe"
                       >
                         <input
                           className="InputField__Input-sc-4opay-6 ceKwqb"
@@ -262,7 +262,7 @@ exports[`Storyshots InputGroup Date of birth 1`] = `
                       className="InputField__Field-sc-4opay-0 kCAFyx"
                     >
                       <div
-                        className="InputField__InputContainer-sc-4opay-2 ksKWcl"
+                        className="InputField__InputContainer-sc-4opay-2 kccDHe"
                       >
                         <input
                           className="InputField__Input-sc-4opay-6 ceKwqb"
@@ -1239,7 +1239,7 @@ exports[`Storyshots InputGroup Phone number 1`] = `
                       className="InputField__Field-sc-4opay-0 kCAFyx"
                     >
                       <div
-                        className="InputField__InputContainer-sc-4opay-2 ksKWcl"
+                        className="InputField__InputContainer-sc-4opay-2 kccDHe"
                       >
                         <input
                           className="InputField__Input-sc-4opay-6 ceKwqb"
@@ -2082,7 +2082,7 @@ exports[`Storyshots InputGroup Playground 1`] = `
                       className="InputField__Field-sc-4opay-0 kCAFyx"
                     >
                       <div
-                        className="InputField__InputContainer-sc-4opay-2 ksKWcl"
+                        className="InputField__InputContainer-sc-4opay-2 kccDHe"
                       >
                         <input
                           className="InputField__Input-sc-4opay-6 ceKwqb"
@@ -2149,7 +2149,7 @@ exports[`Storyshots InputGroup Playground 1`] = `
                       className="InputField__Field-sc-4opay-0 kCAFyx"
                     >
                       <div
-                        className="InputField__InputContainer-sc-4opay-2 ksKWcl"
+                        className="InputField__InputContainer-sc-4opay-2 kccDHe"
                       >
                         <input
                           className="InputField__Input-sc-4opay-6 ceKwqb"
@@ -3300,7 +3300,7 @@ exports[`Storyshots InputGroup RTL 1`] = `
                       className="InputField__Field-sc-4opay-0 kCAFyx"
                     >
                       <div
-                        className="InputField__InputContainer-sc-4opay-2 ksKWcl"
+                        className="InputField__InputContainer-sc-4opay-2 kccDHe"
                       >
                         <input
                           className="InputField__Input-sc-4opay-6 ceKwqb"
@@ -3423,7 +3423,7 @@ exports[`Storyshots InputGroup RTL 1`] = `
                       className="InputField__Field-sc-4opay-0 kCAFyx"
                     >
                       <div
-                        className="InputField__InputContainer-sc-4opay-2 ksKWcl"
+                        className="InputField__InputContainer-sc-4opay-2 kccDHe"
                       >
                         <input
                           className="InputField__Input-sc-4opay-6 ceKwqb"

--- a/src/InputStepper/__snapshots__/InputStepper.stories.storyshot
+++ b/src/InputStepper/__snapshots__/InputStepper.stories.storyshot
@@ -126,7 +126,7 @@ exports[`Storyshots InputStepper Default 1`] = `
                   className="InputField__Field-sc-4opay-0 kCAFyx"
                 >
                   <div
-                    className="InputField__InputContainer-sc-4opay-2 ksKWcl"
+                    className="InputField__InputContainer-sc-4opay-2 kccDHe"
                   >
                     <div
                       className="InputField__Prefix-sc-4opay-4 iNucwo"
@@ -160,7 +160,7 @@ exports[`Storyshots InputStepper Default 1`] = `
                       value={0}
                     />
                     <div
-                      className="InputField__Suffix-sc-4opay-5 kCvrXk"
+                      className="InputField__Suffix-sc-4opay-5 kANGZa"
                     >
                       <div
                         className="ButtonLink__StyledButtonLink-sc-14jv5cl-1 mwSQA InputStepper__PrefixSuffix-sc-1kqzp6i-0 gTLEXo"
@@ -424,7 +424,7 @@ exports[`Storyshots InputStepper Playground 1`] = `
                     </span>
                   </span>
                   <div
-                    className="InputField__InputContainer-sc-4opay-2 bnDMxw"
+                    className="InputField__InputContainer-sc-4opay-2 bitzWY"
                   >
                     <div
                       className="InputField__Prefix-sc-4opay-4 iNucwo"
@@ -465,7 +465,7 @@ exports[`Storyshots InputStepper Playground 1`] = `
                       value={4}
                     />
                     <div
-                      className="InputField__Suffix-sc-4opay-5 kCvrXk"
+                      className="InputField__Suffix-sc-4opay-5 kANGZa"
                     >
                       <div
                         className="ButtonLink__StyledButtonLink-sc-14jv5cl-1 mwSQA InputStepper__PrefixSuffix-sc-1kqzp6i-0 gTLEXo"
@@ -1148,7 +1148,7 @@ exports[`Storyshots InputStepper RTL 1`] = `
                     </span>
                   </span>
                   <div
-                    className="InputField__InputContainer-sc-4opay-2 ksKWcl"
+                    className="InputField__InputContainer-sc-4opay-2 kccDHe"
                   >
                     <div
                       className="InputField__Prefix-sc-4opay-4 gBJmTs"
@@ -1182,7 +1182,7 @@ exports[`Storyshots InputStepper RTL 1`] = `
                       value={0}
                     />
                     <div
-                      className="InputField__Suffix-sc-4opay-5 gxwjvO"
+                      className="InputField__Suffix-sc-4opay-5 exEPdy"
                     >
                       <div
                         className="ButtonLink__StyledButtonLink-sc-14jv5cl-1 mwSQA InputStepper__PrefixSuffix-sc-1kqzp6i-0 gTLEXo"
@@ -1498,7 +1498,7 @@ exports[`Storyshots InputStepper With different size 1`] = `
                     </span>
                   </span>
                   <div
-                    className="InputField__InputContainer-sc-4opay-2 ksKWcl"
+                    className="InputField__InputContainer-sc-4opay-2 kccDHe"
                   >
                     <div
                       className="InputField__Prefix-sc-4opay-4 iNucwo"
@@ -1534,7 +1534,7 @@ exports[`Storyshots InputStepper With different size 1`] = `
                       value={0}
                     />
                     <div
-                      className="InputField__Suffix-sc-4opay-5 kCvrXk"
+                      className="InputField__Suffix-sc-4opay-5 kANGZa"
                     >
                       <div
                         className="ButtonLink__StyledButtonLink-sc-14jv5cl-1 mwSQA InputStepper__PrefixSuffix-sc-1kqzp6i-0 gTLEXo"
@@ -1919,7 +1919,7 @@ exports[`Storyshots InputStepper With help 1`] = `
                     </span>
                   </span>
                   <div
-                    className="InputField__InputContainer-sc-4opay-2 ksKWcl"
+                    className="InputField__InputContainer-sc-4opay-2 kccDHe"
                   >
                     <div
                       className="InputField__Prefix-sc-4opay-4 iNucwo"
@@ -1955,7 +1955,7 @@ exports[`Storyshots InputStepper With help 1`] = `
                       value={0}
                     />
                     <div
-                      className="InputField__Suffix-sc-4opay-5 kCvrXk"
+                      className="InputField__Suffix-sc-4opay-5 kANGZa"
                     >
                       <div
                         className="ButtonLink__StyledButtonLink-sc-14jv5cl-1 mwSQA InputStepper__PrefixSuffix-sc-1kqzp6i-0 gTLEXo"

--- a/src/InputStepper/__tests__/__snapshots__/index.test.js.snap
+++ b/src/InputStepper/__tests__/__snapshots__/index.test.js.snap
@@ -212,7 +212,6 @@ exports[`InputStepper with help, prefix and suffix should match snapshot 1`] = `
   -ms-flex-pack: justify;
   justify-content: space-between;
   box-sizing: border-box;
-  width: 100%;
   height: 44px;
   border-radius: 3px;
   color: #46515e;
@@ -252,7 +251,7 @@ exports[`InputStepper with help, prefix and suffix should match snapshot 1`] = `
 
 .c12 {
   height: 44px;
-  color: #bac7d5;
+  color: #7f91a8;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -4133,7 +4132,7 @@ exports[`InputStepper with help, prefix and suffix should match snapshot 1`] = `
                             "isStatic": false,
                             "lastClassName": "c3",
                             "rules": Array [
-                              "display:flex;position:relative;flex-direction:row;align-items:center;justify-content:space-between;box-sizing:border-box;width:100%;height:",
+                              "display:flex;position:relative;flex-direction:row;align-items:center;justify-content:space-between;box-sizing:border-box;height:",
                               [Function],
                               ";border-radius:",
                               [Function],

--- a/src/Modal/__snapshots__/Modal.stories.storyshot
+++ b/src/Modal/__snapshots__/Modal.stories.storyshot
@@ -6753,7 +6753,7 @@ exports[`Storyshots Modal With Form 1`] = `
                             </span>
                           </span>
                           <div
-                            className="InputField__InputContainer-sc-4opay-2 ksKWcl"
+                            className="InputField__InputContainer-sc-4opay-2 kccDHe"
                           >
                             <input
                               className="InputField__Input-sc-4opay-6 ceKwqb"
@@ -6840,7 +6840,7 @@ exports[`Storyshots Modal With Form 1`] = `
                                 className="InputField__Field-sc-4opay-0 kCAFyx"
                               >
                                 <div
-                                  className="InputField__InputContainer-sc-4opay-2 ksKWcl"
+                                  className="InputField__InputContainer-sc-4opay-2 kccDHe"
                                 >
                                   <input
                                     className="InputField__Input-sc-4opay-6 ceKwqb"

--- a/src/Stack/__snapshots__/Stack.stories.storyshot
+++ b/src/Stack/__snapshots__/Stack.stories.storyshot
@@ -1152,7 +1152,7 @@ exports[`Storyshots Stack Components preview 1`] = `
                         </span>
                       </span>
                       <div
-                        className="InputField__InputContainer-sc-4opay-2 ksKWcl"
+                        className="InputField__InputContainer-sc-4opay-2 kccDHe"
                       >
                         <div
                           className="InputField__Prefix-sc-4opay-4 iNucwo"
@@ -1186,7 +1186,7 @@ exports[`Storyshots Stack Components preview 1`] = `
                           value={0}
                         />
                         <div
-                          className="InputField__Suffix-sc-4opay-5 kCvrXk"
+                          className="InputField__Suffix-sc-4opay-5 kANGZa"
                         >
                           <div
                             className="ButtonLink__StyledButtonLink-sc-14jv5cl-1 mwSQA InputStepper__PrefixSuffix-sc-1kqzp6i-0 gTLEXo"
@@ -1226,7 +1226,7 @@ exports[`Storyshots Stack Components preview 1`] = `
                       </span>
                     </span>
                     <div
-                      className="InputField__InputContainer-sc-4opay-2 ksKWcl"
+                      className="InputField__InputContainer-sc-4opay-2 kccDHe"
                     >
                       <input
                         className="InputField__Input-sc-4opay-6 ceKwqb"
@@ -1255,7 +1255,7 @@ exports[`Storyshots Stack Components preview 1`] = `
                         </span>
                       </span>
                       <div
-                        className="InputField__InputContainer-sc-4opay-2 ksKWcl"
+                        className="InputField__InputContainer-sc-4opay-2 kccDHe"
                       >
                         <div
                           className="InputField__Prefix-sc-4opay-4 iNucwo"
@@ -1289,7 +1289,7 @@ exports[`Storyshots Stack Components preview 1`] = `
                           value={0}
                         />
                         <div
-                          className="InputField__Suffix-sc-4opay-5 kCvrXk"
+                          className="InputField__Suffix-sc-4opay-5 kANGZa"
                         >
                           <div
                             className="ButtonLink__StyledButtonLink-sc-14jv5cl-1 mwSQA InputStepper__PrefixSuffix-sc-1kqzp6i-0 gTLEXo"
@@ -1329,7 +1329,7 @@ exports[`Storyshots Stack Components preview 1`] = `
                       </span>
                     </span>
                     <div
-                      className="InputField__InputContainer-sc-4opay-2 ksKWcl"
+                      className="InputField__InputContainer-sc-4opay-2 kccDHe"
                     >
                       <input
                         className="InputField__Input-sc-4opay-6 ceKwqb"
@@ -1355,7 +1355,7 @@ exports[`Storyshots Stack Components preview 1`] = `
                       </span>
                     </span>
                     <div
-                      className="InputField__InputContainer-sc-4opay-2 ksKWcl"
+                      className="InputField__InputContainer-sc-4opay-2 kccDHe"
                     >
                       <input
                         className="InputField__Input-sc-4opay-6 ceKwqb"
@@ -1435,7 +1435,7 @@ exports[`Storyshots Stack Components preview 1`] = `
                           className="InputField__Field-sc-4opay-0 kCAFyx"
                         >
                           <div
-                            className="InputField__InputContainer-sc-4opay-2 ksKWcl"
+                            className="InputField__InputContainer-sc-4opay-2 kccDHe"
                           >
                             <input
                               className="InputField__Input-sc-4opay-6 ceKwqb"
@@ -1519,7 +1519,7 @@ exports[`Storyshots Stack Components preview 1`] = `
                       </span>
                     </span>
                     <div
-                      className="InputField__InputContainer-sc-4opay-2 ksKWcl"
+                      className="InputField__InputContainer-sc-4opay-2 kccDHe"
                     >
                       <input
                         className="InputField__Input-sc-4opay-6 ceKwqb"
@@ -1599,7 +1599,7 @@ exports[`Storyshots Stack Components preview 1`] = `
                           className="InputField__Field-sc-4opay-0 kCAFyx"
                         >
                           <div
-                            className="InputField__InputContainer-sc-4opay-2 ksKWcl"
+                            className="InputField__InputContainer-sc-4opay-2 kccDHe"
                           >
                             <input
                               className="InputField__Input-sc-4opay-6 ceKwqb"
@@ -30708,7 +30708,7 @@ exports[`Storyshots Stack Desktop properties 1`] = `
                     </span>
                   </span>
                   <div
-                    className="InputField__InputContainer-sc-4opay-2 ksKWcl"
+                    className="InputField__InputContainer-sc-4opay-2 kccDHe"
                   >
                     <input
                       className="InputField__Input-sc-4opay-6 ceKwqb"
@@ -32040,7 +32040,7 @@ exports[`Storyshots Stack Nested example 1`] = `
                       </span>
                     </span>
                     <div
-                      className="InputField__InputContainer-sc-4opay-2 bnDMxw"
+                      className="InputField__InputContainer-sc-4opay-2 bitzWY"
                     >
                       <input
                         className="InputField__Input-sc-4opay-6 ceKwqb"
@@ -33183,7 +33183,7 @@ exports[`Storyshots Stack Playground 1`] = `
                     </span>
                   </span>
                   <div
-                    className="InputField__InputContainer-sc-4opay-2 ksKWcl"
+                    className="InputField__InputContainer-sc-4opay-2 kccDHe"
                   >
                     <input
                       className="InputField__Input-sc-4opay-6 ceKwqb"
@@ -34099,7 +34099,7 @@ exports[`Storyshots Stack RTL 1`] = `
                       </span>
                     </span>
                     <div
-                      className="InputField__InputContainer-sc-4opay-2 bnDMxw"
+                      className="InputField__InputContainer-sc-4opay-2 bitzWY"
                     >
                       <input
                         className="InputField__Input-sc-4opay-6 ceKwqb"

--- a/src/Stack/__tests__/__snapshots__/index.test.js.snap
+++ b/src/Stack/__tests__/__snapshots__/index.test.js.snap
@@ -92,7 +92,6 @@ exports[`Default Stack should match snapshot 1`] = `
   -ms-flex-pack: justify;
   justify-content: space-between;
   box-sizing: border-box;
-  width: 100%;
   height: 44px;
   border-radius: 3px;
   color: #46515e;
@@ -5681,7 +5680,7 @@ exports[`Default Stack should match snapshot 1`] = `
                           "isStatic": false,
                           "lastClassName": "c3",
                           "rules": Array [
-                            "display:flex;position:relative;flex-direction:row;align-items:center;justify-content:space-between;box-sizing:border-box;width:100%;height:",
+                            "display:flex;position:relative;flex-direction:row;align-items:center;justify-content:space-between;box-sizing:border-box;height:",
                             [Function],
                             ";border-radius:",
                             [Function],
@@ -15772,7 +15771,6 @@ exports[`Stack with enabled flex should match snapshot 1`] = `
   -ms-flex-pack: justify;
   justify-content: space-between;
   box-sizing: border-box;
-  width: 100%;
   height: 44px;
   border-radius: 3px;
   color: #46515e;
@@ -21463,7 +21461,7 @@ exports[`Stack with enabled flex should match snapshot 1`] = `
                             "isStatic": false,
                             "lastClassName": "c3",
                             "rules": Array [
-                              "display:flex;position:relative;flex-direction:row;align-items:center;justify-content:space-between;box-sizing:border-box;width:100%;height:",
+                              "display:flex;position:relative;flex-direction:row;align-items:center;justify-content:space-between;box-sizing:border-box;height:",
                               [Function],
                               ";border-radius:",
                               [Function],
@@ -31551,7 +31549,6 @@ exports[`Stack with flex prop should match snapshot 1`] = `
   -ms-flex-pack: justify;
   justify-content: space-between;
   box-sizing: border-box;
-  width: 100%;
   height: 44px;
   border-radius: 3px;
   color: #46515e;
@@ -37133,7 +37130,7 @@ exports[`Stack with flex prop should match snapshot 1`] = `
                           "isStatic": false,
                           "lastClassName": "c3",
                           "rules": Array [
-                            "display:flex;position:relative;flex-direction:row;align-items:center;justify-content:space-between;box-sizing:border-box;width:100%;height:",
+                            "display:flex;position:relative;flex-direction:row;align-items:center;justify-content:space-between;box-sizing:border-box;height:",
                             [Function],
                             ";border-radius:",
                             [Function],


### PR DESCRIPTION
Just deleted the attribute `width` directly on the `<input />`.

Tested in Chrome, Firefox, IE 10 - there should not be any visual breaking change of usage in Stack, because the attribute `width` is needed on the first element - in our case `<label />`.

<img width="780" src="https://user-images.githubusercontent.com/7254437/52119354-1b907280-2619-11e9-87f8-5aef321a5376.png">
 

Closes #756 <br/><br/><br/><url>LiveURL: https://orbit-components-fix-inputfield-suffix.surge.sh</url>