### PR TITLE
FIX: Flow React import in Sticky

### DIFF
--- a/src/Sticky/index.js.flow
+++ b/src/Sticky/index.js.flow
@@ -1,9 +1,8 @@
 // @flow
-import * as React from "react";
 
 export type Props = {|
   +offset?: number,
-  +children: React.Node,
+  +children: React$Node,
 |};
 
 export type State = {|

--- a/src/Sticky/index.js.flow
+++ b/src/Sticky/index.js.flow
@@ -1,4 +1,5 @@
 // @flow
+import * as React from "react";
 
 export type Props = {|
   +offset?: number,


### PR DESCRIPTION
React was not imported in flow declaration `¯\_(ツ)_/¯`

Fixes #975 <br/><br/><br/><url>LiveURL: https://orbit-components-flow-fix-sticky-react-import.surge.sh</url>