### PR TITLE
BREAKING CHANGE: Changing width property of Button and ButtonLink to string

### DIFF
--- a/src/Button/Button.stories.js
+++ b/src/Button/Button.stories.js
@@ -2,7 +2,7 @@
 import * as React from "react";
 import { storiesOf } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
-import { text, number, boolean, select } from "@storybook/addon-knobs";
+import { text, boolean, select } from "@storybook/addon-knobs";
 
 import * as Icons from "../icons";
 import { TYPE_OPTIONS, SIZE_OPTIONS } from "./consts";

--- a/src/Button/Button.stories.js
+++ b/src/Button/Button.stories.js
@@ -233,7 +233,7 @@ storiesOf("Button", module)
       const fullWidth = boolean("fullWidth", false);
       const type = select("Type", Object.values(TYPE_OPTIONS), "primary");
       const size = select("Size", Object.values(SIZE_OPTIONS), "normal");
-      const width = number("Width", 0);
+      const width = text("Width", null);
       const bordered = boolean("Bordered", false);
       const circled = boolean("Circled", false);
       const loading = boolean("Loading", false);

--- a/src/Button/README.md
+++ b/src/Button/README.md
@@ -42,7 +42,7 @@ Table below contains all types of the props available in Button component.
 | tabIndex     | `string`                   |             | Specifies the tab order of an element.                                                                                                          |
 | title        | `string`                   |             | Adds `aria-label`.                                                                                                                              |
 | **type**     | [`enum`](#enum)            | `"primary"` | The type of Button.                                                                                                                             |
-| width        | `number`                   | `0`         | The width of the Button. Number is defined in `px`.                                                                                             |
+| width        | `string`                   | `0`         | The width of the Button. Number is defined in `px`.                                                                                             |
 
 ### enum
 

--- a/src/Button/index.js
+++ b/src/Button/index.js
@@ -101,9 +101,7 @@ export const StyledButton = styled(
   appearance: none;
   text-decoration: none;
   width: ${({ fullWidth, width, onlyIcon }) =>
-    fullWidth
-      ? "100%"
-      : width || (onlyIcon && getSizeToken(TOKENS.heightButton)) || "auto"};
+    fullWidth ? "100%" : width || (onlyIcon && getSizeToken(TOKENS.heightButton)) || "auto"};
   flex: ${({ fullWidth }) => (fullWidth ? "1 1 auto" : "0 0 auto")};
   max-width: 100%; // to ensure that Buttons content wraps in IE
   height: ${getSizeToken(TOKENS.heightButton)};

--- a/src/Button/index.js
+++ b/src/Button/index.js
@@ -103,7 +103,7 @@ export const StyledButton = styled(
   width: ${({ fullWidth, width, onlyIcon }) =>
     fullWidth
       ? "100%"
-      : (width && `${width}px`) || (onlyIcon && getSizeToken(TOKENS.heightButton)) || "auto"};
+      : width || (onlyIcon && getSizeToken(TOKENS.heightButton)) || "auto"};
   flex: ${({ fullWidth }) => (fullWidth ? "1 1 auto" : "0 0 auto")};
   max-width: 100%; // to ensure that Buttons content wraps in IE
   height: ${getSizeToken(TOKENS.heightButton)};
@@ -221,7 +221,7 @@ const Button = React.forwardRef<Props, HTMLButtonElement>((props, ref) => {
     type = TYPE_OPTIONS.PRIMARY,
     fullWidth,
     loading = false,
-    width = 0,
+    width,
     role,
     onClick,
     circled,

--- a/src/Button/index.js.flow
+++ b/src/Button/index.js.flow
@@ -37,7 +37,7 @@ export type Props = {|
   +loading?: boolean,
   +type?: Type,
   +size?: Size,
-  +width?: number,
+  +width?: string,
   +submit?: boolean,
   +icon?: React.Node,
   +iconLeft?: React.Node,

--- a/src/ButtonLink/ButtonLink.stories.js
+++ b/src/ButtonLink/ButtonLink.stories.js
@@ -3,7 +3,7 @@
 import * as React from "react";
 import { storiesOf } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
-import { text, number, boolean, select } from "@storybook/addon-knobs";
+import { text, boolean, select } from "@storybook/addon-knobs";
 
 import * as Icons from "../icons";
 import { TYPES, SIZES } from "./consts";

--- a/src/ButtonLink/ButtonLink.stories.js
+++ b/src/ButtonLink/ButtonLink.stories.js
@@ -64,7 +64,7 @@ storiesOf("ButtonLink", module)
       const fullWidth = boolean("fullWidth", false);
       const type = select("Type", Object.values(TYPES), TYPES.SECONDARY);
       const size = select("Size", Object.values(SIZES), SIZES.LARGE);
-      const width = number("Width", 0);
+      const width = text("Width", null);
       const IconLeft = getIcon(getIcons("iconLeft", "Airplane"));
       const IconRight = getIcon(getIcons("iconRight", "ChevronDown"));
       const href = text("Href", "");

--- a/src/ButtonLink/README.md
+++ b/src/ButtonLink/README.md
@@ -41,7 +41,7 @@ Table below contains all types of the props available in ButtonLink component.
 | transparent  | `boolean`                  | `false`     | If `true`, the ButtonLink will not have `:hover` and `:active` state.                                                                           |
 | title        | `string`                   |             | Adds `aria-label`.                                                                                                                              |
 | **type**     | [`enum`](#enum)            | `"primary"` | The type of ButtonLink.                                                                                                                         |
-| width        | `number`                   | `0`         | The width of the ButtonLink. Number is defined in `px`.                                                                                         |
+| width        | `string`                   | `0`         | The width of the ButtonLink. Number is defined in `px`.                                                                                         |
 
 ### enum
 

--- a/src/ButtonLink/index.js
+++ b/src/ButtonLink/index.js
@@ -97,7 +97,7 @@ export const StyledButtonLink = styled(
   width: ${({ fullWidth, width, onlyIcon }) =>
     fullWidth
       ? "100%"
-      : (width && `${width}px`) || (onlyIcon && getSizeToken(TOKENS.heightButton)) || "auto"};
+      : width || (onlyIcon && getSizeToken(TOKENS.heightButton)) || "auto"};
   flex: ${({ fullWidth }) => (fullWidth ? "1 1 auto" : "0 0 auto")};
   max-width: 100%; // to ensure that Buttons content wraps in IE
   height: ${getSizeToken(TOKENS.heightButton)};
@@ -170,7 +170,7 @@ const ButtonLink = React.forwardRef<Props, HTMLButtonElement>((props, ref) => {
     iconRight,
     type = TYPES.PRIMARY,
     onClick,
-    width = 0,
+    width,
     role,
     disabled,
     circled,

--- a/src/ButtonLink/index.js
+++ b/src/ButtonLink/index.js
@@ -95,9 +95,7 @@ export const StyledButtonLink = styled(
   justify-content: center;
   align-items: center;
   width: ${({ fullWidth, width, onlyIcon }) =>
-    fullWidth
-      ? "100%"
-      : width || (onlyIcon && getSizeToken(TOKENS.heightButton)) || "auto"};
+    fullWidth ? "100%" : width || (onlyIcon && getSizeToken(TOKENS.heightButton)) || "auto"};
   flex: ${({ fullWidth }) => (fullWidth ? "1 1 auto" : "0 0 auto")};
   max-width: 100%; // to ensure that Buttons content wraps in IE
   height: ${getSizeToken(TOKENS.heightButton)};

--- a/src/ButtonLink/index.js.flow
+++ b/src/ButtonLink/index.js.flow
@@ -23,7 +23,7 @@ export type Props = {|
   +type?: Type,
   +size?: Size,
   +href?: string,
-  +width?: number,
+  +width?: string,
   +icon?: React$Node,
   +iconLeft?: React$Node,
   +iconRight?: React$Node,


### PR DESCRIPTION
Migration guides:
Please instead of `width={150}` use `width="150px"`.
<br/><br/><br/><url>LiveURL: https://orbit-components-breaking-button-width.surge.sh</url>