### PR TITLE
WIP: DEV: Update flow-bin to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "eslint-plugin-prettier": "^3.0.1",
     "eslint-plugin-react": "^7.7.0",
     "eslint-plugin-react-hooks": "^1.6.0",
-    "flow-bin": "^0.99.1",
+    "flow-bin": "^0.112.0",
     "fs-extra": "^7.0.1",
     "glob": "^7.1.2",
     "isomorphic-unfetch": "^3.0.0",

--- a/src/Alert/index.js.flow
+++ b/src/Alert/index.js.flow
@@ -9,14 +9,14 @@ type Type = "info" | "success" | "warning" | "critical";
 
 export type Props = {|
   +type?: Type,
-  +children?: React$Node,
+  +children?: React.Node,
   +title?: Translation,
-  +icon?: React$Element<any> | boolean,
+  +icon?: React.Element<any> | boolean,
   +closable?: boolean,
-  +inlineActions?: React$Node,
+  +inlineActions?: React.Node,
   +onClose?: () => void | Promise<any>,
   ...Globals,
   ...spaceAfter,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;

--- a/src/Badge/index.js.flow
+++ b/src/Badge/index.js.flow
@@ -20,13 +20,13 @@ export type Type =
   | "warningInverted";
 
 export type Props = {|
-  +children?: React$Node,
+  +children?: React.Node,
   +type?: Type,
-  +icon?: React$Node,
+  +icon?: React.Node,
   +ariaLabel?: string,
   ...Globals,
 |};
 
 declare export var StyledBadge: ReactComponentStyled<Props>;
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;

--- a/src/Breadcrumbs/BreadcrumbsItem/index.js.flow
+++ b/src/Breadcrumbs/BreadcrumbsItem/index.js.flow
@@ -5,10 +5,10 @@ export type Props = {|
   ...Globals,
   +active?: boolean,
   +component?: Component,
-  +children: React$Node,
+  +children: React.Node,
   +href?: string,
   +contentKey?: number,
   +onClick?: (ev?: SyntheticEvent<HTMLLinkElement>) => void | Promise<any>,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;

--- a/src/Breadcrumbs/index.js.flow
+++ b/src/Breadcrumbs/index.js.flow
@@ -8,11 +8,11 @@ import type { spaceAfter } from "../common/getSpacingToken/index";
 
 export type Props = {|
   ...Globals,
-  children: React$Node,
+  children: React.Node,
   onGoBack?: (ev?: SyntheticEvent<HTMLButtonElement>) => void | Promise<any>,
   ...spaceAfter,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;
 
 declare export var BreadcrumbsItem: BreadcrumbsItemType;

--- a/src/Button/index.js.flow
+++ b/src/Button/index.js.flow
@@ -24,7 +24,7 @@ export type Props = {|
   ...Globals,
   ...Ref,
   ...spaceAfter,
-  +children?: React$Node,
+  +children?: React.Node,
   +component?: Component,
   +href?: string,
   +onClick?: (e: SyntheticEvent<HTMLButtonElement>) => void | Promise<any>,
@@ -38,9 +38,9 @@ export type Props = {|
   +size?: Size,
   +width?: number,
   +submit?: boolean,
-  +icon?: React$Node,
-  +iconLeft?: React$Node,
-  +iconRight?: React$Node,
+  +icon?: React.Node,
+  +iconLeft?: React.Node,
+  +iconRight?: React.Node,
   +tabIndex?: string,
   +ariaExpanded?: boolean,
   +ariaControls?: string,
@@ -52,4 +52,4 @@ export type Props = {|
 
 declare export var StyledButton: ReactComponentStyled<Props>;
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;

--- a/src/ButtonGroup/index.js.flow
+++ b/src/ButtonGroup/index.js.flow
@@ -5,8 +5,8 @@
 import type { Globals } from "../common/common.js.flow";
 
 export type Props = {|
-  +children: React$Node,
+  +children: React.Node,
   ...Globals,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;

--- a/src/ButtonLink/index.js.flow
+++ b/src/ButtonLink/index.js.flow
@@ -14,7 +14,7 @@ export type Props = {|
   ...Globals,
   ...Ref,
   ...spaceAfter,
-  +children?: React$Node,
+  +children?: React.Node,
   +component?: Component,
   +onClick?: (e: SyntheticEvent<HTMLButtonElement>) => void | Promise<any>,
   +disabled?: boolean,
@@ -24,9 +24,9 @@ export type Props = {|
   +size?: Size,
   +href?: string,
   +width?: number,
-  +icon?: React$Node,
-  +iconLeft?: React$Node,
-  +iconRight?: React$Node,
+  +icon?: React.Node,
+  +iconLeft?: React.Node,
+  +iconRight?: React.Node,
   +circled?: boolean,
   +submit?: boolean,
   +transparent?: boolean,
@@ -41,4 +41,4 @@ export type Props = {|
 
 declare export var StyledButtonLink: ReactComponentStyled<Props>;
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;

--- a/src/CallOutBanner/index.js.flow
+++ b/src/CallOutBanner/index.js.flow
@@ -7,10 +7,10 @@ export type Props = {|
   onClick?: () => void | Promise<any>,
   title: Translation,
   description?: Translation,
-  illustration?: React$Element<typeof Illustration>,
-  actions?: React$Node,
-  children?: React$Node,
+  illustration?: React.Element<typeof Illustration>,
+  actions?: React.Node,
+  children?: React.Node,
   ...Globals,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;

--- a/src/Card/CardHeader/index.js.flow
+++ b/src/Card/CardHeader/index.js.flow
@@ -4,14 +4,14 @@ import type { ReactComponentStyled } from "styled-components";
 import type { Globals } from "../../common/common.js.flow";
 
 export type Props = {|
-  +icon?: React$Node,
-  +title: React$Node,
-  +subTitle?: React$Node,
-  +actions?: React$Node,
+  +icon?: React.Node,
+  +title: React.Node,
+  +subTitle?: React.Node,
+  +actions?: React.Node,
   +dataA11ySection?: string,
   ...Globals,
 |};
 
 declare export var StyledCardHeader: ReactComponentStyled<any>;
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;

--- a/src/Card/CardSection/CardSectionContent/index.js.flow
+++ b/src/Card/CardSection/CardSectionContent/index.js.flow
@@ -2,7 +2,7 @@
 import type { ReactComponentStyled } from "styled-components";
 
 export type Props = {|
-  children: React$Node,
+  children: React.Node,
   expanded?: boolean,
   expandable?: boolean,
   visible?: boolean,
@@ -14,4 +14,4 @@ export type State = {|
 
 declare export var StyledCardSectionContent: ReactComponentStyled<any>;
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;

--- a/src/Card/CardSection/CardSectionHeader/index.js.flow
+++ b/src/Card/CardSection/CardSectionHeader/index.js.flow
@@ -2,10 +2,10 @@
 import type { ReactComponentStyled } from "styled-components";
 
 export type Props = {|
-  children: React$Node,
-  actions?: React$Node,
+  children: React.Node,
+  actions?: React.Node,
 |};
 
 declare export var StyledCardSectionHeader: ReactComponentStyled<any>;
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;

--- a/src/Card/CardSection/index.js.flow
+++ b/src/Card/CardSection/index.js.flow
@@ -6,7 +6,7 @@ import typeof CardSectionHeaderType from "./CardSectionHeader/index.js.flow";
 import typeof CardSectionContentType from "./CardSectionContent/index.js.flow";
 
 export type Props = {|
-  +children: React$Node,
+  +children: React.Node,
   +expandable?: boolean,
   +initialExpanded?: boolean,
   +onClose?: () => void | Promise<any>,
@@ -16,7 +16,7 @@ export type Props = {|
 
 declare export var StyledCardSection: ReactComponentStyled<any>;
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;
 
 declare export var CardSectionHeader: CardSectionHeaderType;
 declare export var CardSectionContent: CardSectionContentType;

--- a/src/Card/index.js.flow
+++ b/src/Card/index.js.flow
@@ -10,7 +10,7 @@ import typeof CardSectionContentType from "./CardSection/CardSectionContent/inde
 import typeof CardHeaderType from "./CardHeader/index.js.flow";
 
 export type Props = {|
-  +children?: React$Node,
+  +children?: React.Node,
   +closable?: boolean,
   +onClose?: (ev: SyntheticEvent<HTMLButtonElement>) => void | Promise<any>,
   ...Globals,
@@ -22,7 +22,7 @@ export type State = {|
   initialExpandedSections: Array<number>,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;
 
 declare export var CardHeader: CardHeaderType;
 declare export var CardSection: CardSectionType;

--- a/src/CarrierLogo/index.js.flow
+++ b/src/CarrierLogo/index.js.flow
@@ -23,4 +23,4 @@ type styledCarrierLogo = {
 
 declare export var StyledCarrierLogo: ReactComponentStyled<styledCarrierLogo>;
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;

--- a/src/Checkbox/README.md
+++ b/src/Checkbox/README.md
@@ -35,7 +35,7 @@ class Component extends React.PureComponent<Props> {
     this.ref.current && this.ref.current.focus();
   }
 
-  ref: { current: React$ElementRef<*> | null } = React.createRef();
+  ref: { current: React.ElementRef<*> | null } = React.createRef();
 
   render() {
     return (

--- a/src/Checkbox/index.js.flow
+++ b/src/Checkbox/index.js.flow
@@ -7,13 +7,13 @@ import type { ReactComponentStyled } from "styled-components";
 import type { Globals, Ref } from "../common/common.js.flow";
 
 export type Props = {|
-  +label?: React$Node,
+  +label?: React.Node,
   +value?: string,
   +hasError?: boolean,
   +disabled?: boolean,
   +checked?: boolean,
   +name?: string,
-  +info?: React$Node,
+  +info?: React.Node,
   +tabIndex?: string,
   +readOnly?: boolean,
   +onChange?: (ev: SyntheticInputEvent<HTMLInputElement>) => void | Promise<any>,
@@ -21,6 +21,6 @@ export type Props = {|
   ...Ref,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;
 
 declare export var Label: ReactComponentStyled<any>;

--- a/src/ChoiceGroup/components/FilterWrapper.js.flow
+++ b/src/ChoiceGroup/components/FilterWrapper.js.flow
@@ -1,11 +1,11 @@
 // @flow
 
 type Props = {|
-  +child: React$Element<*>,
-  +children: React$Element<*>,
+  +child: React.Element<*>,
+  +children: React.Element<*>,
   +onOnlySelection?: (SyntheticEvent<HTMLButtonElement>, {}) => void | Promise<any>,
 |};
 
-export type FilterWrapperType = Props => React$Element<*>;
+export type FilterWrapperType = Props => React.Element<*>;
 
 declare export default FilterWrapperType;

--- a/src/ChoiceGroup/index.js.flow
+++ b/src/ChoiceGroup/index.js.flow
@@ -11,7 +11,7 @@ type LabelAs = "h2" | "h3" | "h4" | "h5" | "h6";
 export type Filters = { label: string, value: string };
 export type Props = {|
   ...Globals,
-  children: React$Node,
+  children: React.Node,
   label?: Translation,
   labelSize?: LabelSize,
   labelAs?: LabelAs,
@@ -21,4 +21,4 @@ export type Props = {|
   onChange: (SyntheticInputEvent<HTMLInputElement>) => void | Promise<any>,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;

--- a/src/ClickOutside/index.js.flow
+++ b/src/ClickOutside/index.js.flow
@@ -1,7 +1,7 @@
 // @flow
 export type Props = {|
   +onClickOutside?: (ev: MouseEvent) => void | Promise<any>,
-  +children: React$Node | React$Node[],
+  +children: React.Node | React.Node[],
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;

--- a/src/Collapse/README.md
+++ b/src/Collapse/README.md
@@ -17,7 +17,7 @@ Table below contains all types of the props available in the Collapse component.
 | Name            | Type                                | Default         | Description                     |
 | :-------------- | :---------------------------------- | :-------------- | :------------------------------ |
 | actions         | `React.Node`                        |                 | Actions which will be render next to arrow.
-| **children**    | `React$Node`                        |                 | The children that should be collapsed.
+| **children**    | `React.Node`                        |                 | The children that should be collapsed.
 | dataTest        | `string`                            |                 | Optional prop for testing purposes.
 | expanded        | `boolean`                           |                 | If you pass either `true` or `false` the Collapse component will controlled component and you will have to manage the state via `onClick`.
 | initialExpanded | `boolean`                           | `false`         | If `true` the Collapse component will be expanded on the initial render.

--- a/src/Collapse/index.js.flow
+++ b/src/Collapse/index.js.flow
@@ -5,10 +5,10 @@ export type Props = {|
   initialExpanded?: boolean,
   expanded?: boolean,
   label: Translation,
-  children: React$Node,
-  actions?: React$Node,
+  children: React.Node,
+  actions?: React.Node,
   onClick?: (e: SyntheticEvent<HTMLDivElement>, state: boolean) => void | Promise<any>,
   ...Globals,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;

--- a/src/CountryFlag/index.js.flow
+++ b/src/CountryFlag/index.js.flow
@@ -19,4 +19,4 @@ declare export var getCountryProps: (
   +name: string,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;

--- a/src/Coupon/README.md
+++ b/src/Coupon/README.md
@@ -15,4 +15,4 @@ Table below contains all types of the props available in the Coupon component.
 | Name          | Type                             | Default         | Description                      |
 | :------------ | :------------------------------- | :-------------- | :------------------------------- |
 | dataTest      | `string`                         |                 | Optional prop for testing purposes.
-| **children**  | `React$Node`                     |                 | The content of the Coupon.
+| **children**  | `React.Node`                     |                 | The content of the Coupon.

--- a/src/Coupon/index.js.flow
+++ b/src/Coupon/index.js.flow
@@ -2,8 +2,8 @@
 import type { Globals } from "../common/common.js.flow";
 
 export type Props = {|
-  +children: React$Node,
+  +children: React.Node,
   ...Globals,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;

--- a/src/Desktop/index.js.flow
+++ b/src/Desktop/index.js.flow
@@ -5,7 +5,7 @@
 */
 
 export type Props = {|
-  +children: React$Node,
+  +children: React.Node,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;

--- a/src/DestinationCard/index.js.flow
+++ b/src/DestinationCard/index.js.flow
@@ -30,4 +30,4 @@ export type Props = {|
   +onClick?: () => void,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;

--- a/src/DestinationHeader/index.js.flow
+++ b/src/DestinationHeader/index.js.flow
@@ -8,4 +8,4 @@ export type Props = {|
   +goBack?: () => void | Promise<any>,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;

--- a/src/Dictionary/index.js.flow
+++ b/src/Dictionary/index.js.flow
@@ -7,11 +7,11 @@ export type Translations = {
 
 export type Props = {
   +values: Translations,
-  +children: React$Node,
+  +children: React.Node,
 };
 
 type WithDictionary<A, B> = (a: React.ComponentType<A>) => React.ComponentType<B>;
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;
 
 declare export var withDictionary: WithDictionary<any, any>;

--- a/src/Drawer/components/DrawerClose.js.flow
+++ b/src/Drawer/components/DrawerClose.js.flow
@@ -3,4 +3,4 @@ import type { OnClose } from "../index";
 
 export type Props = {| +onClick?: OnClose |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;

--- a/src/Drawer/index.js.flow
+++ b/src/Drawer/index.js.flow
@@ -7,7 +7,7 @@ export type OnClose = () => void | Promise<any>;
 export type Position = "left" | "right";
 
 export type Props = {|
-  +children: React$Node,
+  +children: React.Node,
   +onClose?: OnClose,
   +shown: boolean,
   +width?: string,
@@ -15,8 +15,8 @@ export type Props = {|
   +noPadding?: boolean,
   +suppressed?: boolean,
   +title?: Translation,
-  +actions?: React$Node,
+  +actions?: React.Node,
   ...Globals,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;

--- a/src/FeatureIcon/FLOW_TEMPLATE.flow
+++ b/src/FeatureIcon/FLOW_TEMPLATE.flow
@@ -11,4 +11,4 @@ export type Props = {|
   ...Globals,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;

--- a/src/FormFeedback/index.js.flow
+++ b/src/FormFeedback/index.js.flow
@@ -6,11 +6,11 @@ import type { Globals } from "../common/common.js.flow";
 type Type = "help" | "error";
 
 export type Props = {|
-  children: React$Node,
+  children: React.Node,
   type?: Type,
   ...Globals,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;
 
 declare export var StyledFormFeedback: ReactComponentStyled<any>;

--- a/src/FormLabel/index.js.flow
+++ b/src/FormLabel/index.js.flow
@@ -2,7 +2,7 @@
 import type { Globals } from "../common/common.js.flow";
 
 export type Props = {
-  children: React$Node,
+  children: React.Node,
   filled?: boolean,
   disabled?: boolean,
   required?: boolean,
@@ -10,4 +10,4 @@ export type Props = {
   ...Globals,
 };
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;

--- a/src/Heading/index.js.flow
+++ b/src/Heading/index.js.flow
@@ -16,7 +16,7 @@ export type Props = {|
   ...spaceAfter,
   +element?: Element,
   +type?: Type,
-  +children: React$Node,
+  +children: React.Node,
   +inverted?: boolean,
   +dataA11ySection?: string,
   +id?: string,
@@ -24,7 +24,7 @@ export type Props = {|
 
 export type GetHeadingToken = (name: string) => ({ ...ThemeProps, type: Type }) => string;
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;
 
 declare export var StyledHeading: ReactComponentStyled<any>;
 

--- a/src/Hide/index.js.flow
+++ b/src/Hide/index.js.flow
@@ -5,9 +5,9 @@
 import type { Devices } from "../utils/mediaQuery/index";
 
 export type Props = {|
-  +children: React$Node,
+  +children: React.Node,
   +on: Devices[],
   +block?: boolean,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;

--- a/src/Icon/index.js.flow
+++ b/src/Icon/index.js.flow
@@ -12,14 +12,14 @@ export type Props = {|
   +color?: Color,
   +className?: string,
   +customColor?: string,
-  +children: React$Node,
+  +children: React.Node,
   +viewBox: string,
   +ariaHidden?: boolean,
   +reverseOnRtl?: boolean,
   +ariaLabel?: string,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;
 
 export type GetSize = (size: Size) => ({ theme: typeof defaultTheme }) => string;
 

--- a/src/Illustration/FLOW_TEMPLATE.flow
+++ b/src/Illustration/FLOW_TEMPLATE.flow
@@ -14,4 +14,4 @@ export type Props = {|
   ...spaceAfter,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;

--- a/src/InputField/InputTags/index.js.flow
+++ b/src/InputField/InputTags/index.js.flow
@@ -1,6 +1,6 @@
 // @flow
 export type Props = {|
-  children: React$Node,
+  children: React.Node,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;

--- a/src/InputField/README.md
+++ b/src/InputField/README.md
@@ -98,7 +98,7 @@ class Component extends React.PureComponent<Props> {
     this.ref.current && this.ref.current.focus();
   }
 
-  ref: { current: React$ElementRef<*> | null } = React.createRef();
+  ref: { current: React.ElementRef<*> | null } = React.createRef();
 
   render() {
     return (

--- a/src/InputField/index.js
+++ b/src/InputField/index.js
@@ -201,7 +201,7 @@ Suffix.defaultProps = {
 
 export const Input = styled(
   React.forwardRef<Props, HTMLInputElement>(
-    ({ type, size, theme, error, help, inlineLabel, ...props }, ref) => (
+    ({ type, size, error, help, inlineLabel, ...props }, ref) => (
       <input type={getDOMType(type)} {...props} ref={ref} />
     ),
   ),

--- a/src/InputField/index.js.flow
+++ b/src/InputField/index.js.flow
@@ -23,11 +23,11 @@ export type Props = {|
   +inlineLabel?: boolean,
   +value?: (() => string | number) | string | number,
   +placeholder?: Translation,
-  +prefix?: React$Node,
-  +suffix?: React$Node,
-  +help?: React$Node,
-  +error?: React$Node,
-  +tags?: React$Node,
+  +prefix?: React.Node,
+  +suffix?: React.Node,
+  +help?: React.Node,
+  +error?: React.Node,
+  +tags?: React.Node,
   +disabled?: boolean,
   +maxValue?: number,
   +minValue?: number,
@@ -53,4 +53,4 @@ declare export var Prefix: ReactComponentStyled<any>;
 
 declare export var InputContainer: ReactComponentStyled<any>;
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;

--- a/src/InputFile/README.md
+++ b/src/InputFile/README.md
@@ -44,7 +44,7 @@ class Component extends React.PureComponent<Props> {
     this.ref.current && this.ref.current.focus();
   }
 
-  ref: { current: React$ElementRef<*> | null } = React.createRef();
+  ref: { current: React.ElementRef<*> | null } = React.createRef();
 
   render() {
     return (

--- a/src/InputFile/index.js.flow
+++ b/src/InputFile/index.js.flow
@@ -9,13 +9,13 @@ export type Props = {|
   ...Globals,
   ...spaceAfter,
   +label?: Translation,
-  +buttonLabel?: React$Node,
+  +buttonLabel?: React.Node,
   +name?: string,
   +placeholder?: Translation,
   +fileName?: string,
   +allowedFileTypes?: string | string[],
-  +help?: React$Node,
-  +error?: React$Node,
+  +help?: React.Node,
+  +error?: React.Node,
   tabIndex?: string,
   +onChange?: (ev: SyntheticInputEvent<HTMLInputElement>) => void | Promise<any>,
   +onFocus?: (ev: SyntheticInputEvent<HTMLInputElement>) => void | Promise<any>,
@@ -24,4 +24,4 @@ export type Props = {|
   ref?: Ref,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;

--- a/src/InputGroup/index.js.flow
+++ b/src/InputGroup/index.js.flow
@@ -11,9 +11,9 @@ export type Props = {|
   +label?: Translation,
   +flex?: string | Array<string>,
   +size?: "small" | "normal",
-  +help?: React$Node,
-  +children: React$Node,
-  +error?: React$Node,
+  +help?: React.Node,
+  +children: React.Node,
+  +error?: React.Node,
   +onChange?: (
     ev: SyntheticInputEvent<HTMLInputElement> | SyntheticInputEvent<HTMLSelectElement>,
   ) => void | Promise<any>,
@@ -30,4 +30,4 @@ export type State = {|
   filled: boolean,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;

--- a/src/InputStepper/InputStepperStateless/index.js.flow
+++ b/src/InputStepper/InputStepperStateless/index.js.flow
@@ -19,4 +19,4 @@ export type StateLessProps = {|
   +onChange?: (SyntheticInputEvent<HTMLInputElement>) => void | Promise<any>,
 |};
 
-declare export default React$ComponentType<StateLessProps>;
+declare export default React.ComponentType<StateLessProps>;

--- a/src/InputStepper/README.md
+++ b/src/InputStepper/README.md
@@ -64,7 +64,7 @@ class Component extends React.PureComponent<Props> {
     this.ref.current && this.ref.current.focus();
   }
 
-  ref: { current: React$ElementRef<*> | null } = React.createRef();
+  ref: { current: React.ElementRef<*> | null } = React.createRef();
 
   render() {
     return (

--- a/src/InputStepper/index.js.flow
+++ b/src/InputStepper/index.js.flow
@@ -13,8 +13,8 @@ export type SharedProps = {|
   +size?: Size,
   +label?: Translation,
   +step?: number,
-  +help?: React$Node,
-  +error?: React$Node,
+  +help?: React.Node,
+  +error?: React.Node,
   +name?: string,
   +disabled?: boolean,
   +maxValue?: number,
@@ -33,4 +33,4 @@ export type Props = {|
   +onChange?: number => void | Promise<any>,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;

--- a/src/Layout/LayoutColumn/index.js.flow
+++ b/src/Layout/LayoutColumn/index.js.flow
@@ -4,9 +4,9 @@ import type { Globals } from "../../common/common.js.flow";
 
 export type Props = {|
   ...Globals,
-  +children: React$Node,
+  +children: React.Node,
   +element?: string,
   +hideOn?: Devices[],
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;

--- a/src/Layout/index.js.flow
+++ b/src/Layout/index.js.flow
@@ -5,9 +5,9 @@ import type { Globals } from "../common/common.js.flow";
 export type Props = {|
   ...Globals,
   type: "Search" | "Booking" | "MMB",
-  children: React$Node,
+  children: React.Node,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;
 
 declare export var LayoutColumn: LayoutColumnType;

--- a/src/LazyImage/index.js.flow
+++ b/src/LazyImage/index.js.flow
@@ -25,6 +25,6 @@ export type PictureProps = {|
   lowRes?: boolean,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;
 
 declare export var StyledLazyImage: ReactComponentStyled<any>;

--- a/src/List/ListItem/index.js.flow
+++ b/src/List/ListItem/index.js.flow
@@ -6,13 +6,13 @@ import type { Size } from "../index";
 import type { Theme } from "../../defaultTheme";
 
 export type Props = {|
-  +children: React$Node,
+  +children: React.Node,
   +label?: Translation,
-  +icon?: React$Element<any>,
+  +icon?: React.Element<any>,
   ...Globals,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;
 
 declare export var Item: ReactComponentStyled<any>;
 

--- a/src/List/index.js.flow
+++ b/src/List/index.js.flow
@@ -12,13 +12,13 @@ export type Size = "small" | "normal" | "large";
 export type Type = "primary" | "secondary" | "separated";
 
 export type Props = {|
-  +children: React$Node,
+  +children: React.Node,
   +size?: Size,
   +type?: Type,
   ...Globals,
   ...spaceAfter,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;
 
 declare export var ListItem: ListItemType;

--- a/src/ListChoice/index.js.flow
+++ b/src/ListChoice/index.js.flow
@@ -10,10 +10,10 @@ export type Props = {|
   +description?: Translation,
   +selectable?: boolean,
   +selected?: boolean,
-  +icon: React$Node,
+  +icon: React.Node,
   +onClick?: (
     e: SyntheticEvent<HTMLDivElement> | SyntheticKeyboardEvent<HTMLElement>,
   ) => void | Promise<any>,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;

--- a/src/Loading/index.js.flow
+++ b/src/Loading/index.js.flow
@@ -9,7 +9,7 @@ import type { Globals, Translation } from "../common/common.js.flow";
 type Type = "buttonLoader" | "boxLoader" | "searchLoader" | "pageLoader" | "inlineLoader";
 
 export type Props = {|
-  +children?: React$Node,
+  +children?: React.Node,
   +loading?: boolean,
   +type?: Type,
   +text?: Translation,
@@ -19,4 +19,4 @@ export type Props = {|
 declare export var StyledSpinner: ReactComponentStyled<any>;
 declare export var StyledLoading: ReactComponentStyled<any>;
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;

--- a/src/Mobile/index.js.flow
+++ b/src/Mobile/index.js.flow
@@ -5,7 +5,7 @@
 */
 
 export type Props = {|
-  +children: React$Node,
+  +children: React.Node,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;

--- a/src/Modal/ModalContext.js.flow
+++ b/src/Modal/ModalContext.js.flow
@@ -14,8 +14,8 @@ export type ModalContextProps = {|
 
 export type ModalContextType = React.Context<ModalContextProps>;
 
-// TODO: write better type
-export type WithModalContextType = (React$ComponentType<any>) => ({ [key: string]: any }) => any;
+export type WithModalContextType =
+  <Config: {}>(React.AbstractComponent<Config>) => React.AbstractComponent<Config>;
 
 declare export var ModalContext: ModalContextType;
 

--- a/src/Modal/ModalFooter/index.js
+++ b/src/Modal/ModalFooter/index.js
@@ -126,7 +126,7 @@ class ModalFooter extends React.PureComponent<Props> {
   }
 }
 
-const DecoratedComponent = withModalContext(ModalFooter);
+const DecoratedComponent = withModalContext<Props>(ModalFooter);
 
 // $FlowFixMe flow doesn't recognize displayName for functions
 DecoratedComponent.displayName = "ModalFooter";

--- a/src/Modal/ModalFooter/index.js.flow
+++ b/src/Modal/ModalFooter/index.js.flow
@@ -7,10 +7,10 @@ import type { ModalContextProps } from "../ModalContext";
 export type Props = {|
   ...Globals,
   ...ModalContextProps,
-  +children: React$Node,
+  +children: React.Node,
   +flex?: string | Array<string>,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;
 
 declare export var StyledModalFooter: ReactComponentStyled<any>;

--- a/src/Modal/ModalHeader/index.js
+++ b/src/Modal/ModalHeader/index.js
@@ -207,7 +207,7 @@ class ModalHeader extends React.PureComponent<Props> {
     );
   }
 }
-const DecoratedComponent = withModalContext(ModalHeader);
+const DecoratedComponent = withModalContext<Props>(ModalHeader);
 
 // $FlowFixMe flow doesn't recognize displayName for functions
 DecoratedComponent.displayName = "ModalHeader";

--- a/src/Modal/ModalHeader/index.js.flow
+++ b/src/Modal/ModalHeader/index.js.flow
@@ -8,14 +8,14 @@ import type { ModalContextProps } from "../ModalContext";
 export type Props = {|
   ...Globals,
   ...ModalContextProps,
-  +children?: React$Node,
-  +illustration?: React$Element<typeof Illustration>,
-  +title?: React$Node,
-  +description?: React$Node,
+  +children?: React.Node,
+  +illustration?: React.Element<typeof Illustration>,
+  +title?: React.Node,
+  +description?: React.Node,
   +suppressed?: boolean,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;
 
 declare export var MobileHeader: ReactComponentStyled<any>;
 

--- a/src/Modal/ModalSection/index.js
+++ b/src/Modal/ModalSection/index.js
@@ -117,7 +117,7 @@ class ModalSection extends React.PureComponent<Props> {
   }
 }
 
-const DecoratedComponent = withModalContext(ModalSection);
+const DecoratedComponent = withModalContext<Props>(ModalSection);
 
 // $FlowFixMe flow doesn't recognize displayName for functions
 DecoratedComponent.displayName = "ModalSection";

--- a/src/Modal/ModalSection/index.js.flow
+++ b/src/Modal/ModalSection/index.js.flow
@@ -7,10 +7,10 @@ import type { ModalContextProps } from "../ModalContext";
 export type Props = {|
   ...Globals,
   ...ModalContextProps,
-  +children: React$Node,
+  +children: React.Node,
   +suppressed?: boolean,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;
 
 declare export var StyledModalSection: ReactComponentStyled<any>;

--- a/src/Modal/README.md
+++ b/src/Modal/README.md
@@ -42,7 +42,7 @@ Table below contains all types of the props available in the Modal component.
 * If you need to set scrollTop position of the Modal component, you can use instance of the component and method `setScrollPosition` like this:
 ```jsx
 class Component extends React.Component {
-  modalRef: { current: null | React$ElementRef<*> } = React.createRef();
+  modalRef: { current: null | React.ElementRef<*> } = React.createRef();
 
   setScroll = () => {
     if(modalRef.current) {

--- a/src/Modal/index.js.flow
+++ b/src/Modal/index.js.flow
@@ -25,16 +25,16 @@ export type onClose = (
 
 export type Props = {|
   +size?: Size,
-  +children: React$Node,
+  +children: React.Node,
   +onClose?: onClose,
   +fixedFooter?: boolean,
   +isMobileFullPage?: boolean,
   ...Globals,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;
 
-declare export var PureModal: React$ComponentType<Props>;
+declare export var PureModal: React.ComponentType<Props>;
 
 declare export var ModalHeader: ModalHeaderType;
 declare export var ModalSection: ModalSectionType;

--- a/src/NavigationBar/index.js.flow
+++ b/src/NavigationBar/index.js.flow
@@ -5,8 +5,8 @@ export type Props = {|
   +onMenuOpen?: () => void | Promise<any>,
   +onShow?: () => void | Promise<any>,
   +onHide?: () => void | Promise<any>,
-  +children: React$Node,
+  +children: React.Node,
   ...Globals,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;

--- a/src/NavigationList/NavigationListItem/index.js.flow
+++ b/src/NavigationList/NavigationListItem/index.js.flow
@@ -6,8 +6,8 @@ import type { Component, Globals } from "../../common/common.js.flow";
 
 export type Props = {|
   +ariaLabel?: string,
-  +icon?: React$Element<any>,
-  +children?: React$Node,
+  +icon?: React.Element<any>,
+  +children?: React.Node,
   +selectable?: boolean,
   +selected?: boolean,
   +href?: string,
@@ -18,4 +18,4 @@ export type Props = {|
   ...Globals,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;

--- a/src/NavigationList/README.md
+++ b/src/NavigationList/README.md
@@ -48,7 +48,7 @@ Table below contains all types of the props available in the NavigationListItem 
 | dataTest      | `string`                          |                 | Optional prop for testing purposes.
 | external      | `boolean`                         |                 | If `true`, the Navigation opens link in a new tab. [See Functional specs](#functional-specs)
 | href          | `string`                          |                 | The URL of the link to open when the NavigationLink is clicked. [See Functional specs](#functional-specs)
-| icon          | `React$Element`                   |                 | The displayed icon on the left.
+| icon          | `React.Element`                   |                 | The displayed icon on the left.
 | onClick       | `() => void \| Promise`           |                 | Function for handling onClick event.
 | selectable    | `boolean`                         | `false`         | If `true`, the NavigationLink will be selectable and it will be possible to use `selected` property.
 | selected      | `boolean`                         |                 | If `true`, the NavigationLink will be selected visually.

--- a/src/NavigationList/index.js.flow
+++ b/src/NavigationList/index.js.flow
@@ -5,12 +5,12 @@ import type { Props as ItemProps } from "./NavigationListItem";
 export type Types = "navigation" | "inline";
 
 export type Props = {|
-  +children: React$Node,
+  +children: React.Node,
   +title?: Translation,
   +type?: Types,
   ...Globals,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;
 
-declare export var NavigationListItem: React$ComponentType<ItemProps>;
+declare export var NavigationListItem: React.ComponentType<ItemProps>;

--- a/src/NotificationBadge/index.js.flow
+++ b/src/NotificationBadge/index.js.flow
@@ -7,11 +7,11 @@ import type { Globals } from "../common/common.js.flow";
 import type { Type } from "../Badge/index.js.flow";
 
 export type Props = {|
-  +children?: React$Node,
+  +children?: React.Node,
   +type?: Type,
-  +icon?: React$Node,
+  +icon?: React.Node,
   +ariaLabel?: string,
   ...Globals,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;

--- a/src/Pagination/components/ActiveButton.js.flow
+++ b/src/Pagination/components/ActiveButton.js.flow
@@ -3,9 +3,9 @@
 import type { Sizes } from "../index";
 
 export type Props = {|
-  children: React$Node,
+  children: React.Node,
   transparent?: boolean,
   size?: Sizes,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;

--- a/src/Pagination/components/CompactPages.js.flow
+++ b/src/Pagination/components/CompactPages.js.flow
@@ -8,4 +8,4 @@ export type Props = {|
   size: Sizes,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;

--- a/src/Pagination/components/PageButtonLink.js.flow
+++ b/src/Pagination/components/PageButtonLink.js.flow
@@ -7,4 +7,4 @@ export type Props = {|
   size: Sizes,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;

--- a/src/Pagination/components/Pages.js
+++ b/src/Pagination/components/Pages.js
@@ -11,7 +11,7 @@ const Pages = ({
   onPageChange,
   enlargement = 1,
   size,
-}: Props): React$Node =>
+}: Props): React.Node =>
   Array(...Array(pageCount)).map((_, index) => {
     const key = index + enlargement;
     return selectedPage === key ? (

--- a/src/Pagination/components/Pages.js.flow
+++ b/src/Pagination/components/Pages.js.flow
@@ -9,4 +9,4 @@ export type Props = {|
   size: Sizes,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;

--- a/src/Pagination/index.js.flow
+++ b/src/Pagination/index.js.flow
@@ -18,4 +18,4 @@ export type Props = {|
   size?: Sizes,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;

--- a/src/Popover/components/ContentWrapper.js
+++ b/src/Popover/components/ContentWrapper.js
@@ -1,5 +1,5 @@
 // @flow
-import React, { useRef, useEffect, useContext, useMemo } from "react";
+import * as React from "react";
 import styled, { css } from "styled-components";
 import convertHexToRgba from "@kiwicom/orbit-design-tokens/lib/convertHexToRgba";
 
@@ -144,19 +144,21 @@ const PopoverContentWrapper = ({
   fixed,
   actions,
 }: Props) => {
-  const { isInsideModal } = useContext(ModalContext);
-  const popover: { current: React$ElementRef<*> } = useRef(null);
-  const content: { current: React$ElementRef<*> } = useRef(null);
-  const overlay: { current: React$ElementRef<*> } = useRef(null);
-  const actionsRef: { current: React$ElementRef<*> } = useRef(null);
+  const { isInsideModal } = React.useContext(ModalContext);
+  const popover: { current: React.ElementRef<*> } = React.useRef(null);
+  const content: { current: React.ElementRef<*> } = React.useRef(null);
+  const overlay: { current: React.ElementRef<*> } = React.useRef(null);
+  const actionsRef: { current: React.ElementRef<*> } = React.useRef(null);
   const position = calculatePopoverPosition(preferredPosition, preferredAlign);
-  const scrollableParent = useMemo(() => getScrollableParent(containerRef.current), [containerRef]);
+  const scrollableParent = React.useMemo(() => getScrollableParent(containerRef.current), [
+    containerRef,
+  ]);
   const dimensions = useDimensions({ containerRef, popover, content, fixed, scrollableParent });
   const verticalPosition = calculateVerticalPosition(position[0], dimensions);
   const horizontalPosition = calculateHorizontalPosition(position[1], dimensions);
-  const actionsDimensions = useMemo(() => boundingClientRect(actionsRef), [actionsRef.current]);
+  const actionsDimensions = React.useMemo(() => boundingClientRect(actionsRef), []);
 
-  useEffect(() => {
+  React.useEffect(() => {
     const timer = setTimeout(() => {
       if (popover.current) {
         popover.current.focus();

--- a/src/Popover/components/ContentWrapper.js.flow
+++ b/src/Popover/components/ContentWrapper.js.flow
@@ -4,18 +4,18 @@ import type { PositionsCore, AlignsCore } from "../index.js.flow";
 
 export type Props = {|
   ...Globals,
-  +children: React$Node,
+  +children: React.Node,
   +closeText?: Translation,
   +preferredPosition: PositionsCore,
   +preferredAlign: AlignsCore,
-  +containerRef: React$ElementRef<*>,
+  +containerRef: React.ElementRef<*>,
   +width?: string,
   +noPadding?: boolean,
   +overlapped?: boolean,
   +shown: boolean,
   +fixed?: boolean,
-  +actions?: React$Node,
+  +actions?: React.Node,
   +onClose: (ev: SyntheticEvent<HTMLElement>) => void,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;

--- a/src/Popover/hooks/useDimensions.js.flow
+++ b/src/Popover/hooks/useDimensions.js.flow
@@ -2,9 +2,9 @@
 import type { DimensionsCore } from "../index.js.flow";
 
 export type Params = {|
-  containerRef: React$ElementRef<*>,
-  popover: ?React$ElementRef<*>,
-  content: ?React$ElementRef<*>,
+  containerRef: React.ElementRef<*>,
+  popover: ?React.ElementRef<*>,
+  content: ?React.ElementRef<*>,
   +fixed?: boolean,
   scrollableParent: ?Node,
 |};

--- a/src/Popover/index.js
+++ b/src/Popover/index.js
@@ -1,5 +1,5 @@
 // @flow
-import React, { useRef, useCallback, useMemo, useEffect } from "react";
+import * as React from "react";
 import styled from "styled-components";
 
 import Portal from "../Portal";
@@ -29,7 +29,7 @@ const Popover = ({
   actions,
 }: Props) => {
   const theme = useTheme();
-  const transitionLength = useMemo(() => parseFloat(theme.orbit.durationFast) * 1000, [
+  const transitionLength = React.useMemo(() => parseFloat(theme.orbit.durationFast) * 1000, [
     theme.orbit.durationFast,
   ]);
   const [shown, setShown, setShownWithTimeout, clearShownTimeout] = useStateWithTimeout<boolean>(
@@ -42,9 +42,9 @@ const Popover = ({
     setRenderWithTimeout,
     clearRenderTimeout,
   ] = useStateWithTimeout<boolean>(false, transitionLength);
-  const container: { current: React$ElementRef<*> } = useRef(null);
+  const container: { current: React.ElementRef<*> } = React.useRef(null);
 
-  const resolveCallback = useCallback(
+  const resolveCallback = React.useCallback(
     state => {
       if (onClose && !state) onClose();
       if (onOpen && state) onOpen();
@@ -52,7 +52,7 @@ const Popover = ({
     [onClose, onOpen],
   );
 
-  const handleOut = useCallback(
+  const handleOut = React.useCallback(
     ev => {
       // If open prop is present ignore custom handler
       if (container.current && !container.current.contains(ev.target)) {
@@ -67,7 +67,7 @@ const Popover = ({
     [clearShownTimeout, onClose, opened, resolveCallback, setRenderWithTimeout, setShown],
   );
 
-  const handleClick = useCallback(() => {
+  const handleClick = React.useCallback(() => {
     // If open prop is present ignore custom handler
     if (typeof opened === "undefined") {
       if (shown) {
@@ -98,7 +98,7 @@ const Popover = ({
     shown,
   ]);
 
-  useEffect(() => {
+  React.useEffect(() => {
     if (typeof opened !== "undefined") {
       if (opened) {
         setRender(true);

--- a/src/Popover/index.js.flow
+++ b/src/Popover/index.js.flow
@@ -30,8 +30,8 @@ export type Anchor = {|
 
 export type Props = {|
   ...Globals,
-  +children: React$Node,
-  +content: React$Node,
+  +children: React.Node,
+  +content: React.Node,
   +preferredPosition?: PositionsCore,
   +preferredAlign?: AlignsCore,
   +opened?: boolean,
@@ -39,9 +39,9 @@ export type Props = {|
   +noPadding?: boolean,
   +overlapped?: boolean,
   +fixed?: boolean,
-  +actions?: React$Node,
+  +actions?: React.Node,
   +onOpen?: () => void | Promise<any>,
   +onClose?: () => void | Promise<any>,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;

--- a/src/Portal/index.js.flow
+++ b/src/Portal/index.js.flow
@@ -5,7 +5,7 @@
 
 export type Props = {|
   +renderInto?: string,
-  +children: React$Node,
+  +children: React.Node,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;

--- a/src/PricingTable/PricingTableItem/index.js.flow
+++ b/src/PricingTable/PricingTableItem/index.js.flow
@@ -7,15 +7,15 @@ export type Props = {|
   +name?: Translation,
   +price?: Translation,
   +mobileDescription?: Translation,
-  +priceBadge?: React$Node,
-  +featureIcon?: React$Node,
-  +badge?: string | React$Node,
-  +children?: React$Node,
+  +priceBadge?: React.Node,
+  +featureIcon?: React.Node,
+  +badge?: string | React.Node,
+  +children?: React.Node,
   +active?: boolean,
   +compact?: boolean,
-  +action?: React$Node,
+  +action?: React.Node,
   +basis?: string,
   +onClick?: () => void | Promise<any>,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;

--- a/src/PricingTable/README.md
+++ b/src/PricingTable/README.md
@@ -41,16 +41,16 @@ Table below contains all types of the props in the PricingTableItem component.
 
 | Name              | Type                   | Default     | Description                      |
 | :---------------- | :--------------------- | :---------- | :------------------------------- |
-| action            | `React$Node`           |             | Area for action elements, like Button.
-| badge             | `string \| React$Node` |             | Badge above the PricingTableItem, [works with Orbit Badge](../Badge/README.md)
+| action            | `React.Node`           |             | Area for action elements, like Button.
+| badge             | `string \| React.Node` |             | Badge above the PricingTableItem, [works with Orbit Badge](../Badge/README.md)
 | **children**      | `React.Node`           |             | Content of the PricingTableItem component.
 | dataTest          | `string`               |             | Optional prop for testing purposes.
-| featureIcon       | `React$Node`           |             | Feature Icon displayed at top of the PricingTableItem
+| featureIcon       | `React.Node`           |             | Feature Icon displayed at top of the PricingTableItem
 | mobileDescription | `Translation`          |             | Description of PricingTableItem, displayed on mobile
 | name              | `Translation`          |             | Name of PricingTableItem
 | onClick           | `() => void \| Promise`|             | Function for handling the onClick event.
 | price             | `Translation`          |             | Price of item
-| priceBadge        | `React$Node`           |             | Badge instead of `price`, [works with Orbit Badge](../Badge/README.md)
+| priceBadge        | `React.Node`           |             | Badge instead of `price`, [works with Orbit Badge](../Badge/README.md)
 
 
 

--- a/src/PricingTable/index.js.flow
+++ b/src/PricingTable/index.js.flow
@@ -8,10 +8,10 @@ import type { Globals } from "../common/common.js.flow";
 
 export type Props = {|
   ...Globals,
-  +children: React$Node, // TODO: Type this propperly
+  +children: React.Node, // TODO: Type this propperly
   +defaultActiveElement?: number,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;
 
 declare export var PricingTableItem: PricingTableItemType;

--- a/src/Radio/README.md
+++ b/src/Radio/README.md
@@ -35,7 +35,7 @@ class Component extends React.PureComponent<Props> {
     this.ref.current && this.ref.current.focus();
   }
 
-  ref: { current: React$ElementRef<*> | null } = React.createRef();
+  ref: { current: React.ElementRef<*> | null } = React.createRef();
 
   render() {
     return (

--- a/src/Radio/index.js.flow
+++ b/src/Radio/index.js.flow
@@ -5,13 +5,13 @@
 import type { Globals, Ref } from "../common/common.js.flow";
 
 export type Props = {|
-  +label?: React$Node,
+  +label?: React.Node,
   +value?: string,
   +hasError?: boolean,
   +disabled?: boolean,
   +name?: string,
   +checked?: boolean,
-  +info?: React$Node,
+  +info?: React.Node,
   +readOnly?: boolean,
   tabIndex?: string,
   +onChange?: (ev: SyntheticInputEvent<HTMLInputElement>) => void | Promise<any>,
@@ -19,4 +19,4 @@ export type Props = {|
   ...Ref,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;

--- a/src/RatingStars/index.js.flow
+++ b/src/RatingStars/index.js.flow
@@ -13,4 +13,4 @@ export type Props = {
   ...Globals,
 };
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;

--- a/src/Select/README.md
+++ b/src/Select/README.md
@@ -62,7 +62,7 @@ class Component extends React.PureComponent<Props> {
     this.ref.current && this.ref.current.focus();
   }
 
-  ref: { current: React$ElementRef<*> | null } = React.createRef();
+  ref: { current: React.ElementRef<*> | null } = React.createRef();
 
   render() {
     return (

--- a/src/Select/index.js.flow
+++ b/src/Select/index.js.flow
@@ -27,17 +27,17 @@ export type Props = {|
   +value?: string | number,
   +disabled?: boolean,
   +name?: string,
-  +error?: React$Node,
-  +help?: React$Node,
+  +error?: React.Node,
+  +help?: React.Node,
   tabIndex?: string,
   +onChange?: (ev: SyntheticInputEvent<HTMLSelectElement>) => void | Promise<any>,
   +onFocus?: (ev: SyntheticInputEvent<HTMLSelectElement>) => void | Promise<any>,
   +onBlur?: (ev: SyntheticInputEvent<HTMLSelectElement>) => void | Promise<any>,
   +options: Option[],
-  +prefix?: React$Node,
+  +prefix?: React.Node,
   +customValueText?: Translation,
 |};
 
 declare export var SelectContainer: ReactComponentStyled<any>;
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;

--- a/src/Separator/index.js.flow
+++ b/src/Separator/index.js.flow
@@ -8,4 +8,4 @@ export type Props = {|
   ...spaceAfter,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;

--- a/src/ServiceLogo/FLOW_TEMPLATE.flow
+++ b/src/ServiceLogo/FLOW_TEMPLATE.flow
@@ -17,5 +17,5 @@ export type Props = {|
   ...Globals,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;
 declare export var StyledServiceLogo: ReactComponentStyled<any>;

--- a/src/SkipLink/index.js.flow
+++ b/src/SkipLink/index.js.flow
@@ -19,4 +19,4 @@ export type Props = {|
   description?: string,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;

--- a/src/SkipNavigation/index.js.flow
+++ b/src/SkipNavigation/index.js.flow
@@ -19,4 +19,4 @@ export type Props = {|
   feedbackUrl?: string,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;

--- a/src/Slider/components/Bar/index.js.flow
+++ b/src/Slider/components/Bar/index.js.flow
@@ -10,7 +10,7 @@ export type Props = {|
   hasHistogram: boolean,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;
 
 export type CalculateBarPosition = (
   value: Value,

--- a/src/Slider/components/Handle/index.js.flow
+++ b/src/Slider/components/Handle/index.js.flow
@@ -19,7 +19,7 @@ export type Props = {|
   ariaValueText: ?string,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;
 
 export type CalculateLeftPosition = (
   valueNow: number,

--- a/src/Slider/components/Histogram/index.js.flow
+++ b/src/Slider/components/Histogram/index.js.flow
@@ -13,4 +13,4 @@ export type Props = {|
   loadingText?: Translation,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;

--- a/src/Slider/index.js
+++ b/src/Slider/index.js
@@ -68,7 +68,7 @@ const StyledSliderInput = styled.div`
 `;
 
 export class PureSlider extends React.PureComponent<Props & ThemeProps, State> {
-  bar: { current: React$ElementRef<*> } = React.createRef();
+  bar: { current: React.ElementRef<*> } = React.createRef();
 
   static defaultProps = {
     theme: defaultTheme,

--- a/src/Slider/index.js.flow
+++ b/src/Slider/index.js.flow
@@ -34,6 +34,6 @@ export type State = {|
   focused: boolean,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;
 
-declare export var PureSlider: React$ComponentType<Props>;
+declare export var PureSlider: React.ComponentType<Props>;

--- a/src/Stack/index.js.flow
+++ b/src/Stack/index.js.flow
@@ -61,7 +61,7 @@ export type Props = {|
   +desktop?: MediaQuery,
   +largeDesktop?: MediaQuery,
   +element?: string,
-  +children: React$Node,
+  +children: React.Node,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;

--- a/src/Stepper/StepperStateless/index.js.flow
+++ b/src/Stepper/StepperStateless/index.js.flow
@@ -17,4 +17,4 @@ export type StateLessProps = {|
   +onChange?: (SyntheticInputEvent<HTMLInputElement>) => void | Promise<any>,
 |};
 
-declare export default React$ComponentType<StateLessProps>;
+declare export default React.ComponentType<StateLessProps>;

--- a/src/Stepper/index.js.flow
+++ b/src/Stepper/index.js.flow
@@ -22,4 +22,4 @@ export type Props = {|
   +step?: number,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;

--- a/src/Sticky/index.js.flow
+++ b/src/Sticky/index.js.flow
@@ -2,7 +2,7 @@
 
 export type Props = {|
   +offset?: number,
-  +children: React$Node,
+  +children: React.Node,
 |};
 
 export type State = {|
@@ -13,4 +13,4 @@ export type State = {|
   initialWidth: boolean,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;

--- a/src/StopoverArrow/index.js.flow
+++ b/src/StopoverArrow/index.js.flow
@@ -9,4 +9,4 @@ export type Props = {|
   ...Globals,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;

--- a/src/Table/TableBody/index.js.flow
+++ b/src/Table/TableBody/index.js.flow
@@ -5,10 +5,10 @@ import type { ReactComponentStyled } from "styled-components";
 import type { Globals } from "../../common/common.js.flow";
 
 export type Props = {|
-  +children: React$Node,
+  +children: React.Node,
   ...Globals,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;
 
 declare export var StyledTableBody: ReactComponentStyled<Props>;

--- a/src/Table/TableCell/index.js.flow
+++ b/src/Table/TableCell/index.js.flow
@@ -7,11 +7,11 @@ import type { Globals } from "../../common/common.js.flow";
 type Align = "left" | "center" | "right";
 
 export type Props = {|
-  +children?: React$Node,
+  +children?: React.Node,
   +align?: Align,
   ...Globals,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;
 
 declare export var StyledTableCell: ReactComponentStyled<Props>;

--- a/src/Table/TableHead/index.js.flow
+++ b/src/Table/TableHead/index.js.flow
@@ -2,8 +2,8 @@
 import type { Globals } from "../../common/common.js.flow";
 
 export type Props = {|
-  +children: React$Node,
+  +children: React.Node,
   ...Globals,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;

--- a/src/Table/TableRow/index.js.flow
+++ b/src/Table/TableRow/index.js.flow
@@ -4,10 +4,10 @@ import type { ReactComponentStyled } from "styled-components";
 import type { Globals } from "../../common/common.js.flow";
 
 export type Props = {|
-  +children: React$Node,
+  +children: React.Node,
   ...Globals,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;
 
 declare export var StyledTableRow: ReactComponentStyled<Props>;

--- a/src/Table/index.js.flow
+++ b/src/Table/index.js.flow
@@ -10,11 +10,11 @@ import typeof TableRowType from "./TableRow/index.js.flow";
 
 export type Props = {|
   +compact?: boolean,
-  +children: React$Node,
+  +children: React.Node,
   ...Globals,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;
 
 declare export var TableBody: TableBodyType;
 declare export var TableCell: TableCellType;

--- a/src/Tag/index.js.flow
+++ b/src/Tag/index.js.flow
@@ -9,8 +9,8 @@ import type { Globals } from "../common/common.js.flow";
 type Size = "small" | "normal";
 
 export type Props = {|
-  +children: React$Node,
-  +icon?: React$Node,
+  +children: React.Node,
+  +icon?: React.Node,
   +selected?: boolean,
   +size?: Size,
   +onRemove?: () => void | Promise<any>,
@@ -18,6 +18,6 @@ export type Props = {|
   ...Globals,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;
 
 declare export var StyledTag: ReactComponentStyled<any>;

--- a/src/Text/index.js.flow
+++ b/src/Text/index.js.flow
@@ -21,12 +21,12 @@ export type Props = {|
   +italic?: boolean,
   +uppercase?: boolean,
   +element?: Element,
-  +children: React$Node,
+  +children: React.Node,
   +id?: string,
   ...Globals,
   ...spaceAfter,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;
 
 declare export var StyledText: ReactComponentStyled<any>;

--- a/src/TextLink/index.js.flow
+++ b/src/TextLink/index.js.flow
@@ -12,9 +12,9 @@ type Type = "primary" | "secondary";
 type Size = "large" | "normal" | "small";
 
 export type Props = {|
-  +children: React$Node,
+  +children: React.Node,
   +href?: string,
-  +icon?: React$Node,
+  +icon?: React.Node,
   +onClick?: (SyntheticEvent<HTMLLinkElement>) => void | Promise<any>,
   +external?: boolean,
   +type?: Type,
@@ -40,4 +40,4 @@ export type GetLinkStyle = GetLinkStyleProps => Interpolation[];
 declare export var getLinkStyle: GetLinkStyle;
 declare export var StyledTextLink: ReactComponentStyled<styledTextLink>;
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;

--- a/src/Textarea/README.md
+++ b/src/Textarea/README.md
@@ -53,7 +53,7 @@ class Component extends React.PureComponent<Props> {
     this.ref.current && this.ref.current.focus();
   }
 
-  ref: { current: React$ElementRef<*> | null } = React.createRef();
+  ref: { current: React.ElementRef<*> | null } = React.createRef();
 
   render() {
     return (

--- a/src/Textarea/index.js.flow
+++ b/src/Textarea/index.js.flow
@@ -15,8 +15,8 @@ export type Props = {|
   +value?: string,
   +fullHeight?: boolean,
   +placeholder?: Translation,
-  +help?: React$Node,
-  +error?: React$Node,
+  +help?: React.Node,
+  +error?: React.Node,
   +resize?: "vertical" | "none",
   +disabled?: boolean,
   +maxLength?: number,
@@ -26,4 +26,4 @@ export type Props = {|
   +onBlur?: (ev: SyntheticInputEvent<HTMLTextAreaElement>) => void | Promise<any>,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;

--- a/src/ThemeProvider/index.js.flow
+++ b/src/ThemeProvider/index.js.flow
@@ -8,7 +8,7 @@ import type { Translations } from "../Dictionary";
 export type Props = {|
   +theme: any,
   +dictionary?: Translations,
-  +children: React$Node,
+  +children: React.Node,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;

--- a/src/Tile/TileExpandable/index.js.flow
+++ b/src/Tile/TileExpandable/index.js.flow
@@ -7,7 +7,7 @@ export type State = {|
 export type Props = {
   +expanded?: boolean,
   +initialExpanded?: boolean,
-  +children: React$Node,
+  +children: React.Node,
 };
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;

--- a/src/Tile/TileHeader/index.js.flow
+++ b/src/Tile/TileHeader/index.js.flow
@@ -3,9 +3,9 @@
 import type { ReactComponentStyled } from "styled-components";
 
 export type Props = {
-  +icon?: React$Node,
-  +title?: React$Node,
-  +description?: React$Node,
+  +icon?: React.Node,
+  +title?: React.Node,
+  +description?: React.Node,
   +external?: boolean,
   +onClick?: (ev: SyntheticEvent<HTMLDivElement>) => void,
   +isExpandable?: boolean,
@@ -20,4 +20,4 @@ export type IconRightProps = {
 
 declare export var StyledIconRight: ReactComponentStyled<IconRightProps>;
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;

--- a/src/Tile/index.js.flow
+++ b/src/Tile/index.js.flow
@@ -10,10 +10,10 @@ export type State = {
 };
 
 export type Props = {|
-  +title?: React$Node,
-  +description?: React$Node,
-  +icon?: React$Node,
-  +children?: React$Node,
+  +title?: React.Node,
+  +description?: React.Node,
+  +icon?: React.Node,
+  +children?: React.Node,
   +external?: boolean,
   +href?: string,
   +onClick?: (
@@ -23,4 +23,4 @@ export type Props = {|
   ...Globals,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;

--- a/src/Tooltip/components/TooltipContent.js.flow
+++ b/src/Tooltip/components/TooltipContent.js.flow
@@ -7,13 +7,13 @@ export type Props = {|
   shown: boolean,
   size: Sizes,
   tooltipId: string,
-  children: React$Node,
+  children: React.Node,
   onClose: () => void,
   onCloseMobile: () => void,
   onEnter: () => void,
   preferredPosition: ?Positions,
-  containerRef: React$ElementRef<*>,
+  containerRef: React.ElementRef<*>,
   ...Globals,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;

--- a/src/Tooltip/hooks/useDimensions.js.flow
+++ b/src/Tooltip/hooks/useDimensions.js.flow
@@ -3,11 +3,11 @@ import type { Dimensions } from "../index";
 
 export type UseDimensions = (
   {
-    containerRef: ?React$ElementRef<*>,
-    tooltip: ?React$ElementRef<*>,
-    content: ?React$ElementRef<*>,
+    containerRef: ?React.ElementRef<*>,
+    tooltip: ?React.ElementRef<*>,
+    content: ?React.ElementRef<*>,
   },
-  children: React$Node,
+  children: React.Node,
 ) => Dimensions;
 
 declare export default UseDimensions;

--- a/src/Tooltip/index.js.flow
+++ b/src/Tooltip/index.js.flow
@@ -38,8 +38,8 @@ export type Size = {|
 
 export type Props = {|
   ...Globals,
-  +children: React$Node,
-  +content: React$Node,
+  +children: React.Node,
+  +content: React.Node,
   +size?: Sizes,
   +stopPropagation?: boolean,
   +preferredPosition?: Positions,
@@ -48,4 +48,4 @@ export type Props = {|
   +removeUnderlinedText?: boolean,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;

--- a/src/Translate/index.js.flow
+++ b/src/Translate/index.js.flow
@@ -19,6 +19,6 @@ export type Translate = {
   translate: (tKey: string, values?: Values) => string,
 };
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;
 
 declare export var pureTranslate: PureTranslate;

--- a/src/TripSector/TripDate/index.js.flow
+++ b/src/TripSector/TripDate/index.js.flow
@@ -3,8 +3,8 @@ import type { Globals, Translation } from "../../common/common.js.flow";
 
 export type Props = {|
   ...Globals,
-  +children: React$Node,
+  +children: React.Node,
   +duration?: Translation,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;

--- a/src/TripSector/TripLayover/index.js.flow
+++ b/src/TripSector/TripLayover/index.js.flow
@@ -3,7 +3,7 @@ import type { Globals } from "../../common/common.js.flow";
 
 export type Props = {|
   ...Globals,
-  +children: React$Node,
+  +children: React.Node,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;

--- a/src/TripSector/index.js.flow
+++ b/src/TripSector/index.js.flow
@@ -8,10 +8,10 @@ import typeof TripLayoverType from "./TripLayover";
 
 export type Props = {|
   ...Globals,
-  +children: React$Node,
+  +children: React.Node,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;
 
 declare export var TripDate: TripDateType;
 declare export var TripLayover: TripLayoverType;

--- a/src/TripSegment/index.js.flow
+++ b/src/TripSegment/index.js.flow
@@ -18,7 +18,7 @@ export type State = {|
 
 export type Props = {|
   ...Globals,
-  +children: React$Node,
+  +children: React.Node,
   +carrier: Carrier,
   +departure: Translation,
   +departureTime: Translation,
@@ -30,6 +30,6 @@ export type Props = {|
   +onClick?: () => void | Promise<any>,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;
 declare export var StyledTripSegment: ReactComponentStyled<any>;
 declare export var StyledTripSegmentMilestone: ReactComponentStyled<any>;

--- a/src/Truncate/index.js.flow
+++ b/src/Truncate/index.js.flow
@@ -2,9 +2,9 @@
 import type { Globals } from "../common/common.js.flow";
 
 export type Props = {|
-  children: React$Node,
+  children: React.Node,
   maxWidth?: string,
   ...Globals,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;

--- a/src/common/common.js.flow
+++ b/src/common/common.js.flow
@@ -11,6 +11,6 @@ export type Ref = {|
   +ref?: RefType,
 |};
 
-export type Translation = React$Element<React$ComponentType<any>> | string;
+export type Translation = React.Element<React.ComponentType<any>> | string;
 
 export type Component = React.ComponentType<{ className: string }>;

--- a/src/utils/Grid/index.js.flow
+++ b/src/utils/Grid/index.js.flow
@@ -16,7 +16,7 @@ export type MediaQuery = {|
   ...BasicProps,
 |};
 
-export type Props = {
+export type Props = {|
   ...BasicProps,
   ...Globals,
   +element?: string,
@@ -25,11 +25,11 @@ export type Props = {
   +tablet?: MediaQuery,
   +desktop?: MediaQuery,
   +largeDesktop?: MediaQuery,
-  +children: React$Node,
-};
+  +children: React.Node,
+|};
 
 export type SmallMobile = {|
   +smallMobile: MediaQuery,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;

--- a/src/utils/Slide/index.js.flow
+++ b/src/utils/Slide/index.js.flow
@@ -8,7 +8,7 @@ export type State = {|
 |};
 
 export type Props = {|
-  +children: React$Node,
+  +children: React.Node,
   +maxHeight: ?number,
   +expanded?: boolean,
   +ariaLabelledBy?: string,
@@ -17,4 +17,4 @@ export type Props = {|
 
 declare export var StyledSlide: ReactComponentStyled<any>;
 
-declare export default React$ComponentType<Props>;
+declare export default React.ComponentType<Props>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5709,10 +5709,10 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.1.tgz#69e57caa8f0eacbc281d2e2cb458d46fdb449e08"
   integrity sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==
 
-flow-bin@^0.99.1:
-  version "0.99.1"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.99.1.tgz#0d4f413ca84a3a95d0aa64214178684dd7c6a4c5"
-  integrity sha512-dipNwJlb4MsVt3IuDgPTymCNL4GFoq3pG+GbY6DmBbl0dJPWFSA383rCTmgbfFhoeJ1XCfYBan0BPryToSxiiQ==
+flow-bin@^0.112.0:
+  version "0.112.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.112.0.tgz#6a21c31937c4a2f23a750056a364c598a95ea216"
+  integrity sha512-vdcuKv0UU55vjv0e2EVh1ZxlU+TSNT19SkE+6gT1vYzTKtzYE6dLuAmBIiS3Rg2N9D9HOI6TKSyl53zPtqZLrA==
 
 flush-write-stream@^1.0.0:
   version "1.1.1"


### PR DESCRIPTION
- `React$` are internal react types and should not be used, this is list of valid React types: https://flow.org/en/docs/react/types/
- Always import react as `import * as React from "react"` - otherwise types are not imported and you can accidentally shadow global types like `Node`
- how to type HOC: https://flow.org/en/docs/react/hoc/

Further reading
- https://medium.com/flow-type/upgrading-flow-codebases-40ef8dd3ccd8
- https://medium.com/flow-type/spreads-common-errors-fixes-9701012e9d58
- https://medium.com/flow-type/supporting-react-forwardref-and-beyond-f8dd88f35544