### PR TITLE
DEV: Use @adeira/js instead of @kiwicom/js

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "styled-components": "^4.2.0"
   },
   "dependencies": {
-    "@kiwicom/js": "^0.9.0",
+    "@adeira/js": "^0.1.0",
     "@kiwicom/orbit-design-tokens": "~0.8.0"
   },
   "devDependencies": {

--- a/src/Button/index.js
+++ b/src/Button/index.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from "react";
 import styled, { css } from "styled-components";
-import { warning } from "@kiwicom/js";
+import { warning } from "@adeira/js";
 
 import defaultTheme from "../defaultTheme";
 import { ICON_SIZES } from "../Icon/consts";

--- a/src/ButtonLink/index.js
+++ b/src/ButtonLink/index.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from "react";
 import styled, { css } from "styled-components";
-import { warning } from "@kiwicom/js";
+import { warning } from "@adeira/js";
 
 import defaultTheme from "../defaultTheme";
 import { TYPES, SIZES, TOKENS, BUTTON_STATES } from "./consts";

--- a/src/CountryFlag/index.js
+++ b/src/CountryFlag/index.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from "react";
 import styled from "styled-components";
-import { warning } from "@kiwicom/js";
+import { warning } from "@adeira/js";
 import convertHexToRgba from "@kiwicom/orbit-design-tokens/lib/convertHexToRgba";
 
 import defaultTheme from "../defaultTheme";

--- a/src/NavigationList/NavigationListItem/index.js
+++ b/src/NavigationList/NavigationListItem/index.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from "react";
 import styled, { css } from "styled-components";
-import { warning } from "@kiwicom/js";
+import { warning } from "@adeira/js";
 
 import transition from "../../utils/transition";
 import { right, left, rtlSpacing } from "../../utils/rtl";

--- a/src/Slider/index.js
+++ b/src/Slider/index.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from "react";
 import styled, { css, withTheme } from "styled-components";
-import { warning } from "@kiwicom/js";
+import { warning } from "@adeira/js";
 
 import Text from "../Text";
 import Heading from "../Heading";

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@adeira/js@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@adeira/js/-/js-0.1.0.tgz#c30444da2000cf545be7d3d99c800c3f3b234c12"
+  integrity sha512-yBDdU8r2HRu8KRv/ogJIqeIUsFO8qh3G7D9qfRmyxgzlNdZfE6TTKoW5BQ8bvmMNDkpJa+pQfSvd+U91CYSx5g==
+
 "@babel/cli@^7.2.3":
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/@babel/cli/-/cli-7.2.3.tgz#1b262e42a3e959d28ab3d205ba2718e1923cfee6"
@@ -1512,11 +1517,6 @@
   dependencies:
     "@types/istanbul-lib-coverage" "^1.1.0"
     "@types/yargs" "^12.0.9"
-
-"@kiwicom/js@^0.9.0":
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/@kiwicom/js/-/js-0.9.0.tgz#67032574d8ee318cd747001a7b4c87013214327a"
-  integrity sha512-CwDiWwLWE0iWzCrL08x7jdEySAIVdmcmF/rik8gjK5oW4jA5G9fOBxsSSVm2bLtq8HG9KIz4YHDbtWO1K7LIiQ==
 
 "@kiwicom/orbit-design-tokens@~0.8.0":
   version "0.8.0"


### PR DESCRIPTION
Hi 👋 

I would like to replace `@kiwicom/js` by `@adeira/js`. `@kiwicom/js` will be no longer maintained, along with other open-sourced projects in original universe repo. Adeira is its continuation https://github.com/adeira/universe/tree/master/src/js 
<br/><br/><br/><url>LiveURL: https://orbit-components-use-adeira.surge.sh</url>