### PR TITLE
FIX: CardSectionContent space fix

### DIFF
--- a/src/Card/Card.stories.js
+++ b/src/Card/Card.stories.js
@@ -387,10 +387,12 @@ storiesOf("Card", module)
                     dataTest={dataTest}
                   />
                   <CardSection dataTest={dataTest}>
-                    <Heading type="title3" element="h3">
-                      Content with Heading and text
-                    </Heading>
-                    <Text>Text in content</Text>
+                    <CardSectionContent>
+                      <Heading type="title3" element="h3">
+                        Content with Heading and text
+                      </Heading>
+                      <Text>Text in content</Text>
+                    </CardSectionContent>
                   </CardSection>
                   <CardSection dataTest={dataTest}>
                     <Heading type="title3" element="h3">

--- a/src/Card/index.js
+++ b/src/Card/index.js
@@ -7,7 +7,7 @@ import Close from "../icons/Close";
 import ButtonLink from "../ButtonLink";
 import CardSection, { StyledCardSection } from "./CardSection";
 import CardHeader, { StyledCardHeader } from "./CardHeader";
-import { StyledCardSectionContent } from "./CardSection/CardSectionContent"
+import { StyledCardSectionContent } from "./CardSection/CardSectionContent";
 import Loading, { StyledLoading } from "../Loading";
 import getSpacingToken from "../common/getSpacingToken";
 import { right } from "../utils/rtl";

--- a/src/Card/index.js
+++ b/src/Card/index.js
@@ -7,6 +7,7 @@ import Close from "../icons/Close";
 import ButtonLink from "../ButtonLink";
 import CardSection, { StyledCardSection } from "./CardSection";
 import CardHeader, { StyledCardHeader } from "./CardHeader";
+import { StyledCardSectionContent } from "./CardSection/CardSectionContent"
 import Loading, { StyledLoading } from "../Loading";
 import getSpacingToken from "../common/getSpacingToken";
 import { right } from "../utils/rtl";
@@ -71,6 +72,10 @@ const StyledCard = styled.div`
 
       + ${StyledChildWrapper} ${StyledCardSection} {
         padding-top: ${({ hasAdjustedHeader }) => hasAdjustedHeader && 0};
+        
+        ${StyledCardSectionContent}:first-of-type { // if there isn't any CardSectionHeader we need to delete padding of CardSectionContent 
+          padding-top: ${({ hasAdjustedHeader }) => hasAdjustedHeader && 0};
+        }
       }
     }
 


### PR DESCRIPTION
If there isn't any `CardSectionHeader` CardSectionContent shouldn't has padding-top

![image](https://user-images.githubusercontent.com/7850592/54126462-e3decc80-4407-11e9-8ff1-bc00bc56c41f.png)
<br/><br/><br/><url>LiveURL: https://orbit-components-fix-cardsection-content-space.surge.sh</url>