### PR TITLE
DOCS: Loader with loading false

### DIFF
--- a/src/Loading/README.md
+++ b/src/Loading/README.md
@@ -14,7 +14,7 @@ Table below contains all types of the props available for icons in general.
 | :------------ | :-------------- | :-------------- | :------------------------------- |
 | children      | `React.Node`    |                 | The content of the Loading. [See Functional specs](#functional-specs)
 | dataTest      | `string`        |                 | Optional prop for testing purposes.
-| loading       | `boolean`       | `false`         | If `true`, the Loading will be displayed.
+| loading       | `boolean`       | `false`         | If `true`, the Loading will be displayed. Loading which doesn't have a children is always shown, even if `loading` prop is set to `false`.
 | **type**      | [`enum`](#enum) |                 | The type of the Loading.
 | text          | `Translation`   |                 | The text of the Loading.
 
@@ -28,6 +28,5 @@ Table below contains all types of the props available for icons in general.
 | `"pageLoader"`   |
 | `"inlineLoader"` |
 
-## Functional specs
-* Loading which doesn't have a children is always shown, even though that `loading` prop is set to `false`.
+
 


### PR DESCRIPTION
If the `loading` is set to false and the children prop is `null`, we have to render something - so the current behavior is alright.

Closes #432 and #522<br/><br/><br/><url>LiveURL: https://orbit-components-fix-loading-false.surge.sh</url>