### PR TITLE
FIX: CountryFlag warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
     "styled-components": "^4.2.0"
   },
   "dependencies": {
-    "@kiwicom/js": "^0.6.0",
     "@kiwicom/orbit-design-tokens": "^0.5.0"
   },
   "devDependencies": {

--- a/src/CountryFlag/index.js
+++ b/src/CountryFlag/index.js
@@ -54,7 +54,7 @@ export function getCountryProps(code: ?string, name: ?string): { code: string, n
   const codeNormalized = code ? code.toUpperCase().replace("-", "_") : "ANYWHERE";
   const countryCodeExists = codeNormalized in CODES;
 
-  if (!countryCodeExists && process.env.NODE_ENV !== "production") {
+  if (!countryCodeExists && process.env.NODE_ENV !== "production" && code) {
     console.warn(`Country code not supported: ${code}`);
   }
   const countryCode = countryCodeExists ? CODES[codeNormalized] : CODES.ANYWHERE;

--- a/src/CountryFlag/index.js
+++ b/src/CountryFlag/index.js
@@ -1,7 +1,6 @@
 // @flow
 import * as React from "react";
 import styled from "styled-components";
-import { warning } from "@kiwicom/js";
 import convertHexToRgba from "@kiwicom/orbit-design-tokens/lib/convertHexToRgba";
 
 import defaultTheme from "../defaultTheme";
@@ -55,7 +54,9 @@ export function getCountryProps(code: ?string, name: ?string): { code: string, n
   const codeNormalized = code ? code.toUpperCase().replace("-", "_") : "ANYWHERE";
   const countryCodeExists = codeNormalized in CODES;
 
-  warning(countryCodeExists, "Country code not supported: %s", code);
+  if (!countryCodeExists && process.env.NODE_ENV !== "production") {
+    console.warn(`Country code not supported: ${code}`);
+  }
   const countryCode = countryCodeExists ? CODES[codeNormalized] : CODES.ANYWHERE;
   const countryName = countryCode === CODES.ANYWHERE && !name ? "Anywhere" : name;
   return { code: countryCode, name: countryName };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1263,11 +1263,6 @@
     "@types/istanbul-lib-coverage" "^1.1.0"
     "@types/yargs" "^12.0.9"
 
-"@kiwicom/js@^0.6.0":
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/@kiwicom/js/-/js-0.6.0.tgz#0fd384d5a5e756a825f395f7b37baf325e768fbd"
-  integrity sha512-kNVXigH9tsGbqwkdfVTyUqutEV/yvt5DGm0zheMKHtqN5Slo22UH81RQaWgClA+rEx01iZfWUiVSkuPZDherKQ==
-
 "@kiwicom/orbit-design-tokens@^0.5.0":
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/@kiwicom/orbit-design-tokens/-/orbit-design-tokens-0.5.0.tgz#a7e20bee3b994390f6abac05bf8cf747b9d1580b"


### PR DESCRIPTION
`@kiwicom/js` is not compiled properly and it's breaking usage of `orbit-components` in IE10+.

Removed for now.<br/><br/><br/><url>LiveURL: https://orbit-components-fix-countryflag-warning.surge.sh</url>