### PR TITLE
DEV: update dependabot to prefix commits with "DEV:"

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -4,3 +4,5 @@ update_configs:
     directory: '/'
     update_schedule: 'live'
     version_requirement_updates: 'increase_versions'
+    commit_message:
+      prefix: 'DEV'


### PR DESCRIPTION
`: ` should be added automatically when prefix is set 🙂 
<br/><br/><br/><url>LiveURL: https://orbit-components-update-dependabot.surge.sh</url>