### PR TITLE
FIX: TripSector icon background in IE

### DIFF
--- a/src/TripSector/index.js
+++ b/src/TripSector/index.js
@@ -33,7 +33,9 @@ const StyledTripSector = styled.div`
       content: " ";
       position: absolute;
       top: 13px;
+      right: 0;
       bottom: 0;
+      left: 0;
       width: 16px;
       background: ${({ theme }) => theme.orbit.paletteWhite};
     }


### PR DESCRIPTION
Closes #870 <br/><br/><br/><url>LiveURL: https://orbit-components-fix-tripsector-icon-bg-ie.surge.sh</url>