### PR TITLE
UPDATE: Add stopPropagation property to TextLink

### DIFF
--- a/src/Checkbox/Checkbox.stories.js
+++ b/src/Checkbox/Checkbox.stories.js
@@ -46,7 +46,10 @@ storiesOf("CheckBox", module)
             <Text>
               I instruct Kiwi.com to cancel this booking under the herein specified conditions and
               to process a refund in accordance with Kiwi.com&rsquo;&nbsp;
-              <TextLink>Terms and Conditions</TextLink>.
+              <TextLink stopPropagation href="https://kiwi.com" external>
+                Terms and Conditions
+              </TextLink>
+              .
             </Text>
           }
           checked={checked}

--- a/src/TextLink/README.md
+++ b/src/TextLink/README.md
@@ -16,19 +16,20 @@ After adding import into your project you can use it simply like:
 
 Table below contains all types of the props available in TextLink component.
 
-| Name        | Type                       | Default     | Description                                                                                |
-| :---------- | :------------------------- | :---------- | :----------------------------------------------------------------------------------------- |
-| asComponent | `string \| React.Node`     | `"a"`       | The component used for the root node. Either a string to use a DOM element or a component. |
-| children    | `React.Node`               |             | The content of the TextLink.                                                               |
-| dataTest    | `string`                   |             | Optional prop for testing purposes.                                                        |
-| external    | `boolean`                  | `false`     | If `true`, the TextLink opens link in a new tab.                                           |
-| href        | `string`                   |             | The URL to link when the TextLink is clicked.                                              |
-| icon        | `React.Node`               |             | The displayed icon.                                                                        |
-| onClick     | `event => void \| Promise` |             | Function for handling onClick event.                                                       |
-| rel         | `string`                   |             | The rel of the TextLink. [See Functional specs](#functional-specs)                         |
-| size        | [`enum`](#enum)            |             | The size of the TextLink. [See Functional specs](#functional-specs)                        |
-| tabIndex    | `string`                   |             | Specifies the tab order of an element                                                      |
-| **type**    | [`enum`](#enum)            | `"primary"` | The color type of the TextLink.                                                            |
+| Name            | Type                       | Default     | Description                                                                                                        |
+| :-------------- | :------------------------- | :---------- | :----------------------------------------------------------------------------------------------------------------- |
+| asComponent     | `string \| React.Node`     | `"a"`       | The component used for the root node. Either a string to use a DOM element or a component.                         |
+| children        | `React.Node`               |             | The content of the TextLink.                                                                                       |
+| dataTest        | `string`                   |             | Optional prop for testing purposes.                                                                                |
+| external        | `boolean`                  | `false`     | If `true`, the TextLink opens link in a new tab.                                                                   |
+| href            | `string`                   |             | The URL to link when the TextLink is clicked.                                                                      |
+| icon            | `React.Node`               |             | The displayed icon.                                                                                                |
+| onClick         | `event => void \| Promise` |             | Function for handling onClick event.                                                                               |
+| rel             | `string`                   |             | The rel of the TextLink. [See Functional specs](#functional-specs)                                                 |
+| size            | [`enum`](#enum)            |             | The size of the TextLink. [See Functional specs](#functional-specs)                                                |
+| stopPropagation | `boolean`                  |             | If `true` the click event on children won't bubble. Useful when you use TextLink inside another clickable element. |
+| tabIndex        | `string`                   |             | Specifies the tab order of an element                                                                              |
+| **type**        | [`enum`](#enum)            | `"primary"` | The color type of the TextLink.                                                                                    |
 
 ### enum
 

--- a/src/TextLink/TextLink.stories.js
+++ b/src/TextLink/TextLink.stories.js
@@ -83,7 +83,7 @@ storiesOf("TextLink", module)
       const Icon = getIcon(getIcons("ChevronRight"));
       const dataTest = text("dataTest", "test");
       const tabIndex = text("tabIndex", "");
-
+      const stopPropagation = boolean("stopPropagation", false);
       return (
         <TextLink
           external={external}
@@ -95,6 +95,7 @@ storiesOf("TextLink", module)
           icon={Icon && <Icon />}
           dataTest={dataTest}
           tabIndex={tabIndex}
+          stopPropagation={stopPropagation}
         >
           {title}
         </TextLink>

--- a/src/TextLink/index.js
+++ b/src/TextLink/index.js
@@ -135,6 +135,7 @@ const TextLink = ({
   dataTest,
   tabIndex,
   asComponent = DefaultComponent,
+  stopPropagation = false,
 }: Props) => {
   const relValues = rel ? rel.split(" ") : [];
 
@@ -148,6 +149,14 @@ const TextLink = ({
     }
   }
 
+  const onClickHandler = ev => {
+    if (stopPropagation) {
+      ev.stopPropagation();
+      if (onClick) onClick(ev);
+    }
+    if (onClick) onClick(ev);
+  };
+
   return (
     <StyledTextLink
       type={type}
@@ -155,7 +164,7 @@ const TextLink = ({
       href={href}
       target={external ? "_blank" : undefined}
       rel={relValues && relValues.join(" ")}
-      onClick={onClick}
+      onClick={onClickHandler}
       data-test={dataTest}
       tabIndex={tabIndex || (!href ? "0" : undefined)}
       role={!href ? "button" : undefined}

--- a/src/TextLink/index.js.flow
+++ b/src/TextLink/index.js.flow
@@ -22,6 +22,7 @@ export type Props = {|
   +rel?: string,
   +tabIndex?: string,
   +asComponent?: Component,
+  +stopPropagation?: boolean,
   ...Globals,
 |};
 


### PR DESCRIPTION
Why: In some cases TextLink is used to open a new tab but with bubbling it will select e.g. CheckBox which is undesired behaviour.<br/><br/><br/><url>LiveURL: https://orbit-components-update-add-stoppropagation-textlink.surge.sh</url>