### PR TITLE
FIX: CountryFlag dimensions in Buttons

### DIFF
--- a/src/Button/index.js
+++ b/src/Button/index.js
@@ -40,7 +40,7 @@ const IconContainer = styled(({ className, children }) => (
   transition: background ${({ theme }) => theme.orbit.durationFast} ease-in-out,
     box-shadow ${({ theme }) => theme.orbit.durationFast} ease-in-out;
 
-  > * {
+  > svg {
     width: ${({ sizeIcon }) => getSize(sizeIcon)};
     height: ${({ sizeIcon }) => getSize(sizeIcon)};
   }

--- a/src/ButtonLink/__tests__/__snapshots__/index.test.js.snap
+++ b/src/ButtonLink/__tests__/__snapshots__/index.test.js.snap
@@ -2231,7 +2231,7 @@ exports[`ButtonLink with Icon should match snapshot 2`] = `
   margin: 0 8px 0 0;
 }
 
-.c2 > * {
+.c2 > svg {
   width: 24px;
   height: 24px;
 }
@@ -2255,7 +2255,7 @@ exports[`ButtonLink with Icon should match snapshot 2`] = `
   margin: 0 0 0 8px;
 }
 
-.c5 > * {
+.c5 > svg {
   width: 24px;
   height: 24px;
 }
@@ -4892,7 +4892,7 @@ exports[`ButtonLink with Icon should match snapshot 2`] = `
                           "rules": Array [
                             "display:flex;flex-direction:row;align-items:center;justify-content:center;margin:",
                             [Function],
-                            ";> *{width:",
+                            ";> svg{width:",
                             [Function],
                             ";height:",
                             [Function],
@@ -8836,7 +8836,7 @@ exports[`ButtonLink with Icon should match snapshot 2`] = `
                           "rules": Array [
                             "display:flex;flex-direction:row;align-items:center;justify-content:center;margin:",
                             [Function],
-                            ";> *{width:",
+                            ";> svg{width:",
                             [Function],
                             ";height:",
                             [Function],

--- a/src/ButtonLink/index.js
+++ b/src/ButtonLink/index.js
@@ -35,7 +35,7 @@ const IconContainer = styled(({ className, children }) => (
   justify-content: center;
   margin: ${getIconSpacing()};
 
-  > * {
+  > svg {
     width: ${({ sizeIcon }) => getSize(sizeIcon)};
     height: ${({ sizeIcon }) => getSize(sizeIcon)};
   }


### PR DESCRIPTION
When `CountryFlag` was passed into `ButtonLink` or `Button` it was stretched due to old selector.<br/><br/><br/><url>LiveURL: https://orbit-components-fix-countryflag-in-buttons.surge.sh</url>