### PR TITLE
DOCS: Fix default name in CountryFlag

### DIFF
--- a/src/CountryFlag/README.md
+++ b/src/CountryFlag/README.md
@@ -14,7 +14,7 @@ Table below contains all types of the props available in CountryFlag component.
 | :------------ | :------------------------------- | :-------------- | :------------------------------- |
 | code          | [`enum`](#enum)                  | `"anywhere"`    | Code for the displayed country flag.
 | dataTest      | `string`                         |                 | Optional prop for testing purposes.
-| name          | `string`                         | `"medium"`      | The name for the flag.
+| name          | `string`                         |                 | The name for the flag.
 
 ### enum
 If code doesn't exist "anywhere" will be used


### PR DESCRIPTION
<br/><br/><br/><url>LiveURL: https://orbit-components-docs-fix-countryflag.surge.sh</url>