### PR TITLE
UPDATE: Add dataAttrs property to InputField and Select

### DIFF
--- a/src/InputField/InputField.stories.js
+++ b/src/InputField/InputField.stories.js
@@ -3,7 +3,7 @@
 import * as React from "react";
 import { storiesOf } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
-import { text, boolean, select, number } from "@storybook/addon-knobs";
+import { text, boolean, select, number, object } from "@storybook/addon-knobs";
 
 import * as Icons from "../icons";
 import { SIZE_OPTIONS, TYPE_OPTIONS, INPUTMODE } from "./consts";
@@ -392,6 +392,7 @@ storiesOf("InputField", module)
       const spaceAfter = select("spaceAfter", [null, ...Object.values(SPACINGS_AFTER)]);
       const id = text("id", "ID");
       const inputMode = select("inputMode", [null, ...Object.values(INPUTMODE)]);
+      const dataAttrs = object("dataAttrs", { "data-recording-ignore": true });
 
       return (
         <InputField
@@ -431,6 +432,7 @@ storiesOf("InputField", module)
           spaceAfter={spaceAfter}
           id={id}
           inputMode={inputMode}
+          dataAttrs={dataAttrs}
         />
       );
     },

--- a/src/InputField/README.md
+++ b/src/InputField/README.md
@@ -20,6 +20,7 @@ Table below contains all types of the props available in InputField component.
 | :----------- | :------------------------- | :--------- | :-------------------------------------------------------------------------------------------------------------------------------------------------- |
 | autoComplete | `string`                   |            | The autocomplete attribute of the input, see [this docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete).                |
 | disabled     | `boolean`                  |            | If `true`, the InputField will be disabled.                                                                                                         |
+| dataAttrs    | `Object`                   |            | Optional prop for passing `data-*` attributes to the `input` DOM element.                                                                           |
 | dataTest     | `string`                   |            | Optional prop for testing purposes.                                                                                                                 |
 | error        | `React.Node`               |            | The error to display beneath the InputField. [See Functional specs](#functional-specs)                                                              |
 | tags         | `React.Node`               |            | Here you can pass <Tag /> component for render tags [See Functional specs](#functional-specs)                                                       |

--- a/src/InputField/__tests__/index.test.js
+++ b/src/InputField/__tests__/index.test.js
@@ -29,6 +29,9 @@ describe(`InputField with help, prefix and suffix`, () => {
   const spaceAfter = SPACINGS_AFTER.NORMAL;
   const id = "id";
   const inputMode = INPUTMODE.NUMERIC;
+  const dataAttrs = {
+    "data-recording-ignore": true,
+  };
 
   const component = shallow(
     <InputField
@@ -57,6 +60,7 @@ describe(`InputField with help, prefix and suffix`, () => {
       onChange={onChange}
       onFocus={onFocus}
       onBlur={onBlur}
+      dataAttrs={dataAttrs}
     />,
   );
   const prefix = component.find("InputField__Prefix");
@@ -92,6 +96,7 @@ describe(`InputField with help, prefix and suffix`, () => {
     expect(input.prop("placeholder")).toBe(placeholder);
     expect(input.prop("maxLength")).toBe(maxLength);
     expect(input.prop("minLength")).toBe(minLength);
+    expect(input.render().prop("data-recording-ignore")).toBe("true");
     expect(input.render().prop("tabindex")).toBe(tabIndex);
     expect(input.render().prop("data-test")).toBe(dataTest);
     expect(input.render().prop("data-state")).toBe("ok");

--- a/src/InputField/index.js
+++ b/src/InputField/index.js
@@ -15,7 +15,6 @@ import getFieldDataState from "../common/getFieldDataState";
 import { StyledButtonLink } from "../ButtonLink/index";
 import randomID from "../utils/randomID";
 import formElementFocus from "./helpers/formElementFocus";
-import type { Theme } from "../defaultTheme";
 
 import type { Props } from ".";
 
@@ -202,11 +201,9 @@ Suffix.defaultProps = {
 };
 
 export const Input = styled(
-  React.forwardRef<{| ...Props, theme: Theme |}, HTMLInputElement>(
-    ({ type, size, theme, error, help, inlineLabel, ...props }, ref) => (
-      <input type={getDOMType(type)} {...props} ref={ref} />
-    ),
-  ),
+  React.forwardRef(({ type, size, theme, error, help, inlineLabel, dataAttrs, ...props }, ref) => (
+    <input type={getDOMType(type)} {...props} {...dataAttrs} ref={ref} />
+  )),
 )`
   appearance: none;
   -webkit-text-fill-color: ${({ disabled }) => disabled && "inherit"};
@@ -321,6 +318,7 @@ const InputField = React.forwardRef<Props, HTMLInputElement>((props, ref) => {
     spaceAfter,
     id,
     inputMode,
+    dataAttrs,
   } = props;
 
   const forID = React.useMemo(() => id || (label ? randomID("inputFieldID") : undefined), [
@@ -369,6 +367,7 @@ const InputField = React.forwardRef<Props, HTMLInputElement>((props, ref) => {
           autoComplete={autoComplete}
           id={forID}
           inputMode={inputMode}
+          dataAttrs={dataAttrs}
         />
         {suffix && <Suffix size={size}>{suffix}</Suffix>}
         <FakeInput size={size} disabled={disabled} error={error} />

--- a/src/InputField/index.js.flow
+++ b/src/InputField/index.js.flow
@@ -2,10 +2,16 @@
 /*
   DOCUMENTATION: https://orbit.kiwi/components/inputfield/
 */
-import * as React from 'react';
+import * as React from "react";
 import type { ReactComponentStyled } from "styled-components";
 
-import type { Globals, Ref, Translation, TranslationString } from "../common/common.js.flow";
+import type {
+  Globals,
+  Ref,
+  Translation,
+  TranslationString,
+  DataAttrs,
+} from "../common/common.js.flow";
 import type { spaceAfter } from "../common/getSpacingToken";
 
 export type Size = "small" | "normal";
@@ -16,6 +22,7 @@ export type Props = {|
   ...Globals,
   ...Ref,
   ...spaceAfter,
+  ...DataAttrs,
   +size?: Size,
   +type?: "text" | "number" | "email" | "password" | "passportid",
   +inputMode?: InputMode,

--- a/src/Select/README.md
+++ b/src/Select/README.md
@@ -19,6 +19,7 @@ Table below contains all types of the props available in the Select component.
 | Name            | Type                       | Default    | Description                                                                                                                                     |
 | :-------------- | :------------------------- | :--------- | :---------------------------------------------------------------------------------------------------------------------------------------------- |
 | customValueText | `Translation`              |            | The custom text alternative of current value. [See Functional specs](#functional-specs)                                                         |
+| dataAttrs       | `Object`                   |            | Optional prop for passing `data-*` attributes to the `select` DOM element.                                                                      |
 | dataTest        | `string`                   |            | Optional prop for testing purposes.                                                                                                             |
 | disabled        | `boolean`                  | `false`    | If `true`, the Select will be disabled.                                                                                                         |
 | error           | `React.Node`               |            | The error message for the Select. [See Functional specs](#functional-specs)                                                                     |

--- a/src/Select/Select.stories.js
+++ b/src/Select/Select.stories.js
@@ -135,6 +135,7 @@ storiesOf("Select", module)
       const spaceAfter = select("spaceAfter", [null, ...Object.values(SPACINGS_AFTER)]);
       const id = text("ID", "select-id");
       const required = boolean("Required", false);
+      const dataAttrs = object("dataAttrs", { "data-recording-ignore": true });
 
       return (
         <Select
@@ -153,6 +154,7 @@ storiesOf("Select", module)
           value={value}
           customValueText={customValueText}
           spaceAfter={spaceAfter}
+          dataAttrs={dataAttrs}
         />
       );
     },

--- a/src/Select/__tests__/Select.test.js
+++ b/src/Select/__tests__/Select.test.js
@@ -21,6 +21,9 @@ const objectOptions = [
   { disabled: true, value: "disabled-six", label: "Disabled Six" },
 ];
 const spaceAfter = SPACINGS_AFTER.NORMAL;
+const dataAttrs = {
+  "data-recording-ignore": true,
+};
 
 describe("Select", () => {
   const component = shallow(
@@ -34,6 +37,7 @@ describe("Select", () => {
       tabIndex={tabIndex}
       dataTest={dataTest}
       spaceAfter={spaceAfter}
+      dataAttrs={dataAttrs}
     />,
   );
   const select = component.find("Select__StyledSelect");
@@ -43,6 +47,9 @@ describe("Select", () => {
   });
   it("should have data-state", () => {
     expect(select.render().prop("data-state")).toBe("ok");
+  });
+  it("should have data-state", () => {
+    expect(select.render().prop("data-recording-ignore")).toBe("true");
   });
   it("should have name", () => {
     expect(select.render().prop("attribs").name).toBe(name);

--- a/src/Select/index.js
+++ b/src/Select/index.js
@@ -50,6 +50,7 @@ const StyledSelect = styled(
         onFocus,
         onBlur,
         id,
+        dataAttrs,
       },
       ref,
     ) => (
@@ -66,6 +67,7 @@ const StyledSelect = styled(
         name={name}
         tabIndex={tabIndex}
         ref={ref}
+        {...dataAttrs}
       >
         {children}
       </select>
@@ -263,6 +265,7 @@ const Select = React.forwardRef<Props, HTMLElement>((props, ref) => {
     prefix,
     spaceAfter,
     customValueText,
+    dataAttrs,
   } = props;
   const filled = !(value == null || value === "");
   return (
@@ -300,6 +303,7 @@ const Select = React.forwardRef<Props, HTMLElement>((props, ref) => {
           id={id}
           required={required}
           ref={ref}
+          dataAttrs={dataAttrs}
         >
           {placeholder && (
             <option label={placeholder} value="">

--- a/src/Select/index.js.flow
+++ b/src/Select/index.js.flow
@@ -4,7 +4,13 @@
 */
 import type { ReactComponentStyled } from "styled-components";
 
-import type { Globals, Ref, Translation, TranslationString } from "../common/common.js.flow";
+import type {
+  Globals,
+  Ref,
+  Translation,
+  TranslationString,
+  DataAttrs,
+} from "../common/common.js.flow";
 import type { spaceAfter } from "../common/getSpacingToken/index";
 
 type Option = {|
@@ -19,6 +25,7 @@ export type Props = {|
   ...Globals,
   ...Ref,
   ...spaceAfter,
+  ...DataAttrs,
   +id?: string,
   +required?: boolean,
   +size?: Size,

--- a/src/common/common.js.flow
+++ b/src/common/common.js.flow
@@ -5,6 +5,10 @@ export type Globals = {|
   +dataTest?: string,
 |};
 
+export type DataAttrs = {|
+  +dataAttrs?: { [key: string]: ?string | ?boolean },
+|};
+
 export type RefType = { current: null | HTMLElement } | ((null | HTMLElement) => mixed);
 
 export type Ref = {|


### PR DESCRIPTION
Adding `dataAttrs` property to InputField and Select, so devs are able to pass custom `data-*` attributes to the root DOM elements.<br/><br/><br/><url>LiveURL: https://orbit-components-updaate-inputs-dataattrs.surge.sh</url>