### PR TITLE
FIX: Tooltip children wrapper set to inline-flex

### DIFF
--- a/src/Radio/Radio.stories.js
+++ b/src/Radio/Radio.stories.js
@@ -7,6 +7,9 @@ import { text, boolean } from "@storybook/addon-knobs";
 import Text from "../Text";
 import TextLink from "../TextLink";
 import RenderInRtl from "../utils/rtl/RenderInRtl";
+import Stack from "../Stack";
+import Tooltip from "../Tooltip";
+import Airplane from "../icons/Airplane";
 
 import Radio from "./index";
 
@@ -48,6 +51,32 @@ storiesOf("Radio", module)
           }
           checked={checked}
           value="value"
+          onChange={action("changed")}
+        />
+      );
+    },
+    {
+      info: "Additionally you can add info to this component.",
+    },
+  )
+  .add(
+    "With stack and icon",
+    () => {
+      const label = text("Label", "Label");
+      const value = text("Value", "value");
+      const info = text("Info", "Additional information to this choice");
+      return (
+        <Radio
+          label={
+            <Stack align="center">
+              <Text size="small">{label}</Text>
+              <Tooltip content="Tooltip content">
+                <Airplane size="small" />
+              </Tooltip>
+            </Stack>
+          }
+          value={value}
+          info={info}
           onChange={action("changed")}
         />
       );

--- a/src/Tooltip/index.js
+++ b/src/Tooltip/index.js
@@ -15,7 +15,7 @@ import useStateWithTimeout from "../hooks/useStateWithTimeout";
 import type { Props } from "./index";
 
 const StyledTooltipChildren = styled.span`
-  display: inline-block;
+  display: inline-flex;
   &:focus:active {
     outline: none;
   }


### PR DESCRIPTION
Changing from inline-block to inline-flex due to Icon not being aligned vertically in center<br/><br/><br/><url>LiveURL: https://orbit-components-fix-radio-icon.surge.sh</url>