### PR TITLE
FIX: Stack default direction in breakpoints

### DIFF
--- a/src/Stack/__tests__/__snapshots__/index.test.js.snap
+++ b/src/Stack/__tests__/__snapshots__/index.test.js.snap
@@ -745,7 +745,7 @@ exports[`Default Stack should match snapshot 1`] = `
         "componentStyle": ComponentStyle {
           "componentId": "Stack__StyledStack-sc-1t576ow-0",
           "isStatic": false,
-          "lastClassName": "bRhNIq",
+          "lastClassName": "edUOUL",
           "rules": Array [
             [Function],
             ";",
@@ -16855,7 +16855,7 @@ exports[`Stack with enabled flex should match snapshot 1`] = `
           "componentStyle": ComponentStyle {
             "componentId": "Stack__StyledStack-sc-1t576ow-0",
             "isStatic": false,
-            "lastClassName": "bRhNIq",
+            "lastClassName": "edUOUL",
             "rules": Array [
               [Function],
               ";",
@@ -32885,7 +32885,7 @@ exports[`Stack with flex prop should match snapshot 1`] = `
         "componentStyle": ComponentStyle {
           "componentId": "Stack__StyledStack-sc-1t576ow-0",
           "isStatic": false,
-          "lastClassName": "bRhNIq",
+          "lastClassName": "edUOUL",
           "rules": Array [
             [Function],
             ";",

--- a/src/Stack/helpers/getDirection.js
+++ b/src/Stack/helpers/getDirection.js
@@ -2,7 +2,10 @@
 import { DIRECTIONS } from "../consts";
 import type { GetDirection } from "./getDirection";
 
-const getDirection: GetDirection = direction =>
-  Object.values(DIRECTIONS).indexOf(direction) !== -1 ? direction : DIRECTIONS.ROW;
-
+const getDirection: GetDirection = direction => {
+  if (!direction) {
+    return false;
+  }
+  return Object.values(DIRECTIONS).indexOf(direction) !== -1 ? direction : DIRECTIONS.ROW;
+};
 export default getDirection;

--- a/src/Stack/helpers/getDirection.js.flow
+++ b/src/Stack/helpers/getDirection.js.flow
@@ -1,6 +1,6 @@
 // @flow
 import type { Direction } from "../index";
 
-export type GetDirection = (direction: Direction) => string;
+export type GetDirection = (direction: Direction) => string | boolean;
 
 declare export default GetDirection;


### PR DESCRIPTION
![Screenshot 2019-04-04 at 15 04 23](https://user-images.githubusercontent.com/7566742/55558022-77e04300-56eb-11e9-999c-50f846ac0106.png)

Live URL: https://orbit-components-update-stack-spacing.surge.sh