### PR TITLE
DOCS: Add data file for airport illustrations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,7 @@ umd
 es
 .out
 .cache
+src/data/airportIllustrations.json
 src/data/illustrations.json
 src/data/icons.json
 src/Illustration/index.js.flow

--- a/config/build.js
+++ b/config/build.js
@@ -10,7 +10,6 @@ import glob from "glob";
 import svgr from "@svgr/core";
 
 import { NAMES as ILLUSTRATION_NAMES } from "../src/Illustration/consts";
-
 import { NAMES as AIRPORT_ILLUSTRATION_NAMES } from "../src/AirportIllustration/consts";
 
 const files = glob.sync("src/icons/svg/*.svg");

--- a/config/build.js
+++ b/config/build.js
@@ -11,6 +11,8 @@ import svgr from "@svgr/core";
 
 import { NAMES as ILLUSTRATION_NAMES } from "../src/Illustration/consts";
 
+import { NAMES as AIRPORT_ILLUSTRATION_NAMES } from "../src/AirportIllustration/consts";
+
 const files = glob.sync("src/icons/svg/*.svg");
 
 const names = files.map(inputFileName => {
@@ -148,4 +150,20 @@ const illustrationsJSON = Object.assign(
 fs.writeFileSync(
   path.join(__dirname, "..", "src", "data", "illustrations.json"),
   JSON.stringify(illustrationsJSON),
+);
+
+// create airport illustrations json file
+const airportIllustrationsJSON = Object.assign(
+  {},
+  ...AIRPORT_ILLUSTRATION_NAMES.map(illustration => ({
+    [illustration]: {
+      resized: `https://images.kiwi.com/illustrations/0x400/${illustration}-Q85.png`,
+      original: `https://images.kiwi.com/illustrations/originals/${illustration}.png`,
+    },
+  })),
+);
+
+fs.writeFileSync(
+  path.join(__dirname, "..", "src", "data", "airportIllustrations.json"),
+  JSON.stringify(airportIllustrationsJSON),
 );


### PR DESCRIPTION
Added a file on build listing airport illustrations. No new tests required and no components added. <br/><br/><br/><url>LiveURL: https://orbit-components-docs-add-airport-illustration-data.surge.sh</url>