### PR TITLE
FIX: Tag displaying cursor:pointer and states on non-actionable type

### DIFF
--- a/src/Tag/Tag.stories.js
+++ b/src/Tag/Tag.stories.js
@@ -32,6 +32,18 @@ storiesOf("Tag", module)
     },
   )
   .add(
+    "Nonactionable",
+    () => {
+      const content = text("Content", "Brno");
+      const Icon = getIcon(getIcons("Airplane"));
+
+      return <Tag icon={Icon && <Icon />}>{content}</Tag>;
+    },
+    {
+      info: "Check Orbit.Kiwi for more detailed design guidelines.",
+    },
+  )
+  .add(
     "Playground",
     () => {
       const content = text("Content", "Transport");

--- a/src/Tag/index.js
+++ b/src/Tag/index.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from "react";
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 
 import defaultTheme from "../defaultTheme";
 import { rtlSpacing, left, right } from "../utils/rtl";
@@ -47,7 +47,7 @@ export const StyledTag = styled.div`
     selected ? theme.orbit.colorTextTagSelected : theme.orbit.colorTextTag};
   background: ${getBackgroundColor(STATES.DEFAULT)};
   display: inline-flex;
-  cursor: pointer;
+
   box-sizing: border-box;
   justify-content: center;
   align-items: center;
@@ -61,21 +61,31 @@ export const StyledTag = styled.div`
     box-shadow ${({ theme }) => theme.orbit.durationFast} ease-in-out,
     background ${({ theme }) => theme.orbit.durationFast} ease-in-out;
 
-  &:hover {
-    background: ${getBackgroundColor(STATES.HOVER)};
-    box-shadow: none;
-  }
-
-  &:active {
-    background: ${getBackgroundColor(STATES.ACTIVE)};
-    box-shadow: none;
-  }
-
   &:focus {
-    background: ${getBackgroundColor(STATES.HOVER)};
-    box-shadow: none;
     outline: 0;
   }
+
+  ${({ actionable }) =>
+    actionable &&
+    css`
+      cursor: pointer;
+
+      &:hover {
+        background: ${getBackgroundColor(STATES.HOVER)};
+        box-shadow: none;
+      }
+
+      &:active {
+        background: ${getBackgroundColor(STATES.ACTIVE)};
+        box-shadow: none;
+      }
+
+      &:focus {
+        background: ${getBackgroundColor(STATES.HOVER)};
+        box-shadow: none;
+        outline: 0;
+      }
+    `};
 `;
 
 StyledTag.defaultProps = {
@@ -142,6 +152,7 @@ const Tag = (props: Props) => {
 
   return (
     <StyledTag
+      actionable={onClick || onRemove}
       data-test={dataTest}
       size={size}
       onClick={onClick}


### PR DESCRIPTION
What: Removing `cursor:pointer;` hover, focus and active states from non-actionable type of `Tag`
Why: By specification, Tag offers a label that can optionally be selected and unselected or removed. So forcing cursor: pointer; is not desired. <br/><br/><br/><url>LiveURL: https://orbit-components-fix-tag-pointer.surge.sh</url>