### PR TITLE
FIX: Cross origin images - prevent sending cookies

### DIFF
--- a/src/CountryFlag/__tests__/__snapshots__/index.test.js.snap
+++ b/src/CountryFlag/__tests__/__snapshots__/index.test.js.snap
@@ -3,6 +3,7 @@
 exports[`CountryFlag of Anywhere should match snapshot 1`] = `
 <CountryFlag__StyledCountryFlag
   alt="Anywhere"
+  crossOrigin="anonymous"
   data-test="test"
   key="anywhere"
   src="//images.kiwi.com/flags/24x0/flag-anywhere.jpg"

--- a/src/CountryFlag/__tests__/index.test.js
+++ b/src/CountryFlag/__tests__/index.test.js
@@ -17,6 +17,7 @@ describe(`CountryFlag of ${name}`, () => {
     expect(component.prop("alt")).toBe(name);
     expect(component.prop("title")).toBe(name);
     expect(component.render().prop("data-test")).toBe(dataTest);
+    expect(component.render().prop("crossorigin")).toBe("anonymous");
   });
   it("should match snapshot", () => {
     expect(component).toMatchSnapshot();

--- a/src/CountryFlag/index.js
+++ b/src/CountryFlag/index.js
@@ -25,6 +25,7 @@ const CountryFlag = (props: Props) => {
       key={code}
       src={`${baseURL}/flags/24x0/flag-${code.toLowerCase()}.jpg`}
       srcSet={`${baseURL}/flags/48x0/flag-${code.toLowerCase()}.jpg 2x`}
+      crossOrigin="anonymous"
       alt={name}
       title={name}
       data-test={dataTest}

--- a/src/Illustration/__tests__/__snapshots__/index.test.js.snap
+++ b/src/Illustration/__tests__/__snapshots__/index.test.js.snap
@@ -3,6 +3,7 @@
 exports[`Illustration of Accommodation should match snapshot 1`] = `
 <Illustration__StyledImage
   alt="Accommodation"
+  crossOrigin="anonymous"
   data-test="test"
   illustrationName="Accommodation"
   size="small"

--- a/src/Illustration/__tests__/index.test.js
+++ b/src/Illustration/__tests__/index.test.js
@@ -27,6 +27,7 @@ describe(`Illustration of ${name}`, () => {
     expect(component.prop("size")).toBe(size);
     expect(component.render().prop("alt")).toBe(name);
     expect(component.render().prop("data-test")).toBe(dataTest);
+    expect(component.render().prop("crossorigin")).toBe("anonymous");
   });
 
   it("should render proper image", () => {

--- a/src/Illustration/index.js
+++ b/src/Illustration/index.js
@@ -43,6 +43,7 @@ const Illustration = ({ name, size = SIZE_OPTIONS.MEDIUM, dataTest, spaceAfter }
     size={size}
     data-test={dataTest}
     spaceAfter={spaceAfter}
+    crossOrigin="anonymous"
   />
 );
 

--- a/src/ServiceLogo/__tests__/__snapshots__/index.test.js.snap
+++ b/src/ServiceLogo/__tests__/__snapshots__/index.test.js.snap
@@ -10,6 +10,7 @@ exports[`ServiceLogo: AirHelp should match snapshot 1`] = `
 <img
   alt="AirHelp"
   className="c0"
+  crossOrigin="anonymous"
   src="//images.kiwi.com/logos/0x48/AirHelp.png"
   srcSet="//images.kiwi.com/logos/0x96/AirHelp.png 2x"
 />
@@ -25,6 +26,7 @@ exports[`ServiceLogo: AirHelp should match snapshot 2`] = `
 <img
   alt="AirHelp"
   className="c0"
+  crossOrigin="anonymous"
   data-test="test"
   src="//images.kiwi.com/logos-grayscale/0x48/AirHelp.png"
   srcSet="//images.kiwi.com/logos-grayscale/0x96/AirHelp.png 2x"

--- a/src/ServiceLogo/__tests__/index.test.js
+++ b/src/ServiceLogo/__tests__/index.test.js
@@ -42,6 +42,7 @@ describe(`ServiceLogo: ${name}`, () => {
     expect(component.prop("srcSet")).toBe(`${IMAGE_PATH_RETINA} 2x`);
     expect(component.prop("alt")).toBe(name);
     expect(component.render().prop("data-test")).toBe(dataTest);
+    expect(component.render().prop("crossorigin")).toBe("anonymous");
   });
 
   it("should match snapshot", () => {

--- a/src/ServiceLogo/index.js
+++ b/src/ServiceLogo/index.js
@@ -26,6 +26,7 @@ export const StyledServiceLogo = styled(({ className, name, size, grayScale, the
     src={`${baseURL}/${getColor(grayScale)}/0x${parseInt(getHeight(theme, size), 10)}/${name}.png`}
     srcSet={`${baseURL}/${getColor(grayScale)}/0x${parseInt(getHeight(theme, size), 10) *
       2}/${name}.png 2x`}
+    crossOrigin="anonymous"
     alt={name}
     data-test={dataTest}
   />


### PR DESCRIPTION
Just added crossorigin anonymous to all images that are served from CDN.<br/><br/><br/><url>LiveURL: https://orbit-components-fix-images-cross-origin.surge.sh</url>