### PR TITLE
FIX: Multiple Popovers close and open

### DIFF
--- a/src/Popover/Popover.stories.js
+++ b/src/Popover/Popover.stories.js
@@ -217,6 +217,29 @@ storiesOf("Popover", module)
     },
   )
   .add(
+    "Multiple Popovers",
+    () => {
+      return (
+        <Stack flex>
+          <Popover content={overlappedContent} onOpen={action("open")} onClose={action("close")}>
+            <Button type="secondary" iconRight={<ChevronDown />}>
+              Open popover
+            </Button>
+          </Popover>
+          <Popover content={overlappedContent} onOpen={action("open")} onClose={action("close")}>
+            <Button type="secondary" iconRight={<ChevronDown />}>
+              Open popover
+            </Button>
+          </Popover>
+        </Stack>
+      );
+    },
+    {
+      info:
+        "You can try all possible configurations of this component. However, check Orbit.Kiwi for more detailed design guidelines.",
+    },
+  )
+  .add(
     "Playground",
     () => {
       const dataTest = text("dataTest", "test");

--- a/src/Popover/__tests__/__snapshots__/index.test.js.snap
+++ b/src/Popover/__tests__/__snapshots__/index.test.js.snap
@@ -3,7 +3,6 @@
 exports[`ContentWrapper it should match snapshot 1`] = `
 <Fragment>
   <ContentWrapper__StyledOverlay
-    onClick={[Function]}
     shown={true}
     theme={
       Object {
@@ -486,7 +485,6 @@ exports[`ContentWrapper it should match snapshot 1`] = `
     containerLeft={0}
     containerTop={0}
     containerWidth={0}
-    onClick={[Function]}
     popoverHeight={0}
     popoverWidth={0}
     position={null}

--- a/src/Popover/components/ContentWrapper.js
+++ b/src/Popover/components/ContentWrapper.js
@@ -1,5 +1,5 @@
 // @flow
-import React, { useRef, useEffect, useCallback } from "react";
+import React, { useRef, useEffect } from "react";
 import styled, { css } from "styled-components";
 
 import defaultTheme from "../../defaultTheme";
@@ -14,6 +14,7 @@ import type { Props } from "./ContentWrapper.js.flow";
 import useDimensions from "../hooks/useDimensions";
 import Translate from "../../Translate";
 import transition from "../../utils/transition";
+import useClickOutside from "../../hooks/useClickOutside";
 
 const StyledPopoverParent = styled.div`
   position: fixed;
@@ -69,7 +70,7 @@ const StyledOverlay = styled.div`
   z-index: 999;
 
   ${media.largeMobile(css`
-    background-color: transparent;
+    display: none;
   `)};
 `;
 StyledOverlay.defaultProps = {
@@ -109,17 +110,6 @@ const PopoverContentWrapper = ({
   const verticalPosition = calculateVerticalPosition(position[0], dimensions);
   const horizontalPosition = calculateHorizontalPosition(position[1], dimensions);
 
-  const handleClick = useCallback(
-    (ev: SyntheticEvent<HTMLElement>) => {
-      ev.stopPropagation();
-
-      if (ev.target === overlay.current) {
-        onClose();
-      }
-    },
-    [onClose],
-  );
-
   useEffect(() => {
     const timer = setTimeout(() => {
       if (popover.current) {
@@ -129,9 +119,11 @@ const PopoverContentWrapper = ({
     return () => clearTimeout(timer);
   }, []);
 
+  useClickOutside(popover, onClose);
+
   return (
     <React.Fragment>
-      <StyledOverlay ref={overlay} onClick={handleClick} shown={shown} />
+      <StyledOverlay ref={overlay} shown={shown} />
       <StyledPopoverParent
         shownMobile={shown}
         shown={shown && verticalPosition && horizontalPosition}
@@ -145,7 +137,6 @@ const PopoverContentWrapper = ({
         popoverWidth={dimensions.popoverWidth}
         width={width}
         ref={popover}
-        onClick={handleClick}
         tabIndex="0"
         data-test={dataTest}
         noPadding={noPadding}

--- a/src/hooks/useClickOutside.js
+++ b/src/hooks/useClickOutside.js
@@ -1,0 +1,22 @@
+// @flow
+import { useEffect } from "react";
+
+import type { UseClickOutside } from "./useClickOutside";
+
+const useClickOutside: UseClickOutside = (ref, handler) => {
+  useEffect(() => {
+    const handleClose = event => {
+      if (ref.current && !ref.current.contains(event.target)) {
+        handler(event);
+      }
+    };
+    window.addEventListener("mousedown", handleClose);
+    window.addEventListener("touchstart", handleClose);
+    return () => {
+      window.removeEventListener("mousedown", handleClose);
+      window.removeEventListener("touchstart", handleClose);
+    };
+  }, [handler, ref]);
+};
+
+export default useClickOutside;

--- a/src/hooks/useClickOutside.js.flow
+++ b/src/hooks/useClickOutside.js.flow
@@ -1,0 +1,7 @@
+// @flow
+export type UseClickOutside = (
+  ref: { current: ?HTMLElement },
+  handler: (ev: Event) => void,
+) => void;
+
+declare export default UseClickOutside;


### PR DESCRIPTION
Fixed case where user had to firstly close first Popover and then open the second one. Now works with one click.<br/><br/><br/><url>LiveURL: https://orbit-components-fix-multiple-popovers-close-open.surge.sh</url>