### PR TITLE
UPDATE: Popover opened readme

### DIFF
--- a/src/Popover/README.MD
+++ b/src/Popover/README.MD
@@ -20,7 +20,7 @@ Table below contains all types of the props available in the Popover component.
 | **children**      | `React.Node`           |                 | The reference element where the Popover will appear.
 | dataTest          | `string`               |                 | Optional prop for testing purposes.
 | noPadding        | `boolean`              | `true`          | Adds or removes padding around popover's content.
-| open              | `boolean`              |                 | Prop for programatically controling Popover inner state. If `open` is present open triggers are ignored
+| opened            | `boolean`              |                 | Prop for programatically controling Popover inner state. If `opened` is present open triggers are ignored
 | preferredPosition | [`enum`](#enum)        | `"bottom"`      | The preferred position to choose [See Functional specs](#functional-specs)
 | width             | `string`               |                 | Width of popover, if not set the with is set to `auto`.
 | onClose           | `() => void \| Promise`|                 | Function for handling onClose.
@@ -38,7 +38,7 @@ Table below contains all types of the props available in the Popover component.
 
 * You can prefer one position that will be used if possible, otherwise the default order in [`enum`](#enum) table will be used.
 
-* The Popover component supports rendering of many different components inside its children. You can use combination of e.g. Text, Stack, List for example:
+* The Popover component supports rendering of many different components inside its children. You can use combination of e.g. Text, Stack, ListChoice for example:
 
 ```jsx
 <Popover


### PR DESCRIPTION
Fixing a not correct README for `opened` prop.<br/><br/><br/><url>LiveURL: https://orbit-components-update-popover-readme.surge.sh</url>