### PR TITLE
FIX: ModalFooter cloning child with ref

### DIFF
--- a/src/Modal/ModalFooter/index.js
+++ b/src/Modal/ModalFooter/index.js
@@ -97,15 +97,17 @@ class ModalFooter extends React.PureComponent<Props> {
         return (
           <StyledChild flex={getChildFlex(key)}>
             {React.cloneElement(child, {
-              ref: node => {
-                // Call the original ref, if any
-                const { ref } = child;
-                if (typeof ref === "function") {
-                  ref(node);
-                } else if (ref !== null) {
-                  ref.current = node;
-                }
-              },
+              ref: child.ref
+                ? node => {
+                    // Call the original ref, if any
+                    const { ref } = child;
+                    if (typeof ref === "function") {
+                      ref(node);
+                    } else if (ref !== null) {
+                      ref.current = node;
+                    }
+                  }
+                : null,
             })}
           </StyledChild>
         );


### PR DESCRIPTION
Close #1344<br/><br/><br/><url>LiveURL: https://orbit-components-fix-modalfooter-ref.surge.sh</url>