### PR TITLE
FIX: Badge with translated node

### DIFF
--- a/src/Badge/Badge.stories.js
+++ b/src/Badge/Badge.stories.js
@@ -126,6 +126,26 @@ storiesOf("Badge", module)
       ],
     };
   })
+  .addWithChapters("Badge with translated node", () => {
+    return {
+      info: "Check Orbit.Kiwi for more detailed design guidelines.",
+      chapters: [
+        {
+          sections: [
+            {
+              sectionFn: () => (
+                <Badge icon={<Icons.Airplane />}>
+                  <span>Content should </span>
+                  <span>be</span>
+                  <span> with space</span>
+                </Badge>
+              ),
+            },
+          ],
+        },
+      ],
+    };
+  })
   .addWithChapters("Playground", () => {
     const content = text("Content", "Badge");
     const type = select("Type", Object.values(TYPE_OPTIONS), TYPE_OPTIONS.INFO);

--- a/src/Badge/__tests__/__snapshots__/index.test.js.snap
+++ b/src/Badge/__tests__/__snapshots__/index.test.js.snap
@@ -882,6 +882,8 @@ exports[`Badge should match snapshot 1`] = `
   >
     <Sightseeing />
   </Badge__IconContainer>
-  badge
+  <Badge__StyledBadgeContent>
+    badge
+  </Badge__StyledBadgeContent>
 </Badge__StyledBadge>
 `;

--- a/src/Badge/index.js
+++ b/src/Badge/index.js
@@ -79,6 +79,8 @@ IconContainer.defaultProps = {
   theme: defaultTokens,
 };
 
+const StyledBadgeContent = styled.div``;
+
 const Badge = (props: Props) => {
   const { type = TYPE_OPTIONS.NEUTRAL, icon, children, circled, dataTest } = props;
 
@@ -89,7 +91,7 @@ const Badge = (props: Props) => {
           {icon}
         </IconContainer>
       )}
-      {children}
+      <StyledBadgeContent>{children}</StyledBadgeContent>
     </StyledBadge>
   );
 };


### PR DESCRIPTION
When Translate component was used inside Badge. The `flex` display trimmed the whitespaces that are necessary. Fixed just with wrapping `div`.<br/><br/><br/><url>LiveURL: https://orbit-components-fix-badge-with-translate.surge.sh</url>