### PR TITLE
FIX: Popover scroll on desktop on IE

### DIFF
--- a/src/Popover/components/ContentWrapper.js
+++ b/src/Popover/components/ContentWrapper.js
@@ -48,6 +48,7 @@ const StyledPopoverParent = styled.div`
     opacity: ${({ shown }) => (shown ? "1" : "0")};
     transform: none;
     border-radius: ${({ theme }) => theme.orbit.borderRadiusNormal};
+    overflow: auto;
 
     ${resolvePopoverPosition}
     ${resolvePopoverHorizontal}


### PR DESCRIPTION
Disabled overflow on desktop so scrollbar won't appear on Windows.