### PR TITLE
UPDATE: media query example in docs

### DIFF
--- a/src/utils/mediaQuery/README.md
+++ b/src/utils/mediaQuery/README.md
@@ -14,7 +14,7 @@ import styled, { css } from "styled-components";
 const StyledComponent = styled.div`
   width: 100%;
   
-  ${mq.desktop(css`
+  ${media.desktop(css`
     width: 50%;
   `)};
 `
@@ -39,7 +39,7 @@ Imagine that we have component and we want to test if it's contain specific styl
 const StyledComponent = styled.div`
   width: 100%;
   
-  ${mq.desktop(css`
+  ${media.desktop(css`
     width: 50%;
   `)};
 ```


### PR DESCRIPTION
Update [docs](https://orbit.kiwi/guidelines/media-queries/)'s example of how to use Orbit's media query inside styled-component. Current `mq` does not work, it works with `media`.