### PR TITLE
FIX: Flow type for exact children

### DIFF
--- a/src/Breadcrumbs/index.js.flow
+++ b/src/Breadcrumbs/index.js.flow
@@ -2,14 +2,12 @@
 /*
   DOCUMENTATION: https://orbit.kiwi/components/breadcrumbs/
 */
-import type { Globals } from "../common/common.js.flow";
+import type { Globals, StrictChildren } from "../common/common.js.flow";
 import typeof BreadcrumbsItemType from "./BreadcrumbsItem";
-
-type Children = React$Element<BreadcrumbsItemType>;
 
 export type Props = {|
   ...Globals,
-  children: Children | Children[],
+  children: StrictChildren<BreadcrumbsItemType>,
 |};
 
 declare export default React$ComponentType<Props>;

--- a/src/ButtonGroup/index.js.flow
+++ b/src/ButtonGroup/index.js.flow
@@ -2,12 +2,12 @@
 /*
   DOCUMENTATION: https://orbit.kiwi/components/buttongroup/
 */
-import type { Globals } from "../common/common.js.flow";
-import ButtonLink from "../ButtonLink";
-import Button from "../Button";
+import type { Globals, StrictChildren } from "../common/common.js.flow";
+import typeof ButtonLink from "../ButtonLink";
+import typeof Button from "../Button";
 
 export type Props = {|
-  +children: Array<React$Element<typeof Button> | React$Element<typeof ButtonLink>>,
+  +children: StrictChildren<Button | ButtonLink>,
   +connected?: boolean,
   ...Globals,
 |};

--- a/src/ChoiceGroup/index.js.flow
+++ b/src/ChoiceGroup/index.js.flow
@@ -2,19 +2,17 @@
 /*
   DOCUMENTATION: https://orbit.kiwi/components/choicegroup/
 */
-import type { Globals, Translation } from "../common/common.js.flow";
-import Radio from "../Radio";
-import Checkbox from "../Checkbox";
+import type { Globals, Translation, StrictChildren } from "../common/common.js.flow";
+import typeof Radio from "../Radio";
+import typeof Checkbox from "../Checkbox";
 
 type LabelSize = "normal" | "large";
 
 type LabelElement = "h2" | "h3" | "h4" | "h5" | "h6";
 
-type Children = React$Element<typeof Radio> | React$Element<typeof Checkbox>;
-
 export type Props = {|
   ...Globals,
-  children: Children | Children[],
+  children: StrictChildren<Radio | Checkbox>,
   label?: Translation,
   labelSize?: LabelSize,
   labelElement?: LabelElement,

--- a/src/InputGroup/index.js.flow
+++ b/src/InputGroup/index.js.flow
@@ -2,16 +2,16 @@
 /*
   DOCUMENTATION: https://orbit.kiwi/components/inputgroup/
 */
-import type { Globals, Translation } from "../common/common.js.flow";
-import InputField from "../InputField";
-import Select from "../Select";
+import type { Globals, Translation, StrictChildren } from "../common/common.js.flow";
+import typeof InputField from "../InputField";
+import typeof Select from "../Select";
 
 export type Props = {|
   +label?: Translation,
   +flex?: string | Array<string>,
   +size?: "small" | "normal",
   +help?: React$Node,
-  +children: Array<React$Element<typeof InputField> | React$Element<typeof Select>>,
+  +children: StrictChildren<InputField | Select>,
   +error?: React$Node,
   +onChange?: (
     ev: SyntheticInputEvent<HTMLInputElement> | SyntheticInputEvent<HTMLSelectElement>,

--- a/src/List/List.stories.js
+++ b/src/List/List.stories.js
@@ -4,7 +4,7 @@ import * as React from "react";
 import { storiesOf, setAddon } from "@storybook/react";
 import styles from "@sambego/storybook-styles";
 import chaptersAddon from "react-storybook-addon-chapters";
-import { withKnobs, text, select } from "@storybook/addon-knobs";
+import { withKnobs, text, select, boolean } from "@storybook/addon-knobs";
 
 import * as Icons from "../icons";
 import { SIZES, TYPES } from "./consts";
@@ -78,6 +78,7 @@ storiesOf("List", module)
   .addWithChapters("With carrier", () => {
     const size = select("Size", Object.values(SIZES), SIZES.SMALL);
     const type = select("Type", Object.values(TYPES), TYPES.SECONDARY);
+    const showMore: ?boolean = boolean("showMore", false);
 
     return {
       info:
@@ -93,7 +94,7 @@ storiesOf("List", module)
                   </ListItem>
                   <ListItem icon={<Icons.InformationCircle />}>Flight no: FR 1337</ListItem>
                   <ListItem icon={<Icons.Trip />}>PNR: TEST0X0</ListItem>
-                  <ListItem icon={<Icons.Airplane />}>Airbus A320 (320)</ListItem>
+                  {showMore && <ListItem icon={<Icons.Airplane />}>Airbus A320 (320)</ListItem>}
                 </List>
               ),
             },

--- a/src/List/index.js.flow
+++ b/src/List/index.js.flow
@@ -3,7 +3,7 @@
   DOCUMENTATION: https://orbit.kiwi/components/list/
 */
 import typeof ListItemType from "./ListItem";
-import type { Globals } from "../common/common.js.flow";
+import type { StrictChildren, Globals } from "../common/common.js.flow";
 import type { spaceAfter } from "../common/getSpacingToken/index";
 
 export type Size = "small" | "normal" | "large";
@@ -11,7 +11,7 @@ export type Size = "small" | "normal" | "large";
 type Type = "primary" | "secondary";
 
 export type Props = {|
-  +children: Array<React$Element<ListItemType>> | React$Element<ListItemType>,
+  +children: StrictChildren<ListItemType>,
   +size?: Size,
   +type?: Type,
   ...Globals,

--- a/src/Table/TableBody/index.js.flow
+++ b/src/Table/TableBody/index.js.flow
@@ -2,10 +2,11 @@
 
 import type { ReactComponentStyled } from "styled-components";
 
-import TableRow from "../TableRow/index";
+import typeof TableRow from "../TableRow/index";
+import type { StrictChildren } from "../../common/common.js.flow";
 
 export type Props = {|
-  +children: Array<React$Element<typeof TableRow>> | React$Element<typeof TableRow>,
+  +children: StrictChildren<TableRow>,
 |};
 
 declare export default React$ComponentType<Props>;

--- a/src/Table/TableHead/index.js.flow
+++ b/src/Table/TableHead/index.js.flow
@@ -1,8 +1,9 @@
 // @flow
-import TableRow from "../TableRow/index";
+import typeof TableRow from "../TableRow/index";
+import type { StrictChildren } from "../../common/common.js.flow";
 
 export type Props = {|
-  +children: Array<React$Element<typeof TableRow>> | React$Element<typeof TableRow>,
+  +children: StrictChildren<TableRow>,
 |};
 
 declare export default React$ComponentType<Props>;

--- a/src/Table/TableRow/index.js.flow
+++ b/src/Table/TableRow/index.js.flow
@@ -1,10 +1,11 @@
 // @flow
 import type { ReactComponentStyled } from "styled-components";
 
-import TableCell from "../TableCell/index";
+import typeof TableCell from "../TableCell/index";
+import type { StrictChildren } from "../../common/common.js.flow";
 
 export type Props = {|
-  +children: Array<React$Element<typeof TableCell>> | React$Element<typeof TableCell>,
+  +children: StrictChildren<TableCell>,
 |};
 
 declare export default React$ComponentType<Props>;

--- a/src/Table/index.js.flow
+++ b/src/Table/index.js.flow
@@ -2,18 +2,16 @@
 /*
   DOCUMENTATION: https://orbit.kiwi/components/table/
 */
-import TBody from "./TableBody";
-import THead from "./TableHead";
-import type { Globals } from "../common/common.js.flow";
+import type { Globals, StrictChildren } from "../common/common.js.flow";
 import typeof TableBodyType from "./TableBody/index.js.flow";
 import typeof TableCellType from "./TableCell/index.js.flow";
 import typeof TableHeadType from "./TableHead/index.js.flow";
 import typeof TableRowType from "./TableRow/index.js.flow";
 
 export type Props = {|
-  +compact?: boolean,
-  +children: Array<React$Element<typeof THead> | React$Element<typeof TBody>>,
   ...Globals,
+  +compact?: boolean,
+  +children: StrictChildren<TableBodyType | TableHeadType>,
 |};
 
 export type State = {|

--- a/src/common/common.js.flow
+++ b/src/common/common.js.flow
@@ -1,4 +1,6 @@
 // @flow
+import typeof { Fragment } from "react";
+
 export type Globals = {|
   +dataTest?: string,
 |};
@@ -8,5 +10,9 @@ export type RefType = () => { current: ?HTMLElement };
 export type Ref = {|
   +ref?: RefType,
 |};
+
+type StrictNode<T> = boolean | React$Element<T | Fragment>;
+
+export type StrictChildren<T> = ?StrictNode<T> | Array<?StrictNode<T>>;
 
 export type Translation = React$Element<React$ComponentType<any>> | string;


### PR DESCRIPTION
What someone uses conditional rendering with boolean, object or array in `List` or `Modal`, the flow cries that inexact is compatible with React.Element.

This can be fixed by the proposed type:
```
type StrictNode<T> = boolean | React$Element<T | Fragment>;

export type StrictChildren<T> = ?StrictNode<T> | Array<?StrictNode<T>>;
```

So the used children can be: `all falsey values`, `the exact type` or `React.Fragment`.

For some cases we gonna stick to using `React$Node`.
Closes #670 <br/><br/><br/><url>LiveURL: https://orbit-components-fix-type-exact-children.surge.sh</url>