### PR TITLE
DEV: Update flow-bin to 0.115.0

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -23,4 +23,10 @@ esproposal.optional_chaining=enable
 suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe
 suppress_comment=\\(.\\|\n\\)*\\$FlowIssue
 suppress_comment=\\(.\\|\n\\)*\\$FlowExpected
+; Following suppress comments are added to make it compatible with FB codebase or to allow smooth Flow
+; upgrades while not being blocked on some already existing issues. You should not use them in your sources
+; manually. Use $FlowIssue or $FlowPullRequest instead. Please read the following link to understand how
+; is this comment being added automatically to our codebase:
+; https://medium.com/flow-type/upgrading-flow-codebases-40ef8dd3ccd8
+suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe\\($\\|[^(]\\|(\\(<VERSION>\\)? *\\(site=[a-z,_]+\\)?)\\)
 server.max_workers=2

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "eslint-plugin-prettier": "^3.1.2",
     "eslint-plugin-react": "^7.18.0",
     "eslint-plugin-react-hooks": "^1.6.0",
-    "flow-bin": "^0.99.1",
+    "flow-bin": "^0.115.0",
     "fs-extra": "^8.1.0",
     "glob": "^7.1.2",
     "isomorphic-unfetch": "^3.0.0",

--- a/src/InputField/index.js
+++ b/src/InputField/index.js
@@ -15,8 +15,9 @@ import getFieldDataState from "../common/getFieldDataState";
 import { StyledButtonLink } from "../ButtonLink/index";
 import randomID from "../utils/randomID";
 import formElementFocus from "./helpers/formElementFocus";
+import type { Theme } from "../defaultTheme";
 
-import type { Props } from "./index";
+import type { Props } from ".";
 
 const getToken = name => ({ theme, size }) => {
   const tokens = {
@@ -201,7 +202,7 @@ Suffix.defaultProps = {
 };
 
 export const Input = styled(
-  React.forwardRef<Props, HTMLInputElement>(
+  React.forwardRef<{| ...Props, theme: Theme |}, HTMLInputElement>(
     ({ type, size, theme, error, help, inlineLabel, ...props }, ref) => (
       <input type={getDOMType(type)} {...props} ref={ref} />
     ),

--- a/src/InputField/index.js.flow
+++ b/src/InputField/index.js.flow
@@ -2,6 +2,7 @@
 /*
   DOCUMENTATION: https://orbit.kiwi/components/inputfield/
 */
+import * as React from 'react';
 import type { ReactComponentStyled } from "styled-components";
 
 import type { Globals, Ref, Translation, TranslationString } from "../common/common.js.flow";
@@ -53,4 +54,4 @@ declare export var Prefix: ReactComponentStyled<any>;
 
 declare export var InputContainer: ReactComponentStyled<any>;
 
-declare export default React$ComponentType<Props>;
+declare export default React.AbstractComponent<Props, HTMLInputElement>;

--- a/src/Modal/ModalContext.js
+++ b/src/Modal/ModalContext.js
@@ -16,6 +16,8 @@ export const ModalContext: ModalContextType = React.createContext({
 
 export const withModalContext: WithModalContextType = Component => props => (
   <ModalContext.Consumer>
-    {contextProps => <Component {...props} {...contextProps} />}
+    {/* $FlowFixMe(>=0.115.0) This comment suppresses an error found when upgrading Flow
+     * to v0.115.0. To view the error, delete this comment and run Flow. */
+    contextProps => <Component {...props} {...contextProps} />}
   </ModalContext.Consumer>
 );

--- a/src/Modal/ModalContext.js.flow
+++ b/src/Modal/ModalContext.js.flow
@@ -14,8 +14,7 @@ export type ModalContextProps = {|
 
 export type ModalContextType = React.Context<ModalContextProps>;
 
-// TODO: write better type
-export type WithModalContextType = (React$ComponentType<any>) => ({ [key: string]: any }) => any;
+export type WithModalContextType = <Config: {}>(React.AbstractComponent<Config>) => React.AbstractComponent<Config>;
 
 declare export var ModalContext: ModalContextType;
 

--- a/src/Modal/ModalFooter/index.js
+++ b/src/Modal/ModalFooter/index.js
@@ -126,7 +126,7 @@ class ModalFooter extends React.PureComponent<Props> {
   }
 }
 
-const DecoratedComponent = withModalContext(ModalFooter);
+const DecoratedComponent = withModalContext<Props>(ModalFooter);
 
 // $FlowFixMe flow doesn't recognize displayName for functions
 DecoratedComponent.displayName = "ModalFooter";

--- a/src/Modal/ModalHeader/index.js
+++ b/src/Modal/ModalHeader/index.js
@@ -15,7 +15,7 @@ import type { Props } from "./index";
 const ModalTitle = styled.div`
   // TODO: create token marginModalTitle and marginModalTitleWithIllustration
   margin-top: ${({ theme, illustration }) => illustration && theme.orbit.spaceXSmall};
-  
+
   ${StyledHeading} {
     padding-${right}: ${({ theme }) => theme.orbit.spaceXLarge};
   }
@@ -207,7 +207,7 @@ class ModalHeader extends React.PureComponent<Props> {
     );
   }
 }
-const DecoratedComponent = withModalContext(ModalHeader);
+const DecoratedComponent = withModalContext<Props>(ModalHeader);
 
 // $FlowFixMe flow doesn't recognize displayName for functions
 DecoratedComponent.displayName = "ModalHeader";

--- a/src/Modal/ModalSection/index.js
+++ b/src/Modal/ModalSection/index.js
@@ -117,7 +117,7 @@ class ModalSection extends React.PureComponent<Props> {
   }
 }
 
-const DecoratedComponent = withModalContext(ModalSection);
+const DecoratedComponent = withModalContext<Props>(ModalSection);
 
 // $FlowFixMe flow doesn't recognize displayName for functions
 DecoratedComponent.displayName = "ModalSection";

--- a/src/Popover/components/ContentWrapper.js
+++ b/src/Popover/components/ContentWrapper.js
@@ -162,7 +162,7 @@ const PopoverContentWrapper = ({
   const dimensions = useDimensions({ containerRef, popover, content, fixed, scrollableParent });
   const verticalPosition = calculateVerticalPosition(position[0], dimensions);
   const horizontalPosition = calculateHorizontalPosition(position[1], dimensions);
-  const actionsDimensions = useMemo(() => boundingClientRect(actionsRef), [actionsRef.current]);
+  const actionsDimensions = useMemo(() => boundingClientRect(actionsRef), []);
 
   useEffect(() => {
     const timer = setTimeout(() => {

--- a/src/Slider/components/Bar/index.js.flow
+++ b/src/Slider/components/Bar/index.js.flow
@@ -1,5 +1,7 @@
 // @flow
 
+import * as React from 'react';
+
 import type { Value } from "../../index";
 
 export type Props = {|
@@ -10,7 +12,7 @@ export type Props = {|
   hasHistogram: boolean,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.AbstractComponent<Props, HTMLElement>;
 
 export type CalculateBarPosition = (
   value: Value,

--- a/src/Slider/index.js
+++ b/src/Slider/index.js
@@ -68,7 +68,7 @@ const StyledSliderInput = styled.div`
 `;
 
 export class PureSlider extends React.PureComponent<Props & ThemeProps, State> {
-  bar: { current: React$ElementRef<*> } = React.createRef();
+  bar = React.createRef<?HTMLElement>();
 
   static defaultProps = {
     theme: defaultTheme,

--- a/src/Tile/components/TileContent/index.js
+++ b/src/Tile/components/TileContent/index.js
@@ -38,7 +38,7 @@ StyledTileContent.defaultProps = {
   theme: defaultTheme,
 };
 
-const TileContent = forwardRef<Props, HTMLElement>(
+const TileContent = forwardRef<Props, HTMLInputElement>(
   (
     { children, noPadding, withPointer = false, withBorder = false, useMargins = true }: Props,
     ref,

--- a/src/Tile/components/TileContent/index.js.flow
+++ b/src/Tile/components/TileContent/index.js.flow
@@ -1,4 +1,6 @@
 // @flow
+import * as React from "react";
+
 export type Props = {|
   children?: React$Node,
   noPadding: boolean,
@@ -7,4 +9,4 @@ export type Props = {|
   useMargins?: boolean,
 |};
 
-declare export default React$ComponentType<Props>;
+declare export default React.AbstractComponent<Props, HTMLDivElement>;

--- a/src/Tile/components/TileExpandable/index.js
+++ b/src/Tile/components/TileExpandable/index.js
@@ -1,5 +1,5 @@
 // @flow
-import React, { useEffect, useRef, useState } from "react";
+import * as React from "react";
 
 import Slide from "../../../utils/Slide/index";
 import randomID from "../../../utils/randomID/index";
@@ -21,9 +21,9 @@ const TileExpandable = ({
   icon,
   dataTest,
 }: Props) => {
-  const [expanded, setExpanded] = useState(initialExpanded);
-  const [contentHeight, setContentHeight] = useState(initialExpanded ? null : 0);
-  const node = useRef(null);
+  const [expanded, setExpanded] = React.useState(initialExpanded);
+  const [contentHeight, setContentHeight] = React.useState(initialExpanded ? null : 0);
+  const node = React.useRef<?HTMLDivElement>(null);
 
   const handleClick = event => {
     if (onClick) {
@@ -47,7 +47,7 @@ const TileExpandable = ({
     }
   };
 
-  useEffect(() => {
+  React.useEffect(() => {
     const calculateHeight = () => {
       if (node && node.current) {
         const { height } = node.current.getBoundingClientRect();

--- a/src/hooks/useMediaQuery/index.js
+++ b/src/hooks/useMediaQuery/index.js
@@ -100,6 +100,8 @@ const useMediaQuery: UseMediaQuery = () => {
       isLargeMobile: null,
       isMediumMobile: null,
     },
+    /* $FlowFixMe(>=0.115.0) This comment suppresses an error found when upgrading Flow to
+     * v0.115.0. To view the error, delete this comment and run Flow. */
     ...breakpointList.map(item => ({ [item.mapping]: item.matches })),
   );
 };

--- a/src/utils/Grid/index.js
+++ b/src/utils/Grid/index.js
@@ -55,7 +55,7 @@ const Grid = ({
 }: Props) => {
   const smallMobile = { inline, rows, columns, gap, rowGap, columnGap, maxWidth };
   return (
-    <StyledGrid smallMobile={smallMobile} data-test={dataTest} as={element} {...props}>
+    <StyledGrid {...props} smallMobile={smallMobile} data-test={dataTest} as={element}>
       {children}
     </StyledGrid>
   );

--- a/src/utils/mediaQuery/index.js
+++ b/src/utils/mediaQuery/index.js
@@ -20,8 +20,12 @@ export const getBreakpointWidth: GetBreakpointWidth = (name, theme, pure) => {
 };
 
 const mediaQueries: MediaQueries = Object.keys(QUERIES).reduce(
+  /* $FlowFixMe(>=0.115.0) This comment suppresses an error found when upgrading Flow to
+   * v0.115.0. To view the error, delete this comment and run Flow. */
   (o, name) => ({
     ...o,
+    /* $FlowFixMe(>=0.115.0) This comment suppresses an error found when upgrading Flow to
+     * v0.115.0. To view the error, delete this comment and run Flow. */
     [QUERIES[name]]: style =>
       css`
         @media ${({ theme }) => getBreakpointWidth(QUERIES[name], theme)} {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5840,10 +5840,10 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.1.tgz#69e57caa8f0eacbc281d2e2cb458d46fdb449e08"
   integrity sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==
 
-flow-bin@^0.99.1:
-  version "0.99.1"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.99.1.tgz#0d4f413ca84a3a95d0aa64214178684dd7c6a4c5"
-  integrity sha512-dipNwJlb4MsVt3IuDgPTymCNL4GFoq3pG+GbY6DmBbl0dJPWFSA383rCTmgbfFhoeJ1XCfYBan0BPryToSxiiQ==
+flow-bin@^0.115.0:
+  version "0.115.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.115.0.tgz#22e3ad9e5c7198967de80138ba8a9154ff387960"
+  integrity sha512-xW+U2SrBaAr0EeLvKmXAmsdnrH6x0Io17P6yRJTNgrrV42G8KXhBAD00s6oGbTTqRyHD0nP47kyuU34zljZpaQ==
 
 flush-write-stream@^1.0.0:
   version "1.1.1"


### PR DESCRIPTION
- update flow to latest version (`0.115.0`)
- fix broken flow types where possible - mostly refs
- broken checks which I found too difficult to fix (and benefit of fixing them is not high) are disabled following this guide: https://medium.com/flow-type/upgrading-flow-codebases-40ef8dd3ccd8<br/><br/><br/><url>LiveURL: https://orbit-components-update-flow-bin.surge.sh</url>