### PR TITLE
FIX: Buttons flex for column Stack

### DIFF
--- a/src/Button/index.js
+++ b/src/Button/index.js
@@ -343,7 +343,7 @@ export const StyledButton = styled(
     block
       ? "100%"
       : (width && `${width}px`) || (onlyIcon && getSizeToken(TOKENS.heightButton)) || "auto"};
-  flex: ${({ block }) => (block ? "1 1 100%" : "0 0 auto")};
+  flex: ${({ block }) => (block ? "1 1 auto" : "0 0 auto")};
   height: ${getSizeToken(TOKENS.heightButton)};
   background: ${({ bordered }) =>
     bordered

--- a/src/ButtonLink/__tests__/__snapshots__/index.test.js.snap
+++ b/src/ButtonLink/__tests__/__snapshots__/index.test.js.snap
@@ -20,6 +20,9 @@ exports[`ButtonLink with Icon should match snapshot 1`] = `
   -ms-flex-align: center;
   align-items: center;
   width: auto;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
   height: 44px;
   background: transparent;
   color: #00a991!important;
@@ -563,11 +566,13 @@ exports[`ButtonLink with Icon should match snapshot 1`] = `
           "componentStyle": ComponentStyle {
             "componentId": "ButtonLink__StyledButtonLink-sc-14jv5cl-1",
             "isStatic": false,
-            "lastClassName": "eytoOq",
+            "lastClassName": "daKYbT",
             "rules": Array [
               "font-family:",
               [Function],
               ";box-sizing:border-box;appearance:none;display:inline-flex;justify-content:center;align-items:center;width:",
+              [Function],
+              ";flex:",
               [Function],
               ";height:",
               [Function],
@@ -2119,6 +2124,9 @@ exports[`ButtonLink with Icon should match snapshot 2`] = `
   -ms-flex-align: center;
   align-items: center;
   width: auto;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
   height: 44px;
   background: transparent;
   color: #00a991!important;
@@ -2657,6 +2665,8 @@ exports[`ButtonLink with Icon should match snapshot 2`] = `
               "font-family:",
               [Function],
               ";box-sizing:border-box;appearance:none;display:inline-flex;justify-content:center;align-items:center;width:",
+              [Function],
+              ";flex:",
               [Function],
               ";height:",
               [Function],

--- a/src/ButtonLink/index.js
+++ b/src/ButtonLink/index.js
@@ -189,6 +189,7 @@ export const StyledButtonLink = styled(
     block
       ? "100%"
       : (width && `${width}px`) || (onlyIcon && getSizeToken(TOKENS.heightButton)) || "auto"};
+  flex: ${({ block }) => (block ? "1 1 auto" : "0 0 auto")};
   height: ${getSizeToken(TOKENS.heightButton)};
   background: ${getTypeToken(TOKENS.backgroundButton)};
   color: ${getTypeToken(TOKENS.colorTextButton)}!important;


### PR DESCRIPTION
When someone used combination of `Stack` with `direction="column"` and block Button, the height was broken. https://codesandbox.io/s/orbitsandbox-izupg<br/><br/><br/><url>LiveURL: https://orbit-components-fix-buttons-stack-column.surge.sh</url>