### PR TITLE
DOCS: Fix Stack shrink and Layout examples 

### DIFF
--- a/src/Layout/README.md
+++ b/src/Layout/README.md
@@ -44,7 +44,7 @@ To implement the Search layout into your project, you need to use this JSX marku
 import Layout, { LayoutColumn } from "@kiwicom/orbit-components/lib/Layout";
 
 const App = () => (
-  <Layout>
+  <Layout type="Search">
     <LayoutColumn>
       The left SideBar for filters
     </LayoutColumn>
@@ -70,7 +70,7 @@ To implement the Booking layout into your project, you need to use this JSX mark
 import Layout, { LayoutColumn } from "@kiwicom/orbit-components/lib/Layout";
 
 const App = () => (
-  <Layout>
+  <Layout type="Booking">
     <LayoutColumn>
       The main section for Booking form
     </LayoutColumn>
@@ -89,7 +89,7 @@ To implement the MMB layout into your project, you need to use this JSX markup:
 import Layout, { LayoutColumn } from "@kiwicom/orbit-components/lib/Layout";
 
 const App = () => (
-  <Layout>
+  <Layout type="MMB">
     <LayoutColumn>
       The main section for ManageMyBooking
     </LayoutColumn>

--- a/src/Stack/README.md
+++ b/src/Stack/README.md
@@ -28,7 +28,7 @@ Table below contains all types of the props available in Stack component.
 | largeDesktop  | [`Object`](#media-queries)  |              | Object for setting up properties for the largeDesktop viewport. [See Media queries](#media-queries)
 | largeMobile   | [`Object`](#media-queries)  |              | Object for setting up properties for the largeMobile viewport. [See Media queries](#media-queries)
 | mediumMobile  | [`Object`](#media-queries)  |              | Object for setting up properties for the mediumMobile viewport. [See Media queries](#media-queries)
-| shrink        | `boolean`                   | `true`       | If `false`, the Stack will have `flex-shrink` set to `0`.
+| shrink        | `boolean`                   | `false`      | If `false`, the Stack will have `flex-shrink` set to `0`.
 | spacing       | [`spacing`](#spacing)       | `"natural"`  | The spacing between its children.
 | spaceAfter    | `enum`                      |              | Additional `padding` to bottom of the Stack. [See this doc](https://github.com/kiwicom/orbit-components/tree/master/src/common/getSpacingToken)
 | tablet        | [`Object`](#media-queries)  |              | Object for setting up properties for the tablet viewport. [See Media queries](#media-queries)

--- a/src/Stack/README.md
+++ b/src/Stack/README.md
@@ -28,7 +28,7 @@ Table below contains all types of the props available in Stack component.
 | largeDesktop  | [`Object`](#media-queries)  |              | Object for setting up properties for the largeDesktop viewport. [See Media queries](#media-queries)
 | largeMobile   | [`Object`](#media-queries)  |              | Object for setting up properties for the largeMobile viewport. [See Media queries](#media-queries)
 | mediumMobile  | [`Object`](#media-queries)  |              | Object for setting up properties for the mediumMobile viewport. [See Media queries](#media-queries)
-| shrink        | `boolean`                   | `false`      | If `false`, the Stack will have `flex-shrink` set to `0`.
+| shrink        | `boolean`                   | `false`      | If `true`, the Stack will have `flex-shrink` set to `1`.
 | spacing       | [`spacing`](#spacing)       | `"natural"`  | The spacing between its children.
 | spaceAfter    | `enum`                      |              | Additional `padding` to bottom of the Stack. [See this doc](https://github.com/kiwicom/orbit-components/tree/master/src/common/getSpacingToken)
 | tablet        | [`Object`](#media-queries)  |              | Object for setting up properties for the tablet viewport. [See Media queries](#media-queries)


### PR DESCRIPTION
There was a wrong default in `Stack` `shrink` prop. And `Layout` missed proper `type` prop in readme.<br/><br/><br/><url>LiveURL: https://orbit-components-update-doc-fixes.surge.sh</url>