### PR TITLE
FIX: Modal decideFixedFooter method

### DIFF
--- a/src/Modal/index.js
+++ b/src/Modal/index.js
@@ -335,8 +335,9 @@ class Modal extends React.PureComponent<Props, State> {
   decideFixedFooter = () => {
     // if the content height is smaller than window height, we need to explicitly set fullyScrolled to true
     const content = this.modalContent.current;
-    // what is 40 value?
-    const fullyScrolled = content?.scrollHeight + 40 <= window.innerHeight;
+    const body = this.modalBody.current;
+    // when scrollHeight + topPadding - scrollingElementHeight is smaller or even than window height
+    const fullyScrolled = content?.scrollHeight + 40 - body?.scrollTop <= window.innerHeight;
     this.setState({ fullyScrolled });
   };
 


### PR DESCRIPTION
When the `decideFixedFooter` was called inside some children (via context) it caused badly calculated `fullyScrolled` state, because it didn't count with the `scrollTop` value of the `ModalBody` element.

Original report: http://recordit.co/CLQzMIOmPH<br/><br/><br/><url>LiveURL: https://orbit-components-fix-modal-decidefixedfooter.surge.sh</url>