### PR TITLE
UPDATE: Deprecate connected prop in ButtonGroup

### DIFF
--- a/src/ButtonGroup/ButtonGroup.stories.js
+++ b/src/ButtonGroup/ButtonGroup.stories.js
@@ -20,7 +20,7 @@ storiesOf("ButtonGroup", module)
       return (
         <ButtonGroup connected={connected} dataTest={dataTest}>
           <Button icon={<Icons.Airplane />}>Button</Button>
-          <Button icon={<Icons.ChevronDown />} />
+          <Button icon={<Icons.ChevronDown />} title="Show more" />
         </ButtonGroup>
       );
     },
@@ -39,7 +39,7 @@ storiesOf("ButtonGroup", module)
           <ButtonLink type="secondary" icon={<Icons.Airplane />}>
             Button
           </ButtonLink>
-          <ButtonLink type="secondary" icon={<Icons.ChevronDown />} />
+          <ButtonLink type="secondary" icon={<Icons.ChevronDown />} title="Show more" />
         </ButtonGroup>
       );
     },
@@ -54,7 +54,7 @@ storiesOf("ButtonGroup", module)
       <RenderInRtl>
         <ButtonGroup connected>
           <Button icon={<Icons.Airplane />}>Button</Button>
-          <Button icon={<Icons.ChevronDown />} />
+          <Button icon={<Icons.ChevronDown />} title="Show more" />
         </ButtonGroup>
       </RenderInRtl>
     ),

--- a/src/ButtonGroup/index.js
+++ b/src/ButtonGroup/index.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from "react";
 import styled from "styled-components";
+import { warning } from "@kiwicom/js";
 
 import defaultTheme from "../defaultTheme";
 import { StyledButtonLink } from "../ButtonLink";
@@ -38,10 +39,16 @@ StyledButtonGroup.defaultProps = {
   theme: defaultTheme,
 };
 
-const ButtonGroup = ({ children, connected, dataTest }: Props) => (
-  <StyledButtonGroup connected={connected} data-test={dataTest}>
-    {children}
-  </StyledButtonGroup>
-);
+const ButtonGroup = ({ children, connected, dataTest }: Props) => {
+  warning(
+    !connected,
+    "Warning: connected property of ButtonGroup component is deprecated. In the next major release, the connected variant will be the default. For unconnected variant, please use Stack component. Check https://orbit.kiwi/roadmap/road-to-1-0-0/#buttongroup-component for more information",
+  );
+  return (
+    <StyledButtonGroup connected={connected} data-test={dataTest}>
+      {children}
+    </StyledButtonGroup>
+  );
+};
 
 export default ButtonGroup;


### PR DESCRIPTION
Added deprecation warning for usage `connected` property of ButtonGroup.<br/><br/><br/><url>LiveURL: https://orbit-components-update-buttongroup-connected.surge.sh</url>