### PR TITLE
FIX: Modal close on mobile devices

### DIFF
--- a/src/Modal/index.js
+++ b/src/Modal/index.js
@@ -619,7 +619,6 @@ export class PureModal extends React.PureComponent<Props & ThemeProps, State> {
           size={size}
           loaded={loaded}
           onScroll={this.handleMobileScroll}
-          onMouseDown={this.handleMouseDown}
           fixedFooter={fixedFooter}
           id={this.modalID}
           isMobileFullPage={isMobileFullPage}
@@ -635,6 +634,7 @@ export class PureModal extends React.PureComponent<Props & ThemeProps, State> {
             footerHeight={footerHeight}
             hasModalSection={hasModalSection}
             isMobileFullPage={isMobileFullPage}
+            onMouseDown={this.handleMouseDown}
           >
             {onClose && (
               <CloseContainer


### PR DESCRIPTION
Fixing calling a onClose callback on mobile devices, the callback was on a bad element causing it to not call onClose on mobile.<br/><br/><br/><url>LiveURL: https://orbit-components-fix-modalOverlay.surge.sh</url>