### PR TITLE
FIX: ChoiceGroup filter hover and focus

### DIFF
--- a/src/ChoiceGroup/components/FilterWrapper.js
+++ b/src/ChoiceGroup/components/FilterWrapper.js
@@ -23,6 +23,7 @@ const StyledContentWrapper = styled.div`
   display: flex;
   align-items: center;
 
+  /* NOTE: Combined selector &:hover, &:focus-within is not ussable here as it renders incorectly in IE and EDGE */
   &:hover {
     ${hoverAndFocus}
   }

--- a/src/ChoiceGroup/components/FilterWrapper.js
+++ b/src/ChoiceGroup/components/FilterWrapper.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from "react";
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 
 import type { FilterWrapperType } from "./FilterWrapper.js.flow";
 import defaultTheme from "../../defaultTheme";
@@ -8,6 +8,14 @@ import ButtonLink from "../../ButtonLink";
 
 const StyledOnlyButton = styled(ButtonLink)``;
 
+const hoverAndFocus = () => css`
+  background-color: ${({ theme }) => theme.orbit.paletteProductLight};
+
+  ${StyledOnlyButton} {
+    visibility: visible;
+    opacity: 1;
+  }
+`;
 const StyledContentWrapper = styled.div`
   width: 100%;
   padding: 0px 4px;
@@ -15,14 +23,11 @@ const StyledContentWrapper = styled.div`
   display: flex;
   align-items: center;
 
-  &:hover,
+  &:hover {
+    ${hoverAndFocus}
+  }
   &:focus-within {
-    background-color: ${({ theme }) => theme.orbit.paletteProductLight};
-
-    ${StyledOnlyButton} {
-      visibility: visible;
-      opacity: 1;
-    }
+    ${hoverAndFocus}
   }
 
   ${StyledOnlyButton} {


### PR DESCRIPTION
Removing combined selector &:hover, &:focus-within as it is not rendered correctly in IE and Edge<br/><br/><br/><url>LiveURL: https://orbit-components-fix-choicegroup-focus-ie.surge.sh</url>