### PR TITLE
FIX: Modal IE unwanted space between content and footer

### DIFF
--- a/src/Modal/index.js
+++ b/src/Modal/index.js
@@ -250,6 +250,9 @@ const ModalWrapperContent = styled.div`
         // or fixed when fixedFooter (overwrite -ms-page)
         position: ${({ fullyScrolled, fixedFooter }) =>
           (fullyScrolled && fixedFooter && "static") || (fixedFooter && "fixed")};
+        // for IE there's need to be added inset box-shadow with same background as footer has
+        box-shadow: ${({ fixedFooter, theme }) =>
+          !fixedFooter && `inset 0 0 0 1px ${theme.orbit.paletteWhite}`};
       }
       // also we need to clear not wanted margins
       ${({ fullyScrolled, fixedFooter }) =>


### PR DESCRIPTION
Fix for this report:
![ie modal](https://user-images.githubusercontent.com/7254437/54361452-54cfef80-4667-11e9-8c6b-1d6dd916e74d.png)
<br/><br/><br/><url>LiveURL: https://orbit-components-fix-modal-ie-unwanted-space.surge.sh</url>