### PR TITLE
UPDATE: required field accessibility

### DIFF
--- a/src/FormLabel/index.js
+++ b/src/FormLabel/index.js
@@ -18,7 +18,11 @@ StyledAsterisk.defaultProps = {
 
 const FormLabel = styled(({ className, children, required, filled, dataTest, id }) => (
   <span className={className} data-test={dataTest} id={id}>
-    {required && <StyledAsterisk filled={filled}>* </StyledAsterisk>}
+    {required && (
+      <StyledAsterisk aria-hidden="true" filled={filled}>
+        *{" "}
+      </StyledAsterisk>
+    )}
     <span>{children}</span>
   </span>
 ))`


### PR DESCRIPTION
Adding `aria-hidden` to asterisk in label of a required input field. To prevent screen readers reading a label as "Star label".<br/><br/><br/><url>LiveURL: https://orbit-components-update-required-fields-accessibility.surge.sh</url>