### PR TITLE
FIX: 0 value counts as valid filled value in Select

### DIFF
--- a/src/Select/Select.stories.js
+++ b/src/Select/Select.stories.js
@@ -14,6 +14,7 @@ import SPACINGS_AFTER from "../common/getSpacingToken/consts";
 import Select from "./index";
 
 const objectOptions = [
+  { value: 0, label: "Zero-th item" },
   { value: 1, label: "First item" },
   { value: 2, label: "Second item" },
   { value: 3, label: "Third item" },

--- a/src/Select/index.js
+++ b/src/Select/index.js
@@ -213,7 +213,7 @@ const Select = React.forwardRef((props: Props, ref: Ref) => {
     prefix,
     spaceAfter,
   } = props;
-  const filled = !!value;
+  const filled = !(value == null || value === "");
   return (
     <Label spaceAfter={spaceAfter}>
       {label && (
@@ -232,7 +232,7 @@ const Select = React.forwardRef((props: Props, ref: Ref) => {
           size={size}
           disabled={disabled}
           error={error}
-          value={value || ""}
+          value={value == null ? "" : value}
           prefix={prefix}
           name={name}
           onFocus={onFocus}


### PR DESCRIPTION
0 was counted as falsy when it can be a valid value.

BEFORE
<img width="1170" alt="Screenshot 2019-04-25 at 17 42 18" src="https://user-images.githubusercontent.com/22741774/56749457-10656280-6782-11e9-80e2-1ea2b884b8e9.png">


AFTER
<img width="1165" alt="Screenshot 2019-04-25 at 17 42 36" src="https://user-images.githubusercontent.com/22741774/56749476-152a1680-6782-11e9-9a86-71770c5f6402.png">
<br/><br/><br/><url>LiveURL: https://orbit-components-fix-select-0-value.surge.sh</url>