### PR TITLE
FIX: Modal IE and iOS Safari flickering

### DIFF
--- a/src/Modal/ModalFooter/index.js
+++ b/src/Modal/ModalFooter/index.js
@@ -28,7 +28,7 @@ StyledChild.defaultProps = {
 
 export const StyledModalFooter = styled.div`
   display: flex;
-  z-index: 10;
+  z-index: 800; // TODO: use z-index framework
   bottom: 0;
   width: 100%;
   background-color: ${({ theme }) => theme.orbit.paletteWhite};

--- a/src/Modal/ModalHeader/index.js
+++ b/src/Modal/ModalHeader/index.js
@@ -123,8 +123,8 @@ export const MobileHeader = styled.div`
   z-index: 10;
 
   ${media.largeMobile(css`
-    left: unset;
-    right: unset;
+    left: auto;
+    right: auto;
     padding: 0;
   `)};
 `;

--- a/src/Modal/__snapshots__/Modal.stories.storyshot
+++ b/src/Modal/__snapshots__/Modal.stories.storyshot
@@ -120,7 +120,7 @@ exports[`Storyshots Modal Full preview 1`] = `
               }
             >
               <div
-                className="Modal__ModalBody-sc-1f0srsl-0 dqeWDj"
+                className="Modal__ModalBody-sc-1f0srsl-0 cFHwNN"
                 data-test="test"
                 onClick={[Function]}
                 onKeyDown={[Function]}
@@ -128,12 +128,12 @@ exports[`Storyshots Modal Full preview 1`] = `
                 tabIndex="0"
               >
                 <div
-                  className="Modal__ModalWrapper-sc-1f0srsl-1 cFckeH"
+                  className="Modal__ModalWrapper-sc-1f0srsl-1 cRKVsK"
                   onScroll={[Function]}
                   size="normal"
                 >
                   <div
-                    className="Modal__ModalWrapperContent-sc-1f0srsl-3 jnycQk"
+                    className="Modal__ModalWrapperContent-sc-1f0srsl-3 dIMKcS"
                     size="normal"
                   >
                     <div
@@ -190,7 +190,7 @@ exports[`Storyshots Modal Full preview 1`] = `
                         </div>
                       </div>
                       <div
-                        className="ModalHeader__MobileHeader-sc-13vyf6i-3 jWCUfS"
+                        className="ModalHeader__MobileHeader-sc-13vyf6i-3 cOHRtu"
                       >
                         Orbit design system
                       </div>
@@ -223,7 +223,7 @@ exports[`Storyshots Modal Full preview 1`] = `
                       </p>
                     </section>
                     <div
-                      className="ModalFooter__StyledModalFooter-sc-17ld6v4-1 brcocJ"
+                      className="ModalFooter__StyledModalFooter-sc-17ld6v4-1 cjDoFb"
                     >
                       <div
                         className="ModalFooter__StyledChild-sc-17ld6v4-0 hFCwHC"
@@ -1698,19 +1698,19 @@ exports[`Storyshots Modal RTL 1`] = `
               }
             >
               <div
-                className="Modal__ModalBody-sc-1f0srsl-0 dqeWDj"
+                className="Modal__ModalBody-sc-1f0srsl-0 cFHwNN"
                 onClick={[Function]}
                 onKeyDown={[Function]}
                 onScroll={[Function]}
                 tabIndex="0"
               >
                 <div
-                  className="Modal__ModalWrapper-sc-1f0srsl-1 cFckeH"
+                  className="Modal__ModalWrapper-sc-1f0srsl-1 cRKVsK"
                   onScroll={[Function]}
                   size="normal"
                 >
                   <div
-                    className="Modal__ModalWrapperContent-sc-1f0srsl-3 erowRe"
+                    className="Modal__ModalWrapperContent-sc-1f0srsl-3 fAIWoE"
                     size="normal"
                   >
                     <div
@@ -1767,7 +1767,7 @@ exports[`Storyshots Modal RTL 1`] = `
                         </div>
                       </div>
                       <div
-                        className="ModalHeader__MobileHeader-sc-13vyf6i-3 cAtvVy"
+                        className="ModalHeader__MobileHeader-sc-13vyf6i-3 gfBIia"
                       >
                         The title of the ModalHeader
                       </div>
@@ -1791,7 +1791,7 @@ exports[`Storyshots Modal RTL 1`] = `
                       </p>
                     </section>
                     <div
-                      className="ModalFooter__StyledModalFooter-sc-17ld6v4-1 brcocJ"
+                      className="ModalFooter__StyledModalFooter-sc-17ld6v4-1 cjDoFb"
                     >
                       <div
                         className="ModalFooter__StyledChild-sc-17ld6v4-0 hahHfK"
@@ -2832,19 +2832,19 @@ exports[`Storyshots Modal Removable sections 1`] = `
               }
             >
               <div
-                className="Modal__ModalBody-sc-1f0srsl-0 dqeWDj"
+                className="Modal__ModalBody-sc-1f0srsl-0 cFHwNN"
                 onClick={[Function]}
                 onKeyDown={[Function]}
                 onScroll={[Function]}
                 tabIndex="0"
               >
                 <div
-                  className="Modal__ModalWrapper-sc-1f0srsl-1 cFckeH"
+                  className="Modal__ModalWrapper-sc-1f0srsl-1 cRKVsK"
                   onScroll={[Function]}
                   size="normal"
                 >
                   <div
-                    className="Modal__ModalWrapperContent-sc-1f0srsl-3 erowRe"
+                    className="Modal__ModalWrapperContent-sc-1f0srsl-3 fAIWoE"
                     size="normal"
                   >
                     <div
@@ -2901,7 +2901,7 @@ exports[`Storyshots Modal Removable sections 1`] = `
                         </div>
                       </div>
                       <div
-                        className="ModalHeader__MobileHeader-sc-13vyf6i-3 jWCUfS"
+                        className="ModalHeader__MobileHeader-sc-13vyf6i-3 cOHRtu"
                       >
                         Enjoy something to eat while you fly
                       </div>
@@ -2925,7 +2925,7 @@ exports[`Storyshots Modal Removable sections 1`] = `
                       </p>
                     </section>
                     <div
-                      className="ModalFooter__StyledModalFooter-sc-17ld6v4-1 brcocJ"
+                      className="ModalFooter__StyledModalFooter-sc-17ld6v4-1 cjDoFb"
                     >
                       <div
                         className="ModalFooter__StyledChild-sc-17ld6v4-0 hFCwHC"
@@ -3895,19 +3895,19 @@ exports[`Storyshots Modal Short Modal 1`] = `
               }
             >
               <div
-                className="Modal__ModalBody-sc-1f0srsl-0 dqeWDj"
+                className="Modal__ModalBody-sc-1f0srsl-0 cFHwNN"
                 onClick={[Function]}
                 onKeyDown={[Function]}
                 onScroll={[Function]}
                 tabIndex="0"
               >
                 <div
-                  className="Modal__ModalWrapper-sc-1f0srsl-1 cFckeH"
+                  className="Modal__ModalWrapper-sc-1f0srsl-1 cRKVsK"
                   onScroll={[Function]}
                   size="normal"
                 >
                   <div
-                    className="Modal__ModalWrapperContent-sc-1f0srsl-3 erowRe"
+                    className="Modal__ModalWrapperContent-sc-1f0srsl-3 fAIWoE"
                     size="normal"
                   >
                     <div
@@ -5679,19 +5679,19 @@ exports[`Storyshots Modal Sizes 1`] = `
               }
             >
               <div
-                className="Modal__ModalBody-sc-1f0srsl-0 dqeWDj"
+                className="Modal__ModalBody-sc-1f0srsl-0 cFHwNN"
                 onClick={[Function]}
                 onKeyDown={[Function]}
                 onScroll={[Function]}
                 tabIndex="0"
               >
                 <div
-                  className="Modal__ModalWrapper-sc-1f0srsl-1 cFckeH"
+                  className="Modal__ModalWrapper-sc-1f0srsl-1 cRKVsK"
                   onScroll={[Function]}
                   size="normal"
                 >
                   <div
-                    className="Modal__ModalWrapperContent-sc-1f0srsl-3 jnycQk"
+                    className="Modal__ModalWrapperContent-sc-1f0srsl-3 dIMKcS"
                     size="normal"
                   >
                     <div
@@ -5737,7 +5737,7 @@ exports[`Storyshots Modal Sizes 1`] = `
                         I&#39;m lovely description
                       </div>
                       <div
-                        className="ModalHeader__MobileHeader-sc-13vyf6i-3 jWCUfS"
+                        className="ModalHeader__MobileHeader-sc-13vyf6i-3 cOHRtu"
                       >
                         Orbit design system
                       </div>
@@ -6630,19 +6630,19 @@ exports[`Storyshots Modal With Form 1`] = `
               }
             >
               <div
-                className="Modal__ModalBody-sc-1f0srsl-0 dqeWDj"
+                className="Modal__ModalBody-sc-1f0srsl-0 cFHwNN"
                 onClick={[Function]}
                 onKeyDown={[Function]}
                 onScroll={[Function]}
                 tabIndex="0"
               >
                 <div
-                  className="Modal__ModalWrapper-sc-1f0srsl-1 cFckeH"
+                  className="Modal__ModalWrapper-sc-1f0srsl-1 cRKVsK"
                   onScroll={[Function]}
                   size="normal"
                 >
                   <div
-                    className="Modal__ModalWrapperContent-sc-1f0srsl-3 erowRe"
+                    className="Modal__ModalWrapperContent-sc-1f0srsl-3 fAIWoE"
                     size="normal"
                   >
                     <div
@@ -6692,7 +6692,7 @@ exports[`Storyshots Modal With Form 1`] = `
                         </div>
                       </div>
                       <div
-                        className="ModalHeader__MobileHeader-sc-13vyf6i-3 jWCUfS"
+                        className="ModalHeader__MobileHeader-sc-13vyf6i-3 cOHRtu"
                       >
                         Refund
                       </div>
@@ -6864,7 +6864,7 @@ exports[`Storyshots Modal With Form 1`] = `
                       </div>
                     </section>
                     <div
-                      className="ModalFooter__StyledModalFooter-sc-17ld6v4-1 brcocJ"
+                      className="ModalFooter__StyledModalFooter-sc-17ld6v4-1 cjDoFb"
                     >
                       <div
                         className="ModalFooter__StyledChild-sc-17ld6v4-0 hFCwHC"
@@ -8460,19 +8460,19 @@ exports[`Storyshots Modal With fixedFooter 1`] = `
               }
             >
               <div
-                className="Modal__ModalBody-sc-1f0srsl-0 dqeWDj"
+                className="Modal__ModalBody-sc-1f0srsl-0 cFHwNN"
                 onClick={[Function]}
                 onKeyDown={[Function]}
                 onScroll={[Function]}
                 tabIndex="0"
               >
                 <div
-                  className="Modal__ModalWrapper-sc-1f0srsl-1 cFckeH"
+                  className="Modal__ModalWrapper-sc-1f0srsl-1 cRKVsK"
                   onScroll={[Function]}
                   size="normal"
                 >
                   <div
-                    className="Modal__ModalWrapperContent-sc-1f0srsl-3 erowRe"
+                    className="Modal__ModalWrapperContent-sc-1f0srsl-3 fAIWoE"
                     size="normal"
                   >
                     <div
@@ -8529,7 +8529,7 @@ exports[`Storyshots Modal With fixedFooter 1`] = `
                         </div>
                       </div>
                       <div
-                        className="ModalHeader__MobileHeader-sc-13vyf6i-3 jWCUfS"
+                        className="ModalHeader__MobileHeader-sc-13vyf6i-3 cOHRtu"
                       >
                         Enjoy something to eat while you fly
                       </div>
@@ -9055,7 +9055,7 @@ exports[`Storyshots Modal With fixedFooter 1`] = `
                       </div>
                     </section>
                     <div
-                      className="ModalFooter__StyledModalFooter-sc-17ld6v4-1 brcocJ"
+                      className="ModalFooter__StyledModalFooter-sc-17ld6v4-1 cjDoFb"
                     >
                       <div
                         className="ModalFooter__StyledChild-sc-17ld6v4-0 hFCwHC"
@@ -16591,19 +16591,19 @@ exports[`Storyshots Modal Without section 1`] = `
               }
             >
               <div
-                className="Modal__ModalBody-sc-1f0srsl-0 dqeWDj"
+                className="Modal__ModalBody-sc-1f0srsl-0 cFHwNN"
                 onClick={[Function]}
                 onKeyDown={[Function]}
                 onScroll={[Function]}
                 tabIndex="0"
               >
                 <div
-                  className="Modal__ModalWrapper-sc-1f0srsl-1 cFckeH"
+                  className="Modal__ModalWrapper-sc-1f0srsl-1 cRKVsK"
                   onScroll={[Function]}
                   size="normal"
                 >
                   <div
-                    className="Modal__ModalWrapperContent-sc-1f0srsl-3 etYHmv"
+                    className="Modal__ModalWrapperContent-sc-1f0srsl-3 hZzxZX"
                     size="normal"
                   >
                     <div
@@ -16660,13 +16660,13 @@ exports[`Storyshots Modal Without section 1`] = `
                         </div>
                       </div>
                       <div
-                        className="ModalHeader__MobileHeader-sc-13vyf6i-3 jWCUfS"
+                        className="ModalHeader__MobileHeader-sc-13vyf6i-3 cOHRtu"
                       >
                         Enjoy something to eat while you fly
                       </div>
                     </div>
                     <div
-                      className="ModalFooter__StyledModalFooter-sc-17ld6v4-1 brcocJ"
+                      className="ModalFooter__StyledModalFooter-sc-17ld6v4-1 cjDoFb"
                     >
                       <div
                         className="ModalFooter__StyledChild-sc-17ld6v4-0 hFCwHC"

--- a/src/Modal/index.js
+++ b/src/Modal/index.js
@@ -6,7 +6,7 @@ import defaultTokens from "../defaultTokens";
 import ButtonLink, { StyledButtonLink } from "../ButtonLink";
 import Close from "../icons/Close";
 import { SIZES, CLOSE_BUTTON_DATA_TEST } from "./consts";
-import media from "../utils/mediaQuery";
+import media, { breakpoints } from "../utils/mediaQuery";
 import { StyledModalFooter } from "./ModalFooter";
 import { MobileHeader, StyledModalHeader } from "./ModalHeader";
 import { StyledModalSection } from "./ModalSection";
@@ -28,6 +28,14 @@ const getSizeToken = () => ({ size, theme }) => {
   return tokens[size];
 };
 
+// media query only for IE 10+, not Edge
+const onlyIE = (style, breakpoint = "all") =>
+  css`
+    @media ${breakpoint} and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+      ${style};
+    }
+  `;
+
 const ModalBody = styled.div`
   width: 100%;
   height: 100%;
@@ -42,10 +50,13 @@ const ModalBody = styled.div`
   overflow-x: hidden;
   background-color: rgba(0, 0, 0, 0.5);
   font-family: ${({ theme }) => theme.orbit.fontfamily};
-
+  -webkit-overflow-scrolling: auto;
   ${media.largeMobile(css`
     overflow-y: auto;
     padding: ${({ theme }) => theme.orbit.spaceXXLarge};
+  `)};
+  ${onlyIE(css`
+    position: -ms-page;
   `)};
 `;
 
@@ -66,6 +77,12 @@ const ModalWrapper = styled.div`
   border-top-right-radius: 9px; // TODO: create token
   transition: ${transition(["top"], "normal", "ease-in-out")};
   top: ${({ loaded }) => (loaded ? "32px" : "100%")};
+
+  ${onlyIE(css`
+    /* IE flex bug, the content won't be centered if there is not 'height' property
+    https://github.com/philipwalton/flexbugs/issues/231 */
+    height: 1px;
+  `)};
 
   ${media.largeMobile(css`
     position: relative;
@@ -100,7 +117,7 @@ const CloseContainer = styled.div`
   
   ${media.largeMobile(css`
     top: ${({ scrolled, fixedClose }) => (fixedClose || scrolled) && "0"};
-    right: ${({ scrolled, fixedClose }) => (fixedClose || scrolled) && "initial"};
+    right: ${({ scrolled, fixedClose }) => (fixedClose || scrolled) && "auto"};
   `)};
   
   & + ${StyledModalSection}:first-of-type {
@@ -183,11 +200,12 @@ const ModalWrapperContent = styled.div`
 
   ${media.largeMobile(css`
     position: relative;
-    bottom: initial;
+    bottom: auto;
     border-radius: 9px;
     padding-bottom: 0;
     height: auto;
     overflow: visible;
+    max-height: 100%;
     ${StyledModalSection}:last-of-type {
       padding-bottom: ${({ theme }) => theme.orbit.spaceXXLarge};
       margin-bottom: ${({ fixedFooter, footerHeight }) =>
@@ -215,6 +233,39 @@ const ModalWrapperContent = styled.div`
         `calc(${modalWidth}px - 48px - ${theme.orbit.spaceXXLarge})`};
     }
   `)};
+
+  ${onlyIE(
+    css`
+      ${StyledModalFooter} {
+        // -ms-page must be used for mobile devices
+        position: ${({ fixedFooter }) => fixedFooter && "-ms-page"};
+      }
+    `,
+  )};
+
+  ${onlyIE(
+    css`
+      ${StyledModalFooter} {
+        // we need to apply static position for IE only when fullyScrolled and fixedFooter
+        // or fixed when fixedFooter (overwrite -ms-page)
+        position: ${({ fullyScrolled, fixedFooter }) =>
+          (fullyScrolled && fixedFooter && "static") || (fixedFooter && "fixed")};
+      }
+      // also we need to clear not wanted margins
+      ${({ fullyScrolled, fixedFooter }) =>
+        fullyScrolled &&
+        fixedFooter &&
+        css`
+          ${StyledModalSection}:last-of-type {
+            margin-bottom: 0;
+          }
+          ${StyledModalHeader} {
+            margin-bottom: ${({ hasModalSection }) => !hasModalSection && "0"};
+          }
+        `};
+    `,
+    breakpoints.largeMobile,
+  )};
 `;
 
 ModalWrapperContent.defaultProps = {


### PR DESCRIPTION
Fixed:
- Broken mobile header after scrolling in IE
- Modal position in IE (should be centered)
- laggy scrolling on iPad
- hidden footer on iOS
- other bugs reported from MMB

Closes #768 
Closes #794
<br/><br/><br/><url>LiveURL: https://orbit-components-fix-modal-ie-safari.surge.sh</url>