### PR TITLE
DOCS: Add theme to example for media queries

### DIFF
--- a/src/utils/mediaQuery/README.md
+++ b/src/utils/mediaQuery/README.md
@@ -1,12 +1,12 @@
 # Media queries
 
-In the `orbit-components` package you can find several media queries that are based on the mobile first approach.
+The `orbit-components` package contains several media queries that are based on a mobile-first approach.
 
 ## Media query functions
 
-By default you should define styles firstly for mobile and then use queries for bigger devices.
+By default, you should first define styles for mobile and then use queries for bigger devices.
 
-Example below is a good start to implement media query functions into your project that uses `styled-components`:
+The example below is a good start to implementing media query functions in a project using `styled-components`:
 
 ```jsx
 import media from "@kiwicom/orbit-components/lib/utils/mediaQuery";
@@ -21,7 +21,31 @@ const StyledComponent = styled.div`
 `;
 ```
 
-You can use these media queries in your project:
+To use the component, combine it with your theme:
+
+```jsx
+import media from "@kiwicom/orbit-components/lib/utils/mediaQuery";
+import styled, { css } from "styled-components";
+import ThemeProvider from "@kiwicom/orbit-components/lib/ThemeProvider";
+import defaultTheme from "@kiwicom/orbit-components/lib/defaultTheme";
+
+const StyledComponent = styled.div`
+  width: 100%;
+
+  ${media.desktop(css`
+    width: 50%;
+  `)};
+`;
+function App() {
+  return (
+    <ThemeProvider theme={defaultTheme}>
+      <StyledComponent>This div will be styled.</StyledComponent>
+    </ThemeProvider>
+  );
+}
+```
+
+You can use the following media queries in your project:
 
 | Name         | Applies from width |
 | :----------- | :----------------- |
@@ -33,9 +57,9 @@ You can use these media queries in your project:
 
 ## Breakpoints for testing purposes
 
-For testing your components with Enzyme, especially styles, you can also use getBreakpointWidth function.
+To test your components with Enzyme, especially styles, you can also use the `getBreakpointWidth` function.
 
-Imagine that we have component and we want to test if it's contain specific styles:
+Imagine that you have a component and want to test if it contains specific styles:
 
 ```jsx
 const StyledComponent = styled.div`
@@ -46,26 +70,26 @@ const StyledComponent = styled.div`
   `)};
 ```
 
-In this case, our test would require to `mount` this component and than check if it's have specific styles with `toHaveStyleRule` function from package [`jest-styled-components`](https://www.npmjs.com/package/jest-styled-components):
+In this case, you would need to `mount` this component and than check if it has specific styles with the `toHaveStyleRule` function from the [`jest-styled-components`](https://www.npmjs.com/package/jest-styled-components) package.
 
-The `getBreakpointWidth` function accepts name of the viewport and theme object. You can use it like:
+The `getBreakpointWidth` function accepts the viewport name and a theme object. You can use it like this:
 
 ```jsx
 import * as React from "react";
 import { mount } from "enzyme";
-import theme from "@kiwicom/orbit-components/lib/defaultTheme
-import { getBreakpointWidth } from "@kiwicom/orbit-components/lib/utils/mediaQuery"
+import theme from "@kiwicom/orbit-components/lib/defaultTheme";
+import { getBreakpointWidth } from "@kiwicom/orbit-components/lib/utils/mediaQuery";
 
-import StyledComponent from "./"
+import StyledComponent from "./";
 
 describe("StyledComponent", () => {
   const component = mount(<StyledComponent />);
 
-  it("should have width 100 % by default", () => {
+  it("should have 100% width by default", () => {
     expect(component).toHaveStyleRule("width", "100%");
   });
 
-  it("should have width 50 % on desktop viewport", () => {
+  it("should have a width of 50% on a desktop viewport", () => {
     expect(component).toHaveStyleRule("width", "50%", {
       media: getBreakpointWidth("desktop", theme),
     });


### PR DESCRIPTION
This pull request only changes the ReadMe.md for mediaQuery.
<br/><br/><br/><url>LiveURL: https://orbit-components-docs-example-for-media-queries.surge.sh</url>