### PR TITLE
FIX: Anchor in Alert font weight

### DIFF
--- a/src/TextLink/index.js
+++ b/src/TextLink/index.js
@@ -55,6 +55,7 @@ export const getLinkStyle = ({
         ? theme.orbit.textDecorationTextLinkSecondary
         : theme.orbit.textDecorationTextLinkPrimary
     };
+      font-weight: ${theme.orbit.fontWeightLinks};
   }
 
   &:hover, &:active {


### PR DESCRIPTION
When someone used generic `anchor` and not `TextLink` inside Alert's children, there was default font-weight, but should be `500 - fontWeightLinks`.<br/><br/><br/><url>LiveURL: https://orbit-components-fix-alert-anchor-font-weight.surge.sh</url>