### PR TITLE
UPDATE: Add onlySelectionText property to filter ChoiceGroup

### DIFF
--- a/src/ChoiceGroup/ChoiceGroup.stories.js
+++ b/src/ChoiceGroup/ChoiceGroup.stories.js
@@ -47,12 +47,14 @@ storiesOf("ChoiceGroup", module)
     "Filter",
     () => {
       const label = text("Label", "What was the reason for your cancellation?");
+      const onlySelectionText = text("onlySelectionText", "Only");
       return (
         <ChoiceGroup
           label={label}
           filter
           onChange={action("onChange")}
           onOnlySelection={action("onOnlySelection")}
+          onlySelectionText={onlySelectionText}
         >
           <Checkbox label="Reason one" value="one" disabled />
           <Checkbox label="Reason two" value="two" />

--- a/src/ChoiceGroup/README.md
+++ b/src/ChoiceGroup/README.md
@@ -21,17 +21,18 @@ After adding import into your project you can use it simply like:
 
 Table below contains all types of the props available in the ChoiceGroup component.
 
-| Name            | Type                                                              | Default    | Description                                                                                                       |
-| :-------------- | :---------------------------------------------------------------- | :--------- | :---------------------------------------------------------------------------------------------------------------- |
-| dataTest        | `string`                                                          |            | Optional prop for testing purposes.                                                                               |
-| **children**    | `React.Node`                                                      |            | The content of the ChoiceGroup, normally **Radio** or **Checkbox**                                                |
-| error           | `Translation`                                                     |            | The error to display beneath the ChoiceGroup. Also, the Checkboxes/Radios will turn red when you pass some value. |
-| label           | `Translation`                                                     |            | Heading text of the ChoiceGroup                                                                                   |
-| labelAs         | [`enum`](#enum)                                                   | `"h4"`     | The element used to render the label into.                                                                        |
-| labelSize       | [`enum`](#enum)                                                   | `"normal"` | The size type of Heading.                                                                                         |
-| **onChange**    | `event => void \| Promise`                                        |            | Function for handling onChange event. [See Functional specs](#functional-specs)                                   |
-| filter          | `boolean`                                                         | `false`    | Changes visual appearance of child components, to contain background on hover and updates padding.                |
-| onOnlySelection | `(event, {value: string, label: string}) => void \| Promise<any>` |            | Function for handling onOnlySelection, read more in Functional specs.                                             |
+| Name              | Type                                                              | Default    | Description                                                                                                       |
+| :---------------- | :---------------------------------------------------------------- | :--------- | :---------------------------------------------------------------------------------------------------------------- |
+| dataTest          | `string`                                                          |            | Optional prop for testing purposes.                                                                               |
+| **children**      | `React.Node`                                                      |            | The content of the ChoiceGroup, normally **Radio** or **Checkbox**                                                |
+| error             | `Translation`                                                     |            | The error to display beneath the ChoiceGroup. Also, the Checkboxes/Radios will turn red when you pass some value. |
+| label             | `Translation`                                                     |            | Heading text of the ChoiceGroup                                                                                   |
+| labelAs           | [`enum`](#enum)                                                   | `"h4"`     | The element used to render the label into.                                                                        |
+| labelSize         | [`enum`](#enum)                                                   | `"normal"` | The size type of Heading.                                                                                         |
+| **onChange**      | `event => void \| Promise`                                        |            | Function for handling onChange event. [See Functional specs](#functional-specs)                                   |
+| filter            | `boolean`                                                         | `false`    | Changes visual appearance of child components, to contain background on hover and updates padding.                |
+| onOnlySelection   | `(event, {value: string, label: string}) => void \| Promise<any>` |            | Function for handling onOnlySelection, read more in Functional specs.                                             |
+| onlySelectionText | `Translation`                                                     |            | Property for passing translation string when you want to use the `onOnlySelection` callback.                      |
 
 ### enum
 

--- a/src/ChoiceGroup/components/FilterWrapper.js
+++ b/src/ChoiceGroup/components/FilterWrapper.js
@@ -46,7 +46,12 @@ StyledContentWrapper.defaultProps = {
   theme: defaultTheme,
 };
 
-const FilterWrapper: FilterWrapperType = ({ child, children, onOnlySelection }) => {
+const FilterWrapper: FilterWrapperType = ({
+  child,
+  children,
+  onOnlySelection,
+  onlySelectionText,
+}) => {
   const { value, label, disabled } = child.props;
   return (
     <StyledContentWrapper disabled={disabled}>
@@ -60,7 +65,7 @@ const FilterWrapper: FilterWrapperType = ({ child, children, onOnlySelection }) 
           }}
           transparent
         >
-          Only {/* TODO: Dictionary */}
+          {onlySelectionText}
         </StyledOnlyButton>
       )}
     </StyledContentWrapper>

--- a/src/ChoiceGroup/components/FilterWrapper.js.flow
+++ b/src/ChoiceGroup/components/FilterWrapper.js.flow
@@ -1,9 +1,12 @@
 // @flow
 
+import type { Translation } from "../../common/common.js.flow";
+
 type Props = {|
   +child: React$Element<*>,
   +children: React$Element<*>,
   +onOnlySelection?: (SyntheticEvent<HTMLButtonElement>, {}) => void | Promise<any>,
+  +onlySelectionText?: Translation,
 |};
 
 export type FilterWrapperType = Props => React$Element<*>;

--- a/src/ChoiceGroup/index.js
+++ b/src/ChoiceGroup/index.js
@@ -57,7 +57,7 @@ class ChoiceGroup extends React.PureComponent<Props> {
       children,
       filter,
       onOnlySelection,
-      onlySelectionText
+      onlySelectionText,
     } = this.props;
 
     return (
@@ -82,7 +82,11 @@ class ChoiceGroup extends React.PureComponent<Props> {
                 })}
               </React.Fragment>
             ) : (
-              <FilterWrapper child={child} onOnlySelection={onOnlySelection} onlySelectionText={onlySelectionText}>
+              <FilterWrapper
+                child={child}
+                onOnlySelection={onOnlySelection}
+                onlySelectionText={onlySelectionText}
+              >
                 <React.Fragment>
                   {React.cloneElement(child, {
                     onChange: this.handleChange,

--- a/src/ChoiceGroup/index.js
+++ b/src/ChoiceGroup/index.js
@@ -57,6 +57,7 @@ class ChoiceGroup extends React.PureComponent<Props> {
       children,
       filter,
       onOnlySelection,
+      onlySelectionText
     } = this.props;
 
     return (
@@ -81,7 +82,7 @@ class ChoiceGroup extends React.PureComponent<Props> {
                 })}
               </React.Fragment>
             ) : (
-              <FilterWrapper child={child} onOnlySelection={onOnlySelection}>
+              <FilterWrapper child={child} onOnlySelection={onOnlySelection} onlySelectionText={onlySelectionText}>
                 <React.Fragment>
                   {React.cloneElement(child, {
                     onChange: this.handleChange,

--- a/src/ChoiceGroup/index.js.flow
+++ b/src/ChoiceGroup/index.js.flow
@@ -16,6 +16,7 @@ export type Props = {|
   labelSize?: LabelSize,
   labelAs?: LabelAs,
   error?: Translation,
+  onlySelectionText?: Translation,
   filter?: boolean,
   onOnlySelection?: (SyntheticEvent<HTMLButtonElement>, {}) => void | Promise<any>,
   onChange: (SyntheticInputEvent<HTMLInputElement>) => void | Promise<any>,


### PR DESCRIPTION
Why: We can't provide generic translation key for this use case as it's very dependent on the actual usage and also language context.
<br/><br/><br/><url>LiveURL: https://orbit-components-update-add-onlyselectiontext-choicegroup.surge.sh</url>