### PR TITLE
DEV: Get rid of deprecated imports - knobs

### DIFF
--- a/src/Breadcrumbs/Breadcrumbs.stories.js
+++ b/src/Breadcrumbs/Breadcrumbs.stories.js
@@ -5,7 +5,7 @@ import { storiesOf, setAddon } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
 import styles from "@sambego/storybook-styles";
 import chaptersAddon from "react-storybook-addon-chapters";
-import { withKnobs } from "@storybook/addon-knobs/react";
+import { withKnobs } from "@storybook/addon-knobs";
 
 import Breadcrumbs, { BreadcrumbsItem } from "./index";
 

--- a/src/ChoiceGroup/ChoiceGroup.stories.js
+++ b/src/ChoiceGroup/ChoiceGroup.stories.js
@@ -4,7 +4,7 @@ import { storiesOf, setAddon } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
 import styles from "@sambego/storybook-styles";
 import chaptersAddon from "react-storybook-addon-chapters";
-import { withKnobs, text, select } from "@storybook/addon-knobs/react";
+import { withKnobs, text, select } from "@storybook/addon-knobs";
 
 import { LABEL_ELEMENTS, LABEL_SIZES } from "./consts";
 import Radio from "../Radio";

--- a/src/Hide/Hide.stories.js
+++ b/src/Hide/Hide.stories.js
@@ -3,7 +3,7 @@ import * as React from "react";
 import { storiesOf, setAddon } from "@storybook/react";
 import styles from "@sambego/storybook-styles";
 import chaptersAddon from "react-storybook-addon-chapters";
-import { withKnobs, boolean } from "@storybook/addon-knobs/react";
+import { withKnobs, boolean } from "@storybook/addon-knobs";
 
 import ChevronLeft from "../icons/ChevronLeft";
 

--- a/src/ListChoice/ListChoice.stories.js
+++ b/src/ListChoice/ListChoice.stories.js
@@ -5,7 +5,7 @@ import { storiesOf, setAddon } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
 import styles from "@sambego/storybook-styles";
 import chaptersAddon from "react-storybook-addon-chapters";
-import { withKnobs, text, boolean, select } from "@storybook/addon-knobs/react";
+import { withKnobs, text, boolean, select } from "@storybook/addon-knobs";
 
 import * as Icons from "../icons";
 import RenderInRtl from "../utils/rtl/RenderInRtl";

--- a/src/Stepper/Stepper.stories.js
+++ b/src/Stepper/Stepper.stories.js
@@ -4,7 +4,7 @@ import { storiesOf, setAddon } from "@storybook/react";
 import styles from "@sambego/storybook-styles";
 import { action } from "@storybook/addon-actions";
 import chaptersAddon from "react-storybook-addon-chapters";
-import { withKnobs, text, number, boolean } from "@storybook/addon-knobs/react";
+import { withKnobs, text, number, boolean } from "@storybook/addon-knobs";
 
 import Stepper from "./index";
 

--- a/src/Tooltip/Tooltip.stories.js
+++ b/src/Tooltip/Tooltip.stories.js
@@ -3,7 +3,7 @@ import * as React from "react";
 import { storiesOf, setAddon } from "@storybook/react";
 import styles from "@sambego/storybook-styles";
 import chaptersAddon from "react-storybook-addon-chapters";
-import { withKnobs, text, select } from "@storybook/addon-knobs/react";
+import { withKnobs, text, select } from "@storybook/addon-knobs";
 
 import * as Icons from "../icons";
 import { POSITIONS, SIZE_OPTIONS } from "./consts";

--- a/src/_deprecated/Card/Card.stories.js
+++ b/src/_deprecated/Card/Card.stories.js
@@ -4,7 +4,7 @@ import { storiesOf, setAddon } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
 import styles from "@sambego/storybook-styles";
 import chaptersAddon from "react-storybook-addon-chapters";
-import { withKnobs, text, boolean, select } from "@storybook/addon-knobs/react";
+import { withKnobs, text, boolean, select } from "@storybook/addon-knobs";
 
 import * as Icons from "../../icons";
 import Heading from "../../Heading";


### PR DESCRIPTION
Cleaned console warnings for deprecated imports from @storybook/addon-knobs.<br/><br/><br/><url>LiveURL: https://orbit-components-dev-fix-imports-knobs.surge.sh</url>