### PR TITLE
FIX: Move dataTest to label in Radio and Checkbox

### DIFF
--- a/src/Checkbox/__tests__/__snapshots__/index.test.js.snap
+++ b/src/Checkbox/__tests__/__snapshots__/index.test.js.snap
@@ -3,6 +3,7 @@
 exports[`Default CheckBox should match snapshot 1`] = `
 <Checkbox__Label
   checked={false}
+  dataTest="test"
   disabled={false}
   hasError={false}
   theme={
@@ -443,7 +444,6 @@ exports[`Default CheckBox should match snapshot 1`] = `
 >
   <Checkbox__Input
     checked={false}
-    data-test="test"
     disabled={false}
     name="name"
     onChange={

--- a/src/Checkbox/__tests__/index.test.js
+++ b/src/Checkbox/__tests__/index.test.js
@@ -23,11 +23,12 @@ describe(`Default CheckBox`, () => {
       tabIndex={tabIndex}
     />,
   );
+  const labelEl = component.find("Checkbox__Label");
   const checkbox = component.find("Checkbox__Input");
   it("should contain a label", () => {
     expect(
       component
-        .find("Checkbox__LabelText")
+        .find("Checkbox__Label")
         .render()
         .text(),
     ).toBe(label);
@@ -36,7 +37,7 @@ describe(`Default CheckBox`, () => {
     expect(checkbox.prop("value")).toBe(value);
   });
   it("should have data-test", () => {
-    expect(checkbox.render().prop("data-test")).toBe(dataTest);
+    expect(labelEl.render().prop("data-test")).toBe(dataTest);
   });
 
   it("should have tabindex", () => {

--- a/src/Checkbox/index.js
+++ b/src/Checkbox/index.js
@@ -173,9 +173,8 @@ const Checkbox = React.forwardRef((props: Props, ref: Ref) => {
   } = props;
 
   return (
-    <Label disabled={disabled} hasError={hasError} checked={checked}>
+    <Label disabled={disabled} hasError={hasError} checked={checked} dataTest={dataTest}>
       <Input
-        data-test={dataTest}
         value={value}
         type="checkbox"
         disabled={disabled}

--- a/src/Radio/__tests__/__snapshots__/index.test.js.snap
+++ b/src/Radio/__tests__/__snapshots__/index.test.js.snap
@@ -3,6 +3,7 @@
 exports[`Default Radio should match snapshot 1`] = `
 <Radio__Label
   checked={false}
+  data-test="test"
   disabled={false}
   hasError={false}
   theme={
@@ -443,7 +444,6 @@ exports[`Default Radio should match snapshot 1`] = `
 >
   <Radio__Input
     checked={false}
-    data-test="test"
     disabled={false}
     name="name"
     onChange={

--- a/src/Radio/__tests__/index.test.js
+++ b/src/Radio/__tests__/index.test.js
@@ -23,17 +23,18 @@ describe(`Default Radio`, () => {
       tabIndex={tabIndex}
     />,
   );
+  const labelEl = component.find("Radio__Label");
   const radio = component.find("Radio__Input");
   it("should contain a label", () => {
     expect(
       component
-        .find("Radio__LabelText")
+        .find("Radio__Label")
         .render()
         .text(),
     ).toBe(label);
   });
   it("should have data-test", () => {
-    expect(radio.render().prop("data-test")).toBe(dataTest);
+    expect(labelEl.render().prop("data-test")).toBe(dataTest);
   });
 
   it("should have tabindex", () => {

--- a/src/Radio/index.js
+++ b/src/Radio/index.js
@@ -163,9 +163,8 @@ const Radio = React.forwardRef((props: Props, ref: Ref) => {
     dataTest,
   } = props;
   return (
-    <Label disabled={disabled} hasError={hasError} checked={checked}>
+    <Label disabled={disabled} hasError={hasError} checked={checked} data-test={dataTest}>
       <Input
-        data-test={dataTest}
         value={value}
         type="radio"
         disabled={disabled}


### PR DESCRIPTION
This Pull Request meets the following criteria:

* [x] Tests have been added/adjusted for my new feature

Closes #807 <br/><br/><br/><url>LiveURL: https://orbit-components-fix-datatest-label-radio-checkbox.surge.sh</url>