### PR TITLE
BREAKING: PricingTable uncontrolled

### DIFF
--- a/src/PricingTable/PricingTable.stories.js
+++ b/src/PricingTable/PricingTable.stories.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from "react";
 import { storiesOf } from "@storybook/react";
-import { withKnobs } from "@storybook/addon-knobs";
+import { withKnobs, number, boolean } from "@storybook/addon-knobs";
 import { action } from "@storybook/addon-actions";
 
 import Badge from "../Badge";
@@ -100,8 +100,11 @@ storiesOf("PricingTable", module)
   .add(
     "Compact",
     () => {
+      const activeElement = number("activeElement", null);
+      const hasError = boolean("hasError", false);
+
       return (
-        <PricingTable defaultActiveElement={1} dataTest="PricingTable">
+        <PricingTable hasError={hasError} activeElement={activeElement} dataTest="PricingTable">
           <PricingTableItem
             dataTest="PricingTableItem"
             name="Limited Services"
@@ -171,12 +174,14 @@ storiesOf("PricingTable", module)
     },
   )
   .add("Booking", () => {
+    const activeElement = number("activeElement", 0);
+
     return (
       <Layout type="Booking">
         <LayoutColumn>
           <Card>
             <CardSection>
-              <PricingTable defaultActiveElement={1}>
+              <PricingTable activeElement={activeElement}>
                 <PricingTableItem
                   name="Limited Services"
                   priceBadge={<Badge type="info">Included</Badge>}
@@ -247,12 +252,14 @@ storiesOf("PricingTable", module)
     );
   })
   .add("Translated", () => {
+    const activeElement = number("activeElement", 0);
+
     return (
       <Layout type="Booking">
         <LayoutColumn>
           <Card>
             <CardSection>
-              <PricingTable defaultActiveElement={1}>
+              <PricingTable activeElement={activeElement}>
                 <PricingTableItem
                   name="Basic Service"
                   priceBadge={<Badge type="info">Inbegriffen</Badge>}

--- a/src/PricingTable/PricingTableItem/index.js
+++ b/src/PricingTable/PricingTableItem/index.js
@@ -12,8 +12,9 @@ import media from "../../utils/mediaQuery";
 import type { Props } from "./index.js.flow";
 import STATES from "./consts";
 
-const getBoxShadow = state => ({ theme, active }) => {
+const getBoxShadow = state => ({ theme, active, hasError }) => {
   const getActive = shadow => {
+    if (hasError) return `${shadow}, inset 0 0 0 1px ${theme.orbit.borderColorInputError}`;
     if (active) return `${shadow}, inset 0 0 0 2px ${theme.orbit.paletteProductNormal}`;
     return shadow;
   };
@@ -114,6 +115,7 @@ const PricingTableItem = ({
   children,
   onClick,
   basis,
+  hasError,
 }: Props) => {
   const onClickHandler = () => {
     if (onClick) {
@@ -128,6 +130,7 @@ const PricingTableItem = ({
       featureIcon={!!featureIcon}
       active={active}
       data-test={dataTest}
+      hasError={hasError}
     >
       {badge && (
         <StyledBadgeWrapper>
@@ -172,7 +175,7 @@ const PricingTableItem = ({
           ) : (
             <Stack justify="center" align="center" grow={false}>
               <Item>
-                <Radio checked={active} onChange={onClickHandler} />
+                <Radio checked={active} onChange={onClickHandler} hasError={hasError} />
               </Item>
             </Stack>
           )}

--- a/src/PricingTable/PricingTableItem/index.js.flow
+++ b/src/PricingTable/PricingTableItem/index.js.flow
@@ -15,6 +15,7 @@ export type Props = {|
   +compact?: boolean,
   +action?: React$Node,
   +basis?: string,
+  +hasError?: boolean,
   +onClick?: () => void | Promise<any>,
 |};
 

--- a/src/PricingTable/README.md
+++ b/src/PricingTable/README.md
@@ -19,11 +19,12 @@ After adding import into your project you can use it simply like:
 
 Table below contains all types of the props available in the PricingTable component.
 
-| Name                 | Type         | Default | Description                                                          |
-| :------------------- | :----------- | :------ | :------------------------------------------------------------------- |
-| children             | `React.Node` |         | The content of the PricingTable. [See Subcomponents](#subcomponents) |
-| dataTest             | `string`     |         | Optional prop for testing purposes.                                  |
-| defaultActiveElement | `number`     | `0`     | Sets default active element on mobile view                           |
+| Name          | Type         | Default | Description                                                          |
+| :------------ | :----------- | :------ | :------------------------------------------------------------------- |
+| activeElement | `number`     |         | Sets default active element on mobile view                           |
+| children      | `React.Node` |         | The content of the PricingTable. [See Subcomponents](#subcomponents) |
+| dataTest      | `string`     |         | Optional prop for testing purposes.                                  |
+| hasError      | `boolean`    |         | Sets default active element on mobile view                           |
 
 ---
 

--- a/src/PricingTable/__tests__/index.test.js
+++ b/src/PricingTable/__tests__/index.test.js
@@ -152,7 +152,7 @@ describe("PricingTableItem desktrop", () => {
 describe("PricingTable", () => {
   const mobileDescription = "Basic ticket fare includes:";
   const component = shallow(
-    <PricingTable dataTest={dataTest}>
+    <PricingTable activeElement={0} dataTest={dataTest}>
       <PricingTableItem
         dataTest={dataTest}
         name={name}

--- a/src/PricingTable/index.js
+++ b/src/PricingTable/index.js
@@ -1,5 +1,5 @@
 // @flow
-import React, { useState } from "react";
+import React from "react";
 import styled from "styled-components";
 
 import Stack from "../Stack";
@@ -9,16 +9,8 @@ import type { Props } from "./index.js.flow";
 
 const StyledPricingTable = styled.div``;
 
-const PricingTable = ({ children, defaultActiveElement = 0, dataTest }: Props) => {
+const PricingTable = ({ children, dataTest, activeElement, hasError }: Props) => {
   const { isDesktop } = useMediaQuery();
-  const [activeElement, setActiveElement] = useState(defaultActiveElement);
-  const handleOnClick = i => {
-    return () => {
-      if (!isDesktop) {
-        setActiveElement(i);
-      }
-    };
-  };
   const resolveBasis = item => {
     if (item.length) {
       return `${Math.floor(100 / item.length)}%`;
@@ -45,7 +37,7 @@ const PricingTable = ({ children, defaultActiveElement = 0, dataTest }: Props) =
                     active: activeElement === i,
                     compact: true,
                     basis: resolveBasis(child),
-                    onClick: handleOnClick(i),
+                    hasError,
                   }),
                 )}
           </Stack>

--- a/src/PricingTable/index.js.flow
+++ b/src/PricingTable/index.js.flow
@@ -9,7 +9,8 @@ import type { Globals } from "../common/common.js.flow";
 export type Props = {|
   ...Globals,
   +children: React$Node, // TODO: Type this propperly
-  +defaultActiveElement?: number,
+  +activeElement?: ?number,
+  +hasError?: boolean,
 |};
 
 declare export default React$ComponentType<Props>;


### PR DESCRIPTION
Adding a `hasError` and removing state, to support non selected variant.
Why: There was a need to make PricingTable more customisable 

<br/><br/><br/><url>LiveURL: https://orbit-components-update-pricing-table-uncontrolled.surge.sh</url>