### PR TITLE
ADD: fromPlainObject export

### DIFF
--- a/src/fromPlainObject.js
+++ b/src/fromPlainObject.js
@@ -1,0 +1,2 @@
+// @flow
+export { fromPlainObject as default } from "@kiwicom/orbit-design-tokens";

--- a/src/fromPlainObject.js.flow
+++ b/src/fromPlainObject.js.flow
@@ -1,0 +1,4 @@
+// @flow
+import type { fromPlainObject } from "@kiwicom/orbit-design-tokens";
+
+declare export default fromPlainObject;


### PR DESCRIPTION
We can't get rid off `orbit-design-tokens` as dependency in projects, when we don't have `fromPlainObject` export.

<br/><br/><br/><url>LiveURL: https://orbit-components-dev-update-tokens-export.surge.sh</url>