### PR TITLE
DOCS: Fixing wrong escape in pagination

### DIFF
--- a/src/Pagination/README.md
+++ b/src/Pagination/README.md
@@ -18,7 +18,7 @@ Table below contains all types of the props available in the Pagination componen
 | **onPageChange ** | `func`            |                 | Function for handling onPageChange event. [See Functional specs](#functional-specs)
 | **pageCount**     | `number`          |                 | The page count to render into separated buttons. [See Functional specs](#functional-specs)
 | selectedPage      | `number`          | `1`             | The index number of the selected page.
-| size              | [`enum`](#enum)`  | `"normal"`      | The size of the Pagination.
+| size              | [`enum`](#enum)   | `"normal"`      | The size of the Pagination.
 
 ### enum
 


### PR DESCRIPTION
<br/><br/><br/><url>LiveURL: https://orbit-components-docs-pagination-escape.surge.sh</url>