### PR TITLE
FIX: CountryFlag code normalization

### DIFF
--- a/src/CountryFlag/index.js
+++ b/src/CountryFlag/index.js
@@ -52,7 +52,7 @@ StyledShadow.defaultProps = {
 };
 
 export function getCountryProps(code: ?string, name: ?string): { code: string, name: ?string } {
-  const codeNormalized = code ? code.toUpperCase() : "ANYWHERE";
+  const codeNormalized = code ? code.toUpperCase().replace("-", "_") : "ANYWHERE";
   const countryCodeExists = codeNormalized in CODES;
 
   warning(countryCodeExists, "Country code not supported: %s", code);


### PR DESCRIPTION
When using `ca-fr` is code, the output of normalization was `anywhere` due to missing replace dash for underscore.<br/><br/><br/><url>LiveURL: https://orbit-components-fix-countryflag-normalization.surge.sh</url>