### PR TITLE
FIX: Circled Badge

### DIFF
--- a/src/Badge/README.md
+++ b/src/Badge/README.md
@@ -12,7 +12,7 @@ Table below contains all types of the props available in Badge component.
 
 | Name          | Type                  | Default         | Description                      |
 | :------------ | :---------------------| :-------------- | :------------------------------- |
-| circled       | `boolean`             | `false`         | If `true`, the Badge will have circular shape.
+| circled       | `boolean`             | `false`         | If `true`, the Badge will have circular shape.  [See Functional specs](#functional-specs)
 | **children**  | `React.Node`          |                 | The content of the Badge.
 | dataTest      | `string`              |                 | Optional prop for testing purposes.
 | icon          | `React.Node`          |                 | The displayed icon on the left.
@@ -28,3 +28,7 @@ Table below contains all types of the props available in Badge component.
 | `"success"`   |
 | `"warning"`   |
 | `"critical"`  |
+
+## Functional specs
+
+* The `circled` property is meant to be used only for two characters. Don't combine it with any `icon` or `children`.

--- a/src/Badge/__snapshots__/Badge.stories.storyshot
+++ b/src/Badge/__snapshots__/Badge.stories.storyshot
@@ -123,7 +123,7 @@ exports[`Storyshots Badge Default 1`] = `
                 className="Badge__StyledBadge-sc-1y6i8f0-0 iQkwdQ"
               >
                 <div
-                  className="Badge__IconContainer-sc-1y6i8f0-1 gMFnXK"
+                  className="Badge__IconContainer-sc-1y6i8f0-1 hwyQOD"
                 >
                   <svg
                     className="Icon__StyledIcon-sc-1pnzn3g-0 geWqaO"
@@ -399,7 +399,7 @@ exports[`Storyshots Badge Notification badge 1`] = `
               }
             >
               <div
-                className="Badge__StyledBadge-sc-1y6i8f0-0 iFXaxY"
+                className="Badge__StyledBadge-sc-1y6i8f0-0 jIrATE"
               >
                 3
               </div>
@@ -678,7 +678,7 @@ exports[`Storyshots Badge Playground 1`] = `
                 data-test="test"
               >
                 <div
-                  className="Badge__IconContainer-sc-1y6i8f0-1 gMFnXK"
+                  className="Badge__IconContainer-sc-1y6i8f0-1 hwyQOD"
                 >
                   <svg
                     className="Icon__StyledIcon-sc-1pnzn3g-0 geWqaO"
@@ -1049,7 +1049,7 @@ exports[`Storyshots Badge RTL 1`] = `
                 className="Badge__StyledBadge-sc-1y6i8f0-0 bxpgmY"
               >
                 <div
-                  className="Badge__IconContainer-sc-1y6i8f0-1 ksxIrm"
+                  className="Badge__IconContainer-sc-1y6i8f0-1 jsAsmf"
                 >
                   <svg
                     className="Icon__StyledIcon-sc-1pnzn3g-0 geWqaO"
@@ -1406,7 +1406,7 @@ exports[`Storyshots Badge Types 1`] = `
                 className="Badge__StyledBadge-sc-1y6i8f0-0 iQkwdQ"
               >
                 <div
-                  className="Badge__IconContainer-sc-1y6i8f0-1 gMFnXK"
+                  className="Badge__IconContainer-sc-1y6i8f0-1 hwyQOD"
                 >
                   <svg
                     className="Icon__StyledIcon-sc-1pnzn3g-0 geWqaO"
@@ -1611,7 +1611,7 @@ exports[`Storyshots Badge Types 1`] = `
                 className="Badge__StyledBadge-sc-1y6i8f0-0 bxpgmY"
               >
                 <div
-                  className="Badge__IconContainer-sc-1y6i8f0-1 gMFnXK"
+                  className="Badge__IconContainer-sc-1y6i8f0-1 hwyQOD"
                 >
                   <svg
                     className="Icon__StyledIcon-sc-1pnzn3g-0 geWqaO"
@@ -1816,7 +1816,7 @@ exports[`Storyshots Badge Types 1`] = `
                 className="Badge__StyledBadge-sc-1y6i8f0-0 eINXZg"
               >
                 <div
-                  className="Badge__IconContainer-sc-1y6i8f0-1 gMFnXK"
+                  className="Badge__IconContainer-sc-1y6i8f0-1 hwyQOD"
                 >
                   <svg
                     className="Icon__StyledIcon-sc-1pnzn3g-0 geWqaO"
@@ -2021,7 +2021,7 @@ exports[`Storyshots Badge Types 1`] = `
                 className="Badge__StyledBadge-sc-1y6i8f0-0 qdIcr"
               >
                 <div
-                  className="Badge__IconContainer-sc-1y6i8f0-1 gMFnXK"
+                  className="Badge__IconContainer-sc-1y6i8f0-1 hwyQOD"
                 >
                   <svg
                     className="Icon__StyledIcon-sc-1pnzn3g-0 geWqaO"
@@ -2226,7 +2226,7 @@ exports[`Storyshots Badge Types 1`] = `
                 className="Badge__StyledBadge-sc-1y6i8f0-0 iHgMEy"
               >
                 <div
-                  className="Badge__IconContainer-sc-1y6i8f0-1 gMFnXK"
+                  className="Badge__IconContainer-sc-1y6i8f0-1 hwyQOD"
                 >
                   <svg
                     className="Icon__StyledIcon-sc-1pnzn3g-0 geWqaO"
@@ -2431,7 +2431,7 @@ exports[`Storyshots Badge Types 1`] = `
                 className="Badge__StyledBadge-sc-1y6i8f0-0 eBqsVH"
               >
                 <div
-                  className="Badge__IconContainer-sc-1y6i8f0-1 gMFnXK"
+                  className="Badge__IconContainer-sc-1y6i8f0-1 hwyQOD"
                 >
                   <svg
                     className="Icon__StyledIcon-sc-1pnzn3g-0 geWqaO"
@@ -2644,7 +2644,7 @@ exports[`Storyshots Badge Types 1`] = `
                   className="Badge__StyledBadge-sc-1y6i8f0-0 cGXnVY"
                 >
                   <div
-                    className="Badge__IconContainer-sc-1y6i8f0-1 gMFnXK"
+                    className="Badge__IconContainer-sc-1y6i8f0-1 hwyQOD"
                   >
                     <svg
                       className="Icon__StyledIcon-sc-1pnzn3g-0 geWqaO"

--- a/src/Badge/__tests__/__snapshots__/index.test.js.snap
+++ b/src/Badge/__tests__/__snapshots__/index.test.js.snap
@@ -442,6 +442,7 @@ exports[`Badge should match snapshot 1`] = `
   type="info"
 >
   <Badge__IconContainer
+    hasContent={true}
     theme={
       Object {
         "orbit": Object {

--- a/src/Badge/index.js
+++ b/src/Badge/index.js
@@ -51,7 +51,7 @@ const StyledBadge = styled(({ className, children, dataTest }) => (
   background-color: ${getTypeToken(TOKENS.background)};
   color: ${getTypeToken(TOKENS.color)};
   border-radius: ${({ theme }) => theme.orbit.borderRadiusBadge};
-  padding: ${({ theme }) => theme.orbit.paddingBadge};
+  padding: ${({ theme, circled }) => !circled && theme.orbit.paddingBadge};
 `;
 
 StyledBadge.defaultProps = {
@@ -62,7 +62,9 @@ const IconContainer = styled(({ className, children }) => (
   <div className={className}>{children}</div>
 ))`
   display: flex;
-  margin: ${({ theme }) =>
+  flex-shrink: 0;
+  margin: ${({ theme, hasContent }) =>
+    hasContent &&
     rtlSpacing(
       `0 ${theme.orbit.marginRightBadgeIcon} 0 0`,
     )}; // TODO: change token to four direction one
@@ -82,7 +84,11 @@ const Badge = (props: Props) => {
 
   return (
     <StyledBadge type={type} circled={circled} dataTest={dataTest}>
-      {icon && <IconContainer type={type}>{icon}</IconContainer>}
+      {icon && (
+        <IconContainer type={type} hasContent={!!children}>
+          {icon}
+        </IconContainer>
+      )}
       {children}
     </StyledBadge>
   );

--- a/src/Card/__snapshots__/Card.stories.storyshot
+++ b/src/Card/__snapshots__/Card.stories.storyshot
@@ -166,7 +166,7 @@ exports[`Storyshots Card Card with default expanded 1`] = `
                                 className="Badge__StyledBadge-sc-1y6i8f0-0 qdIcr"
                               >
                                 <div
-                                  className="Badge__IconContainer-sc-1y6i8f0-1 gMFnXK"
+                                  className="Badge__IconContainer-sc-1y6i8f0-1 hwyQOD"
                                 >
                                   <svg
                                     className="Icon__StyledIcon-sc-1pnzn3g-0 geWqaO"


### PR DESCRIPTION
Fixed circled badge with an icon or just with some string in IE.
Improved documentation - the `circled` property is meant to be used only for two characters.
Closes #777 <br/><br/><br/><url>LiveURL: https://orbit-components-fix-badge-circled.surge.sh</url>