### PR TITLE
FIX: Radio and CheckBox text wrap in IE

### DIFF
--- a/src/Checkbox/__snapshots__/Checkbox.stories.storyshot
+++ b/src/Checkbox/__snapshots__/Checkbox.stories.storyshot
@@ -143,7 +143,7 @@ exports[`Storyshots CheckBox Default 1`] = `
                   </svg>
                 </div>
                 <div
-                  className="Checkbox__TextContainer-sc-1x6twh3-1 ePDkGQ"
+                  className="Checkbox__TextContainer-sc-1x6twh3-1 iRwkQb"
                 >
                   <span
                     className="Checkbox__LabelText-sc-1x6twh3-3 kNgPJv"
@@ -453,7 +453,7 @@ exports[`Storyshots CheckBox Playground 1`] = `
                   </svg>
                 </div>
                 <div
-                  className="Checkbox__TextContainer-sc-1x6twh3-1 ePDkGQ"
+                  className="Checkbox__TextContainer-sc-1x6twh3-1 iRwkQb"
                 >
                   <span
                     className="Checkbox__LabelText-sc-1x6twh3-3 kNgPJv"
@@ -917,7 +917,7 @@ exports[`Storyshots CheckBox RTL 1`] = `
                   </svg>
                 </div>
                 <div
-                  className="Checkbox__TextContainer-sc-1x6twh3-1 lgBZYI"
+                  className="Checkbox__TextContainer-sc-1x6twh3-1 gaCoAR"
                 >
                   <span
                     className="Checkbox__LabelText-sc-1x6twh3-3 kNgPJv"
@@ -1307,7 +1307,7 @@ exports[`Storyshots CheckBox With TextLink in label 1`] = `
                   </svg>
                 </div>
                 <div
-                  className="Checkbox__TextContainer-sc-1x6twh3-1 ePDkGQ"
+                  className="Checkbox__TextContainer-sc-1x6twh3-1 iRwkQb"
                 >
                   <span
                     className="Checkbox__LabelText-sc-1x6twh3-3 kNgPJv"
@@ -1646,7 +1646,7 @@ exports[`Storyshots CheckBox With help 1`] = `
                   </svg>
                 </div>
                 <div
-                  className="Checkbox__TextContainer-sc-1x6twh3-1 ePDkGQ"
+                  className="Checkbox__TextContainer-sc-1x6twh3-1 iRwkQb"
                 >
                   <span
                     className="Checkbox__LabelText-sc-1x6twh3-3 kNgPJv"

--- a/src/Checkbox/index.js
+++ b/src/Checkbox/index.js
@@ -57,6 +57,7 @@ const TextContainer = styled.div`
   display: flex;
   flex-direction: column;
   margin: ${({ theme }) => rtlSpacing(`0 0 0 ${theme.orbit.spaceXSmall}`)};
+  flex: 1; // IE wrapping fix
 `;
 
 TextContainer.defaultProps = {

--- a/src/ChoiceGroup/__snapshots__/ChoiceGroup.stories.storyshot
+++ b/src/ChoiceGroup/__snapshots__/ChoiceGroup.stories.storyshot
@@ -151,7 +151,7 @@ exports[`Storyshots ChoiceGroup Default 1`] = `
                       />
                     </div>
                     <div
-                      className="Radio__TextContainer-sc-5lanou-2 fngmbH"
+                      className="Radio__TextContainer-sc-5lanou-2 hNfBAd"
                     >
                       <span
                         className="Radio__LabelText-sc-5lanou-4 kvtYjE"
@@ -181,7 +181,7 @@ exports[`Storyshots ChoiceGroup Default 1`] = `
                       />
                     </div>
                     <div
-                      className="Radio__TextContainer-sc-5lanou-2 fngmbH"
+                      className="Radio__TextContainer-sc-5lanou-2 hNfBAd"
                     >
                       <span
                         className="Radio__LabelText-sc-5lanou-4 kvtYjE"
@@ -211,7 +211,7 @@ exports[`Storyshots ChoiceGroup Default 1`] = `
                       />
                     </div>
                     <div
-                      className="Radio__TextContainer-sc-5lanou-2 fngmbH"
+                      className="Radio__TextContainer-sc-5lanou-2 hNfBAd"
                     >
                       <span
                         className="Radio__LabelText-sc-5lanou-4 kvtYjE"
@@ -783,7 +783,7 @@ exports[`Storyshots ChoiceGroup Multiple 1`] = `
                       </svg>
                     </div>
                     <div
-                      className="Checkbox__TextContainer-sc-1x6twh3-1 ePDkGQ"
+                      className="Checkbox__TextContainer-sc-1x6twh3-1 iRwkQb"
                     >
                       <span
                         className="Checkbox__LabelText-sc-1x6twh3-3 kNgPJv"
@@ -817,7 +817,7 @@ exports[`Storyshots ChoiceGroup Multiple 1`] = `
                       </svg>
                     </div>
                     <div
-                      className="Checkbox__TextContainer-sc-1x6twh3-1 ePDkGQ"
+                      className="Checkbox__TextContainer-sc-1x6twh3-1 iRwkQb"
                     >
                       <span
                         className="Checkbox__LabelText-sc-1x6twh3-3 kNgPJv"
@@ -851,7 +851,7 @@ exports[`Storyshots ChoiceGroup Multiple 1`] = `
                       </svg>
                     </div>
                     <div
-                      className="Checkbox__TextContainer-sc-1x6twh3-1 ePDkGQ"
+                      className="Checkbox__TextContainer-sc-1x6twh3-1 iRwkQb"
                     >
                       <span
                         className="Checkbox__LabelText-sc-1x6twh3-3 kNgPJv"
@@ -1420,7 +1420,7 @@ exports[`Storyshots ChoiceGroup Playground 1`] = `
                       />
                     </div>
                     <div
-                      className="Radio__TextContainer-sc-5lanou-2 fngmbH"
+                      className="Radio__TextContainer-sc-5lanou-2 hNfBAd"
                     >
                       <span
                         className="Radio__LabelText-sc-5lanou-4 kvtYjE"
@@ -1450,7 +1450,7 @@ exports[`Storyshots ChoiceGroup Playground 1`] = `
                       />
                     </div>
                     <div
-                      className="Radio__TextContainer-sc-5lanou-2 fngmbH"
+                      className="Radio__TextContainer-sc-5lanou-2 hNfBAd"
                     >
                       <span
                         className="Radio__LabelText-sc-5lanou-4 kvtYjE"
@@ -1480,7 +1480,7 @@ exports[`Storyshots ChoiceGroup Playground 1`] = `
                       />
                     </div>
                     <div
-                      className="Radio__TextContainer-sc-5lanou-2 fngmbH"
+                      className="Radio__TextContainer-sc-5lanou-2 hNfBAd"
                     >
                       <span
                         className="Radio__LabelText-sc-5lanou-4 kvtYjE"

--- a/src/Radio/__snapshots__/Radio.stories.storyshot
+++ b/src/Radio/__snapshots__/Radio.stories.storyshot
@@ -139,7 +139,7 @@ exports[`Storyshots Radio Default 1`] = `
                   />
                 </div>
                 <div
-                  className="Radio__TextContainer-sc-5lanou-2 fngmbH"
+                  className="Radio__TextContainer-sc-5lanou-2 hNfBAd"
                 >
                   <span
                     className="Radio__LabelText-sc-5lanou-4 kvtYjE"
@@ -445,7 +445,7 @@ exports[`Storyshots Radio Playground 1`] = `
                   />
                 </div>
                 <div
-                  className="Radio__TextContainer-sc-5lanou-2 fngmbH"
+                  className="Radio__TextContainer-sc-5lanou-2 hNfBAd"
                 >
                   <span
                     className="Radio__LabelText-sc-5lanou-4 kvtYjE"
@@ -905,7 +905,7 @@ exports[`Storyshots Radio RTL 1`] = `
                   />
                 </div>
                 <div
-                  className="Radio__TextContainer-sc-5lanou-2 lmqToe"
+                  className="Radio__TextContainer-sc-5lanou-2 QKAgd"
                 >
                   <span
                     className="Radio__LabelText-sc-5lanou-4 kvtYjE"
@@ -1291,7 +1291,7 @@ exports[`Storyshots Radio With TextLink in label 1`] = `
                   />
                 </div>
                 <div
-                  className="Radio__TextContainer-sc-5lanou-2 fngmbH"
+                  className="Radio__TextContainer-sc-5lanou-2 hNfBAd"
                 >
                   <span
                     className="Radio__LabelText-sc-5lanou-4 kvtYjE"
@@ -1626,7 +1626,7 @@ exports[`Storyshots Radio With help 1`] = `
                   />
                 </div>
                 <div
-                  className="Radio__TextContainer-sc-5lanou-2 fngmbH"
+                  className="Radio__TextContainer-sc-5lanou-2 hNfBAd"
                 >
                   <span
                     className="Radio__LabelText-sc-5lanou-4 kvtYjE"

--- a/src/Radio/index.js
+++ b/src/Radio/index.js
@@ -52,6 +52,7 @@ const TextContainer = styled.div`
   display: flex;
   flex-direction: column;
   margin: ${({ theme }) => rtlSpacing(`0 0 0 ${theme.orbit.spaceXSmall}`)};
+  flex: 1; // IE wrapping fix
 `;
 
 TextContainer.defaultProps = {

--- a/src/Stack/__snapshots__/Stack.stories.storyshot
+++ b/src/Stack/__snapshots__/Stack.stories.storyshot
@@ -665,7 +665,7 @@ exports[`Storyshots Stack Components preview 1`] = `
                       </svg>
                     </div>
                     <div
-                      className="Checkbox__TextContainer-sc-1x6twh3-1 ePDkGQ"
+                      className="Checkbox__TextContainer-sc-1x6twh3-1 iRwkQb"
                     >
                       <span
                         className="Checkbox__LabelText-sc-1x6twh3-3 kNgPJv"
@@ -698,7 +698,7 @@ exports[`Storyshots Stack Components preview 1`] = `
                       />
                     </div>
                     <div
-                      className="Radio__TextContainer-sc-5lanou-2 fngmbH"
+                      className="Radio__TextContainer-sc-5lanou-2 hNfBAd"
                     >
                       <span
                         className="Radio__LabelText-sc-5lanou-4 kvtYjE"
@@ -739,7 +739,7 @@ exports[`Storyshots Stack Components preview 1`] = `
                       </svg>
                     </div>
                     <div
-                      className="Checkbox__TextContainer-sc-1x6twh3-1 ePDkGQ"
+                      className="Checkbox__TextContainer-sc-1x6twh3-1 iRwkQb"
                     >
                       <span
                         className="Checkbox__LabelText-sc-1x6twh3-3 kNgPJv"
@@ -772,7 +772,7 @@ exports[`Storyshots Stack Components preview 1`] = `
                       />
                     </div>
                     <div
-                      className="Radio__TextContainer-sc-5lanou-2 fngmbH"
+                      className="Radio__TextContainer-sc-5lanou-2 hNfBAd"
                     >
                       <span
                         className="Radio__LabelText-sc-5lanou-4 kvtYjE"
@@ -826,7 +826,7 @@ exports[`Storyshots Stack Components preview 1`] = `
                           </svg>
                         </div>
                         <div
-                          className="Checkbox__TextContainer-sc-1x6twh3-1 ePDkGQ"
+                          className="Checkbox__TextContainer-sc-1x6twh3-1 iRwkQb"
                         >
                           <span
                             className="Checkbox__LabelText-sc-1x6twh3-3 kNgPJv"
@@ -860,7 +860,7 @@ exports[`Storyshots Stack Components preview 1`] = `
                           </svg>
                         </div>
                         <div
-                          className="Checkbox__TextContainer-sc-1x6twh3-1 ePDkGQ"
+                          className="Checkbox__TextContainer-sc-1x6twh3-1 iRwkQb"
                         >
                           <span
                             className="Checkbox__LabelText-sc-1x6twh3-3 kNgPJv"
@@ -894,7 +894,7 @@ exports[`Storyshots Stack Components preview 1`] = `
                           </svg>
                         </div>
                         <div
-                          className="Checkbox__TextContainer-sc-1x6twh3-1 ePDkGQ"
+                          className="Checkbox__TextContainer-sc-1x6twh3-1 iRwkQb"
                         >
                           <span
                             className="Checkbox__LabelText-sc-1x6twh3-3 kNgPJv"
@@ -941,7 +941,7 @@ exports[`Storyshots Stack Components preview 1`] = `
                           </svg>
                         </div>
                         <div
-                          className="Checkbox__TextContainer-sc-1x6twh3-1 ePDkGQ"
+                          className="Checkbox__TextContainer-sc-1x6twh3-1 iRwkQb"
                         >
                           <span
                             className="Checkbox__LabelText-sc-1x6twh3-3 kNgPJv"
@@ -975,7 +975,7 @@ exports[`Storyshots Stack Components preview 1`] = `
                           </svg>
                         </div>
                         <div
-                          className="Checkbox__TextContainer-sc-1x6twh3-1 ePDkGQ"
+                          className="Checkbox__TextContainer-sc-1x6twh3-1 iRwkQb"
                         >
                           <span
                             className="Checkbox__LabelText-sc-1x6twh3-3 kNgPJv"
@@ -1009,7 +1009,7 @@ exports[`Storyshots Stack Components preview 1`] = `
                           </svg>
                         </div>
                         <div
-                          className="Checkbox__TextContainer-sc-1x6twh3-1 ePDkGQ"
+                          className="Checkbox__TextContainer-sc-1x6twh3-1 iRwkQb"
                         >
                           <span
                             className="Checkbox__LabelText-sc-1x6twh3-3 kNgPJv"


### PR DESCRIPTION
Fixed wrapping text in IE 11.
![bug](https://user-images.githubusercontent.com/7254437/52564422-70e03700-2e04-11e9-9d5e-bccd5b79d969.png)
 <br/><br/><br/><url>LiveURL: https://orbit-components-fix-radio-checkbox-text-flex.surge.sh</url>