### PR TITLE
UPDATE: Alert inlineActions prop

### DIFF
--- a/src/Alert/Alert.stories.js
+++ b/src/Alert/Alert.stories.js
@@ -108,6 +108,36 @@ storiesOf("Alert", module)
     },
   )
   .add(
+    "Inline Actions",
+    () => {
+      const inlineActions = boolean("inlineActions", true);
+      const type = select("Type", Object.values(TYPE_OPTIONS), "info");
+      const title = text("Title", "You can change the title by changing the Title knob");
+      const button = text("Button", "I am a link");
+      const closable = boolean("Closable", false);
+      const Icon = getIcon(getIcons("Airplane"));
+
+      return (
+        <Alert
+          type={type}
+          icon={Icon && <Icon />}
+          title={title}
+          closable={closable}
+          onClose={action("Close")}
+          inlineActions={inlineActions}
+        >
+          <Button type={type} size="small" href="#">
+            {button}
+          </Button>
+        </Alert>
+      );
+    },
+    {
+      info:
+        "You can try all possible configurations of this component. However, check Orbit.Kiwi for more detailed design guidelines.",
+    },
+  )
+  .add(
     "Playground",
     () => {
       const type = select("Type", Object.values(TYPE_OPTIONS), "info");
@@ -121,6 +151,8 @@ storiesOf("Alert", module)
       const closable = boolean("Closable", false);
       const Icon = getIcon(getIcons("Airplane"));
       const spaceAfter = select("spaceAfter", [null, ...Object.values(SPACINGS_AFTER)]);
+      const inlineActions = boolean("inlineActions", true);
+
       return (
         <Alert
           type={type}
@@ -130,6 +162,7 @@ storiesOf("Alert", module)
           onClose={action("Close")}
           dataTest={dataTest}
           spaceAfter={spaceAfter}
+          inlineActions={inlineActions}
         >
           <Stack spacing="compact">
             <div>{message}</div>

--- a/src/Alert/Alert.stories.js
+++ b/src/Alert/Alert.stories.js
@@ -110,7 +110,6 @@ storiesOf("Alert", module)
   .add(
     "Inline Actions",
     () => {
-      const inlineActions = boolean("inlineActions", true);
       const type = select("Type", Object.values(TYPE_OPTIONS), "info");
       const title = text("Title", "You can change the title by changing the Title knob");
       const button = text("Button", "I am a link");
@@ -124,12 +123,12 @@ storiesOf("Alert", module)
           title={title}
           closable={closable}
           onClose={action("Close")}
-          inlineActions={inlineActions}
-        >
-          <Button type={type} size="small" href="#">
-            {button}
-          </Button>
-        </Alert>
+          inlineActions={
+            <Button type={type} size="small" href="#">
+              {button}
+            </Button>
+          }
+        />
       );
     },
     {
@@ -151,7 +150,6 @@ storiesOf("Alert", module)
       const closable = boolean("Closable", false);
       const Icon = getIcon(getIcons("Airplane"));
       const spaceAfter = select("spaceAfter", [null, ...Object.values(SPACINGS_AFTER)]);
-      const inlineActions = boolean("inlineActions", true);
 
       return (
         <Alert
@@ -162,7 +160,6 @@ storiesOf("Alert", module)
           onClose={action("Close")}
           dataTest={dataTest}
           spaceAfter={spaceAfter}
-          inlineActions={inlineActions}
         >
           <Stack spacing="compact">
             <div>{message}</div>

--- a/src/Alert/README.md
+++ b/src/Alert/README.md
@@ -16,6 +16,7 @@ Table below contains all types of the props available in Alert component.
 | closable      | `boolean`                       | `false`         | If `true`, the Close icon will be displayed. [See Functional specs](#functional-specs)
 | dataTest      | `string`                        |                 | Optional prop for testing purposes.
 | icon          | `React.Element<any> \| boolean` |                 | The displayed icon. [See Functional specs](#functional-specs)
+| inlineActions | `React.Node`                    |                 | Renders action to a right side of a Alert. [See Functional specs](#functional-specs)
 | onClose       | `() => void \| Promise`         |                 | Function for handling Alert onClose.
 | spaceAfter    | `enum`                          |                 | Additional `margin-bottom` after component. [See this docs](https://github.com/kiwicom/orbit-components/tree/master/src/common/getSpacingToken)
 | title         | `Translation`                   |                 | The title of the Alert.
@@ -34,3 +35,5 @@ Table below contains all types of the props available in Alert component.
 * By passing the `closable` prop into Alert, you will be able to handle `onClose` function and Close icon will be displayed. Also, if you want to select the Close Button element for testing purposes, use [data-test="AlertCloseButton"] selector.
 
 * If you set up `icon` props as `true`, Alert will have it's own icon, based on selected `type`. If you want to use different icon, just pass it to the `icon` prop as `React.Element`. Alert without `icon` prop doesn't have any icon.
+
+* Passing a `inlineActions` will cause `children` to be ignored.

--- a/src/Alert/README.md
+++ b/src/Alert/README.md
@@ -8,7 +8,7 @@ After adding import into your project you can use it simply like:
 <Alert>Hello World!</Alert>
 ```
 ## Props
-Table below contains all types of the props available in Alert component.
+The table below contains all types of the props available in Alert component.
 
 | Name          | Type                            | Default         | Description                      |
 | :------------ | :------------------------------ | :-------------- | :------------------------------- |
@@ -32,8 +32,8 @@ Table below contains all types of the props available in Alert component.
 | `"critical"`  |
 
 ## Functional specs
-* By passing the `closable` prop into Alert, you will be able to handle `onClose` function and Close icon will be displayed. Also, if you want to select the Close Button element for testing purposes, use [data-test="AlertCloseButton"] selector.
+* Bypassing the `closable` prop into Alert, you will be able to handle `onClose` function and Close icon will be displayed. Also, if you want to select the Close Button element for testing purposes, use [data-test="AlertCloseButton"] selector.
 
-* If you set up `icon` props as `true`, Alert will have it's own icon, based on selected `type`. If you want to use different icon, just pass it to the `icon` prop as `React.Element`. Alert without `icon` prop doesn't have any icon.
+* If you set up `icon` props as `true`, Alert will have its own icon, based on selected `type`. If you want to use a different icon, just pass it to the `icon` prop as `React.Element`. Alert without `icon` prop doesn't have any icon.
 
-* Passing a `inlineActions` will cause `children` to be ignored.
+* Passing a `inlineActions` will cause `children` to be ignored. `inlineActions` should be used for displaying buttons inside short alerts which only have a `title`. 

--- a/src/Alert/README.md
+++ b/src/Alert/README.md
@@ -32,7 +32,7 @@ The table below contains all types of the props available in Alert component.
 | `"critical"`  |
 
 ## Functional specs
-* Bypassing the `closable` prop into Alert, you will be able to handle `onClose` function and Close icon will be displayed. Also, if you want to select the Close Button element for testing purposes, use [data-test="AlertCloseButton"] selector.
+* By passing the `closable` prop into Alert, you will be able to handle `onClose` function and Close icon will be displayed. Also, if you want to select the Close Button element for testing purposes, use [data-test="AlertCloseButton"] selector.
 
 * If you set up `icon` props as `true`, Alert will have its own icon, based on selected `type`. If you want to use a different icon, just pass it to the `icon` prop as `React.Element`. Alert without `icon` prop doesn't have any icon.
 

--- a/src/Alert/__tests__/__snapshots__/index.test.js.snap
+++ b/src/Alert/__tests__/__snapshots__/index.test.js.snap
@@ -464,8 +464,11 @@ exports[`Alert should match snapshot 1`] = `
   }
   type="info"
 >
-  <Alert__ContentWrapper>
+  <Alert__ContentWrapper
+    inlineActions={false}
+  >
     <Alert__Content
+      inlineActions={false}
       theme={
         Object {
           "orbit": Object {

--- a/src/Alert/__tests__/__snapshots__/index.test.js.snap
+++ b/src/Alert/__tests__/__snapshots__/index.test.js.snap
@@ -468,7 +468,6 @@ exports[`Alert should match snapshot 1`] = `
     inlineActions={false}
   >
     <Alert__Content
-      inlineActions={false}
       theme={
         Object {
           "orbit": Object {

--- a/src/Alert/index.js
+++ b/src/Alert/index.js
@@ -125,6 +125,8 @@ const IconContainer = styled(StyledDiv)`
   flex-shrink: 0;
   margin: ${({ theme }) => rtlSpacing(`0 ${theme.orbit.spaceSmall} 0 0`)};
   color: ${getTypeToken(TOKENS.colorIconAlert)};
+  display: ${({ inlineActions }) => (inlineActions ? "flex" : "")};
+  align-items: ${({ inlineActions }) => (inlineActions ? "center" : "")};
 `;
 
 IconContainer.defaultProps = {
@@ -134,14 +136,16 @@ IconContainer.defaultProps = {
 const ContentWrapper = styled(StyledDiv)`
   flex: 1; // IE wrapping fix
   display: flex;
-  flex-direction: ${({ title }) => title && "column"};
+  flex-direction: ${({ title, inlineActions }) => title && (inlineActions ? "row" : "column")};
   align-items: ${({ title }) => !title && "center"};
+  justify-content: ${({ inlineActions }) => (inlineActions ? "space-between" : "")};
 `;
 
 const Title = styled(StyledDiv)`
   display: flex;
   align-items: center;
-  margin-bottom: ${({ theme, hasChildren }) => hasChildren && theme.orbit.spaceXSmall};
+  margin-bottom: ${({ theme, hasChildren, inlineActions }) =>
+    hasChildren && (inlineActions ? "0" : theme.orbit.spaceXSmall)};
   font-weight: ${({ theme }) => theme.orbit.fontWeightBold};
   line-height: ${({ theme }) => theme.orbit.lineHeightHeading};
   min-height: ${({ theme }) => theme.orbit.heightIconMedium};
@@ -153,7 +157,8 @@ Title.defaultProps = {
 
 const Content = styled(StyledDiv)`
   display: block;
-  margin-bottom: ${({ theme, title }) => title && theme.orbit.spaceXXSmall};
+  margin-bottom: ${({ theme, title, inlineActions }) =>
+    title && (inlineActions ? "0" : theme.orbit.spaceXSmall)};
   line-height: ${({ theme }) => theme.orbit.lineHeightText};
 
   & a,
@@ -198,6 +203,7 @@ const Alert = (props: Props) => {
     children,
     dataTest,
     spaceAfter,
+    inlineActions = false,
   } = props;
   return (
     <StyledAlert
@@ -208,14 +214,18 @@ const Alert = (props: Props) => {
       spaceAfter={spaceAfter}
     >
       {icon && (
-        <IconContainer type={type}>
+        <IconContainer type={type} inlineActions={inlineActions}>
           <Icon type={type} icon={icon} />
         </IconContainer>
       )}
-      <ContentWrapper title={title}>
-        {title && <Title hasChildren={children}>{title}</Title>}
+      <ContentWrapper title={title} inlineActions={inlineActions}>
+        {title && (
+          <Title hasChildren={children} inlineActions={inlineActions}>
+            {title}
+          </Title>
+        )}
         {children && (
-          <Content title={title} type={type}>
+          <Content title={title} type={type} inlineActions={inlineActions}>
             {children}
           </Content>
         )}

--- a/src/Alert/index.js
+++ b/src/Alert/index.js
@@ -125,8 +125,8 @@ const IconContainer = styled(StyledDiv)`
   flex-shrink: 0;
   margin: ${({ theme }) => rtlSpacing(`0 ${theme.orbit.spaceSmall} 0 0`)};
   color: ${getTypeToken(TOKENS.colorIconAlert)};
-  display: ${({ inlineActions }) => (inlineActions ? "flex" : "")};
-  align-items: ${({ inlineActions }) => (inlineActions ? "center" : "")};
+  display: ${({ inlineActions }) => inlineActions && "flex"};
+  align-items: ${({ inlineActions }) => inlineActions && "center"};
 `;
 
 IconContainer.defaultProps = {
@@ -138,7 +138,7 @@ const ContentWrapper = styled(StyledDiv)`
   display: flex;
   flex-direction: ${({ title, inlineActions }) => title && (inlineActions ? "row" : "column")};
   align-items: ${({ title }) => !title && "center"};
-  justify-content: ${({ inlineActions }) => (inlineActions ? "space-between" : "")};
+  justify-content: ${({ inlineActions }) => inlineActions && "space-between"};
 `;
 
 const Title = styled(StyledDiv)`

--- a/src/Alert/index.js
+++ b/src/Alert/index.js
@@ -224,9 +224,14 @@ const Alert = (props: Props) => {
             {title}
           </Title>
         )}
-        {children && (
-          <Content title={title} type={type} inlineActions={inlineActions}>
+        {children && !inlineActions && (
+          <Content title={title} type={type}>
             {children}
+          </Content>
+        )}
+        {inlineActions && (
+          <Content title={title} type={type} inlineActions={inlineActions}>
+            {inlineActions}
           </Content>
         )}
       </ContentWrapper>

--- a/src/Alert/index.js.flow
+++ b/src/Alert/index.js.flow
@@ -13,7 +13,7 @@ export type Props = {|
   +title?: Translation,
   +icon?: React$Element<any> | boolean,
   +closable?: boolean,
-  +inlineActions?: boolean,
+  +inlineActions?: React$Node,
   +onClose?: () => void | Promise<any>,
   ...Globals,
   ...spaceAfter,

--- a/src/Alert/index.js.flow
+++ b/src/Alert/index.js.flow
@@ -13,6 +13,7 @@ export type Props = {|
   +title?: Translation,
   +icon?: React$Element<any> | boolean,
   +closable?: boolean,
+  +inlineActions?: boolean,
   +onClose?: () => void | Promise<any>,
   ...Globals,
   ...spaceAfter,


### PR DESCRIPTION
Adding `inlinActions` prop for cases where there is only a heading and displaying a button under heading wouldn't look ideal.<br/><br/><br/><url>LiveURL: https://orbit-components-update-alert-inline.surge.sh</url>