### PR TITLE
DEV: Upgrade Flow to version 0.95.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "eslint-plugin-prettier": "^3.0.1",
     "eslint-plugin-react": "^7.7.0",
     "eslint-plugin-react-hooks": "^1.6.0",
-    "flow-bin": "^0.89.0",
+    "flow-bin": "^0.95.0",
     "fs-extra": "^7.0.1",
     "glob": "^7.1.2",
     "isomorphic-unfetch": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5534,10 +5534,10 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.0.tgz#55122b6536ea496b4b44893ee2608141d10d9916"
   integrity sha512-R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg==
 
-flow-bin@^0.89.0:
-  version "0.89.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.89.0.tgz#6bd29c2af7e0f429797f820662f33749105c32fa"
-  integrity sha512-DkO4PsXYrl53V6G5+t5HbRMC5ajYUQej2LEGPUZ+j9okTb41Sn5j9vfxsCpXMEAslYnQoysHhYu4GUZsQX/DrQ==
+flow-bin@^0.95.0:
+  version "0.95.1"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.95.1.tgz#633113831ccff4b7ee70a2730f63fc43b69ba85f"
+  integrity sha512-06IOC/pqPMNRYtC6AMZEWYR9Fi6UdBC7gImGinPuNUpPZFnP5E9/0cBCl3DWrH4zz/gSM2HdDilU7vPGpYIr2w==
 
 flush-write-stream@^1.0.0:
   version "1.1.1"


### PR DESCRIPTION
Next version throws errors but this is a good first step to bump it again to 96.

This Pull Request meets the following criteria:

* [ ] Tests have been added/adjusted for my new feature
* [ ] New Components are registered in index.js of my project
<br/><br/><br/><url>LiveURL: https://orbit-components-flow-95.surge.sh</url>