### PR TITLE
FIX: Invisible tags inside InputField on iOS

### DIFF
--- a/src/InputField/InputTags/index.js
+++ b/src/InputField/InputTags/index.js
@@ -9,6 +9,7 @@ import { StyledTag } from "../../Tag";
 import type { Props } from "./index";
 
 const StyledInputTags = styled.div`
+  position: relative;
   margin: ${({ theme }) => rtlSpacing(`0 0 0 ${theme.orbit.spaceSmall}`)};
   display: flex;
   align-items: center;


### PR DESCRIPTION
Fix for bug on iOS devices, when tags inside `InputField` are not visible.

https://monosnap.com/file/Urm4Rj5hzNwiVhlZG12PIXcCVI9zfY

Problem is not present on all devices (it doesn't appear for example on 6th gen iPad), but can be replicated on iPad Air 2 (physical which is used by QA for testing or configuration below available on browserstack.com ).
https://monosnap.com/file/kSoUOhDlaLslUAKHmusNlHJsLfGcxH
https://monosnap.com/file/pX1pN2yp72kIuQcPqT2CTPvbGgWQfF<br/><br/><br/><url>LiveURL: https://orbit-components-fix-inputfield-tags-ios.surge.sh</url>