### PR TITLE
FIX: Enable tree-shaking for module bundlers

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@kiwicom/orbit-components",
   "version": "0.68.0",
   "description": "Orbit-components is a React component library which provides developers with the easiest possible way of building Kiwi.com’s products.",
+  "sideEffects": false,
   "scripts": {
     "storybook": "start-storybook -p 6007 -c .storybook --ci -s ./static",
     "build": "yarn clean && yarn build:icons && yarn build:iconFont && yarn build:flowFiles && yarn build:lib && yarn build:module && yarn build:umd",


### PR DESCRIPTION
Adding `"sideEffects": false` to `package.json` tells module bundlers that none of the modules in this package have side effects, meaning that importing them won't execute anything, so it's safe to tree-shake unused exports.

This applies to the ESM build in `es` directory.

https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free

This Pull Request meets the following criteria:

* [x] Tests have been added/adjusted for my new feature
* [x] New Components are registered in index.js of my project
