### PR TITLE
UPDATE: ListChoice heading render

### DIFF
--- a/src/ListChoice/_tests_/__snapshots__/index.test.js.snap
+++ b/src/ListChoice/_tests_/__snapshots__/index.test.js.snap
@@ -1359,6 +1359,7 @@ exports[`ListChoice should match snapshot 1`] = `
     }
   >
     <Heading
+      element="div"
       type="title4"
     >
       Choice Title

--- a/src/ListChoice/index.js
+++ b/src/ListChoice/index.js
@@ -83,7 +83,9 @@ const ListChoice = (props: Props) => {
     <StyledListChoice onClick={onClick} data-test={dataTest}>
       {icon && <StyledListChoiceIcon>{icon}</StyledListChoiceIcon>}
       <StyledListChoiceContent>
-        <Heading type="title4">{title}</Heading>
+        <Heading type="title4" element="div">
+          {title}
+        </Heading>
         {description && (
           <Text type="secondary" size="small">
             {description}


### PR DESCRIPTION
Updating render of heading to render to `div` instead of `H1`<br/><br/><br/><url>LiveURL: https://orbit-components-update-ListChoice-a11y.surge.sh</url>