### PR TITLE
UPDATE: Modal click outside condition

### DIFF
--- a/src/Modal/index.js
+++ b/src/Modal/index.js
@@ -477,8 +477,9 @@ export class PureModal extends React.PureComponent<Props & ThemeProps, State> {
     if (
       onClose &&
       this.modalContent?.current &&
-      ev.target instanceof Node &&
-      !this.modalContent.current.contains(ev.target)
+      ev.target instanceof Element &&
+      !this.modalContent.current.contains(ev.target) &&
+      /ModalBody|ModalWrapper/.test(ev.target.className)
     ) {
       // If is clicked outside of modal
       onClose(ev);


### PR DESCRIPTION
Limiting `Modal` click outside functionality only to `ModalBody` and `ModalWrapper`.
To prevent modal from closing in special cases when content is nested inside modal, but added to DOM using Portals (Modals, Notifications...).

More in Slack discussion: https://skypicker.slack.com/archives/CAMS40F7B/p1559045983010400<br/><br/><br/><url>LiveURL: https://orbit-components-update-modal-click-outside.surge.sh</url>