### PR TITLE
DOCS: Fix enum in FeatureIcon

### DIFF
--- a/src/FeatureIcon/README.md
+++ b/src/FeatureIcon/README.md
@@ -17,7 +17,7 @@ Table below contains all types of the props available in the FeatureIcon compone
 
 ### enum
 
-| code                |
+| name                |
 | :------------------ |
 | `"TicketFlexi"`     |
 | `"TicketSaver"`     |


### PR DESCRIPTION
<br/><br/><br/><url>LiveURL: https://orbit-components-docs-fix-featureicon.surge.sh</url>