### PR TITLE
UPDATE: Add none spaceAfter option

### DIFF
--- a/src/common/getSpacingToken/README.md
+++ b/src/common/getSpacingToken/README.md
@@ -23,16 +23,17 @@ const App = () => <MyComponent spaceAfter="small" />
 ## Parameter
 This function receives one parameter - object. With usage in `styled-components` it can receive it *automatically*.
 
-| Name         | Type                     | Description                      |
-| :-------     | :----------------------- | :------------------------------- |
-| spaceAfter   | [`enum`](#enum)          | The value to be applied.
-| theme        | `typeof defaultTheme`    | Theme object with tokens and rtl.
+| Name         | Type                     | Default       | Description                      |
+| :-------     | :----------------------- | :------------ | :------------------------------- |
+| spaceAfter   | [`enum`](#enum)          | `"none"`      | The value to be applied.
+| theme        | `typeof defaultTheme`    |               | Theme object with tokens and rtl.
 
 > Please note that the *token value* in the documentation may not be up to date. Check [orbit.kiwi](https://orbit.kiwi/design-tokens/).
 
 ### enum
 | name              | used token      | token value |
 | :---------------- | :-------------- | :---------- |
+| `"none"`          | `spaceXXSmall`  | `4px`       |
 | `"smallest"`      | `spaceXXSmall`  | `4px`       |
 | `"small"`         | `spaceXSmall`   | `8px`       |
 | `"normal"`        | `spaceSmall`    | `12px`      |

--- a/src/common/getSpacingToken/README.md
+++ b/src/common/getSpacingToken/README.md
@@ -33,7 +33,7 @@ This function receives one parameter - object. With usage in `styled-components`
 ### enum
 | name              | used token      | token value |
 | :---------------- | :-------------- | :---------- |
-| `"none"`          | `spaceXXSmall`  | `4px`       |
+| `"none"`          | `spaceXXSmall`  | `null`      |
 | `"smallest"`      | `spaceXXSmall`  | `4px`       |
 | `"small"`         | `spaceXSmall`   | `8px`       |
 | `"normal"`        | `spaceSmall`    | `12px`      |

--- a/src/common/getSpacingToken/consts.js
+++ b/src/common/getSpacingToken/consts.js
@@ -1,5 +1,6 @@
 // @flow
 const SPACINGS_AFTER = {
+  NONE: "none",
   SMALLEST: "smallest",
   SMALL: "small",
   NORMAL: "normal",

--- a/src/common/getSpacingToken/index.js
+++ b/src/common/getSpacingToken/index.js
@@ -5,6 +5,7 @@ import type { Props } from ".";
 
 const getSpacingToken = ({ spaceAfter, theme }: Props) => {
   const tokens = {
+    [SPACINGS_AFTER.NONE]: "0",
     [SPACINGS_AFTER.SMALLEST]: theme.orbit.spaceXXSmall,
     [SPACINGS_AFTER.SMALL]: theme.orbit.spaceXSmall,
     [SPACINGS_AFTER.NORMAL]: theme.orbit.spaceSmall,

--- a/src/common/getSpacingToken/index.js.flow
+++ b/src/common/getSpacingToken/index.js.flow
@@ -2,7 +2,7 @@
 import defaultTheme from "../../defaultTheme";
 
 export type spaceAfter = {|
-  +spaceAfter?: "smallest" | "small" | "normal" | "medium" | "large" | "largest",
+  +spaceAfter?: "none" | "smallest" | "small" | "normal" | "medium" | "large" | "largest",
 |};
 
 export type Props = {|


### PR DESCRIPTION
Adding `none` option to `spaceAfter` prop - function, so developers can you it like this:
```jsx
<Text spaceAfter={someProperty ? "largest" : "none"} />
```

We can't use maybe type for that, as we need to support `spaceAfter` in media queries in the Stack component and it can be rendered with `null` or `undefined`.<br/><br/><br/><url>LiveURL: https://orbit-components-update-none-spaceafter.surge.sh</url>