### PR TITLE
FIX: Card header prop, padding in CardSection

### DIFF
--- a/src/Card/CardSection/components/SectionHeader.js
+++ b/src/Card/CardSection/components/SectionHeader.js
@@ -22,13 +22,13 @@ const StyledCardSectionHeader = styled.div`
   position: relative;
   padding: ${({ theme }) => theme.orbit.spaceMedium};
   margin: -${SpacingMobile};
-  margin-bottom: ${({ expanded }) => expanded && 0};
+  margin-bottom: ${({ expanded, isContent }) => expanded && isContent && 0};
   min-height: ${({ expandable }) => expandable && getSize(ICON_SIZES.MEDIUM)};
 
   ${mq.tablet(css`
     margin: -${SpacingDesktop};
     padding: ${({ theme }) => theme.orbit.spaceLarge};
-    margin-bottom: ${({ expanded }) => expanded && 0};
+    margin-bottom: ${({ expanded, isContent }) => expanded && isContent && 0};
   `)}
 
   &:hover {
@@ -57,6 +57,7 @@ type Props = {|
   handleKeyDown: (ev: SyntheticKeyboardEvent<HTMLDivElement>) => void,
   onClick?: () => void,
   slideID: string,
+  isContent: boolean,
   labelID: string,
 |};
 
@@ -64,6 +65,7 @@ const CardSectionHeader = ({
   title,
   description,
   icon,
+  isContent,
   expandable,
   expanded,
   onClick,
@@ -85,6 +87,7 @@ const CardSectionHeader = ({
       role={expandable ? "button" : undefined}
       onKeyDown={handleKeyDown}
       tabIndex={expandable ? "0" : undefined}
+      isContent={isContent}
     >
       <Header
         title={title}

--- a/src/Card/CardSection/index.js
+++ b/src/Card/CardSection/index.js
@@ -103,6 +103,7 @@ const CardSection = ({
           expandable={expandable}
           expanded={opened}
           actions={actions}
+          isContent={!!children}
           onClick={expandable ? handleClick : undefined}
           description={description}
           handleKeyDown={handleKeyDown}

--- a/src/Card/index.js
+++ b/src/Card/index.js
@@ -67,7 +67,7 @@ const Card = ({
 
   return (
     <StyledCard spaceAfter={spaceAfter} data-test={dataTest}>
-      {title && !loading && (
+      {(title || header) && !loading && (
         <CardWrapper bottomBorder={!children || expandedSections.some(val => val === 0)}>
           <Header
             icon={icon}


### PR DESCRIPTION
There was missing condition, so it was not possible to use custom `header` prop

Also i removed padding in CardSection bottom if there is not children in CardSection. <br/><br/><br/><url>LiveURL: https://orbit-components-mainframe-crdhdrfix.surge.sh</url>