### PR TITLE
DOCS: Removed airports from list of illustrations

### DIFF
--- a/src/Illustration/README.md
+++ b/src/Illustration/README.md
@@ -34,11 +34,9 @@ Table below contains all types of the props available in Illustration component.
 | `"AirportShuttle"`              |
 | `"AppQRCode"`                   |
 | `"BaggageDrop"`                 |
-| `"BGYFastTrack"`                |
 | `"Boarding"`                    |
 | `"BoardingPass"`                |
 | `"BusinessTravel"`              |
-| `"BUDFastTrack"`                |
 | `"CabinBaggage"`                |
 | `"CompassCollectPoints"`        |
 | `"CompassDemoted"`              |
@@ -67,7 +65,6 @@ Table below contains all types of the props available in Illustration component.
 | `"MobileApp"`                   |
 | `"Money"`                       |
 | `"MusicalInstruments"`          |
-| `"NCEFastTrack"`                |
 | `"NetVerify"`                   |
 | `"NoBookings"`                  |
 | `"NoFavoriteFlights"`           |


### PR DESCRIPTION
Removed illustrations that have been moved to AirportIllustration.<br/><br/><br/><url>LiveURL: https://orbit-components-docs-update-illustration-list.surge.sh</url>