### PR TITLE
FIX: Select autofill setting

### DIFF
--- a/src/Select/Select.stories.js
+++ b/src/Select/Select.stories.js
@@ -1,5 +1,5 @@
 // @flow
-import React, { useState } from "react";
+import * as React from "react";
 import { storiesOf } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
 import { object, select, text, boolean } from "@storybook/addon-knobs";
@@ -10,7 +10,6 @@ import CountryFlag from "../CountryFlag";
 import { CODES } from "../CountryFlag/consts";
 import RenderInRtl from "../utils/rtl/RenderInRtl";
 import SPACINGS_AFTER from "../common/getSpacingToken/consts";
-import InputField from "../InputField";
 
 import Select from "./index";
 
@@ -20,20 +19,6 @@ const objectOptions = [
   { value: 2, label: "Second item" },
   { value: 3, label: "Third item" },
 ];
-
-const SelectWithState = () => {
-  const [value, setValue] = useState("");
-  return (
-    <Select
-      label="Select box (with prefix)"
-      options={[{ value: "pl", label: "Poland" }, { value: "cz", label: "Czech Republic" }]}
-      prefix={<Airplane color="secondary" />}
-      name="nationality"
-      value={value}
-      onChange={ev => setValue(ev.target.value)}
-    />
-  );
-};
 
 storiesOf("Select", module)
   .add("Default", () => <Select options={objectOptions} onChange={action("onChange")} />, {
@@ -185,21 +170,5 @@ storiesOf("Select", module)
     ),
     {
       info: "This is a preview of this component in RTL setup.",
-    },
-  )
-  .add(
-    "Autofill",
-    () => (
-      <>
-        <form>
-          <InputField label="First name" name="firstname" placeholder="First name" />
-          <InputField label="Last name" name="lastname" placeholder="Last name" />
-          <SelectWithState />
-        </form>
-      </>
-    ),
-    {
-      info:
-        "Selects are used for showing content hierarchy and are important for improving the reading experience for our users. Visit Orbit.Kiwi for more detailed guidelines.",
     },
   );

--- a/src/Select/Select.stories.js
+++ b/src/Select/Select.stories.js
@@ -1,5 +1,5 @@
 // @flow
-import * as React from "react";
+import React, { useState } from "react";
 import { storiesOf } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
 import { object, select, text, boolean } from "@storybook/addon-knobs";
@@ -10,6 +10,7 @@ import CountryFlag from "../CountryFlag";
 import { CODES } from "../CountryFlag/consts";
 import RenderInRtl from "../utils/rtl/RenderInRtl";
 import SPACINGS_AFTER from "../common/getSpacingToken/consts";
+import InputField from "../InputField";
 
 import Select from "./index";
 
@@ -19,6 +20,20 @@ const objectOptions = [
   { value: 2, label: "Second item" },
   { value: 3, label: "Third item" },
 ];
+
+const SelectWithState = () => {
+  const [value, setValue] = useState("");
+  return (
+    <Select
+      label="Select box (with prefix)"
+      options={[{ value: "pl", label: "Poland" }, { value: "cz", label: "Czech Republic" }]}
+      prefix={<Airplane color="secondary" />}
+      name="nationality"
+      value={value}
+      onChange={ev => setValue(ev.target.value)}
+    />
+  );
+};
 
 storiesOf("Select", module)
   .add("Default", () => <Select options={objectOptions} onChange={action("onChange")} />, {
@@ -170,5 +185,21 @@ storiesOf("Select", module)
     ),
     {
       info: "This is a preview of this component in RTL setup.",
+    },
+  )
+  .add(
+    "Autofill",
+    () => (
+      <>
+        <form>
+          <InputField label="First name" name="firstname" placeholder="First name" />
+          <InputField label="Last name" name="lastname" placeholder="Last name" />
+          <SelectWithState />
+        </form>
+      </>
+    ),
+    {
+      info:
+        "Selects are used for showing content hierarchy and are important for improving the reading experience for our users. Visit Orbit.Kiwi for more detailed guidelines.",
     },
   );

--- a/src/Select/index.js
+++ b/src/Select/index.js
@@ -145,10 +145,14 @@ const StyledSelect = styled(
     }
   }
 
-  &:-webkit-autofill,
-  &:-internal-autofill-selected {
-    -webkit-text-fill-color: transparent;
-  }
+  ${({ customValueText }) =>
+    customValueText &&
+    `
+    &:-webkit-autofill,
+    &:-internal-autofill-selected {
+      -webkit-text-fill-color: transparent;
+    }
+  `}
 `;
 
 StyledSelect.defaultProps = {

--- a/src/Select/index.js
+++ b/src/Select/index.js
@@ -145,6 +145,10 @@ const StyledSelect = styled(
     }
   }
 
+  /*
+    This fix is needed for case where Select has customValueText and it's autofilled by webkit based browser.
+    In that case autofilled value would be displayed, overflowing customValueText.
+  */
   ${({ customValueText }) =>
     customValueText &&
     `


### PR DESCRIPTION
This fix is needed for case where `Select` has `customValueText` and it's autofilled by webkit based browser.
In that case autofilled `value` would be displayed, overflowing `customValueText`.<br/><br/><br/><url>LiveURL: https://orbit-components-fix-select-autofill.surge.sh</url>