### PR TITLE
feat(illustrations): Add optional alt property

### DIFF
--- a/src/AirportIllustration/AirportIllustration.stories.js
+++ b/src/AirportIllustration/AirportIllustration.stories.js
@@ -18,9 +18,16 @@ storiesOf("AirportIllustration", module)
       const size = select("Size", Object.values(SIZE_OPTIONS), SIZE_OPTIONS.MEDIUM);
       const name = select("Name", Object.values(NAMES), "BGYFastTrack");
       const dataTest = text("dataTest", "test");
+      const alt = text("alt", null);
       const spaceAfter = select("spaceAfter", [null, ...Object.values(SPACINGS_AFTER)]);
       return (
-        <AirportIllustration size={size} name={name} dataTest={dataTest} spaceAfter={spaceAfter} />
+        <AirportIllustration
+          size={size}
+          name={name}
+          dataTest={dataTest}
+          spaceAfter={spaceAfter}
+          alt={alt}
+        />
       );
     },
     {

--- a/src/AirportIllustration/FLOW_TEMPLATE.flow
+++ b/src/AirportIllustration/FLOW_TEMPLATE.flow
@@ -10,6 +10,7 @@ type Name =%NAMES%
 export type Props = {|
   +size?: "small" | "medium" | "large" | "display",
   +name: Name,
+  +alt?: string,
   ...Globals,
   ...spaceAfter,
 |};

--- a/src/AirportIllustration/README.md
+++ b/src/AirportIllustration/README.md
@@ -18,6 +18,7 @@ Table below contains all types of the props available in AirportIllustration com
 
 | Name       | Type            | Default    | Description                                                                                                                                     |
 | :--------- | :-------------- | :--------- | :---------------------------------------------------------------------------------------------------------------------------------------------- |
+| alt        | `string`        |            | Optional property for passing own `alt` attribute to the DOM image element. Bby default, the `name` of illustration is used.                    |
 | dataTest   | `string`        |            | Optional prop for testing purposes.                                                                                                             |
 | **name**   | [`enum`](#enum) |            | Name for the displayed Airportillustration.                                                                                                     |
 | size       | [`enum`](#enum) | `"medium"` | The size of the AirportIllustration.                                                                                                            |

--- a/src/AirportIllustration/index.js
+++ b/src/AirportIllustration/index.js
@@ -6,8 +6,8 @@ import IllustrationPrimitive from "../primitives/IllustrationPrimitive";
 
 import type { Props } from "./index";
 
-const AirportIllustration = ({ name, size = SIZE_OPTIONS.MEDIUM, dataTest, spaceAfter }: Props) => (
-  <IllustrationPrimitive name={name} size={size} dataTest={dataTest} spaceAfter={spaceAfter} />
+const AirportIllustration = ({ size = SIZE_OPTIONS.MEDIUM, ...props }: Props) => (
+  <IllustrationPrimitive {...props} size={size} />
 );
 
 export default AirportIllustration;

--- a/src/Illustration/FLOW_TEMPLATE.flow
+++ b/src/Illustration/FLOW_TEMPLATE.flow
@@ -10,6 +10,7 @@ type Name =%NAMES%
 export type Props = {|
   +size?: "small" | "medium" | "large" | "display",
   +name: Name,
+  +alt?: string,
   ...Globals,
   ...spaceAfter,
 |};

--- a/src/Illustration/Illustration.stories.js
+++ b/src/Illustration/Illustration.stories.js
@@ -18,8 +18,17 @@ storiesOf("Illustration", module)
       const size = select("Size", Object.values(SIZE_OPTIONS), SIZE_OPTIONS.MEDIUM);
       const name = select("Name", Object.values(NAMES), "Accommodation");
       const dataTest = text("dataTest", "test");
+      const alt = text("alt", null);
       const spaceAfter = select("spaceAfter", [null, ...Object.values(SPACINGS_AFTER)]);
-      return <Illustration size={size} name={name} dataTest={dataTest} spaceAfter={spaceAfter} />;
+      return (
+        <Illustration
+          size={size}
+          name={name}
+          dataTest={dataTest}
+          spaceAfter={spaceAfter}
+          alt={alt}
+        />
+      );
     },
     {
       info: "Explore our new set of illustrations for Kiwi.com.",

--- a/src/Illustration/README.md
+++ b/src/Illustration/README.md
@@ -18,6 +18,7 @@ Table below contains all types of the props available in Illustration component.
 
 | Name       | Type            | Default    | Description                                                                                                                                     |
 | :--------- | :-------------- | :--------- | :---------------------------------------------------------------------------------------------------------------------------------------------- |
+| alt        | `string`        |            | Optional property for passing own `alt` attribute to the DOM image element. Bby default, the `name` of illustration is used.                    |
 | dataTest   | `string`        |            | Optional prop for testing purposes.                                                                                                             |
 | **name**   | [`enum`](#enum) |            | Name for the displayed illustration.                                                                                                            |
 | size       | [`enum`](#enum) | `"medium"` | The size of the Illustration.                                                                                                                   |

--- a/src/Illustration/index.js
+++ b/src/Illustration/index.js
@@ -6,8 +6,8 @@ import IllustrationPrimitive from "../primitives/IllustrationPrimitive";
 
 import type { Props } from "./index";
 
-const Illustration = ({ name, size = SIZE_OPTIONS.MEDIUM, dataTest, spaceAfter }: Props) => (
-  <IllustrationPrimitive name={name} size={size} dataTest={dataTest} spaceAfter={spaceAfter} />
+const Illustration = ({ size = SIZE_OPTIONS.MEDIUM, ...props }: Props) => (
+  <IllustrationPrimitive {...props} size={size} />
 );
 
 export default Illustration;

--- a/src/primitives/IllustrationPrimitive/README.md
+++ b/src/primitives/IllustrationPrimitive/README.md
@@ -12,9 +12,9 @@ After adding import into your project you can use it simply like:
 <IllustrationPrimitive name="Accommodation" size="small" />
 ```
 
-## Ussage
+## Usage
 
-As with every primitive, you should have a good reason to use `IllustrationPrimitive`, prefer ussage of `Illustration` and `AirportIllustration` as they are typed more strictly.
+As with every primitive, you should have a good reason to use `IllustrationPrimitive`, prefer usage of `Illustration` and `AirportIllustration` as they are typed more strictly.
 
 ## Props
 
@@ -22,6 +22,7 @@ Table below contains all types of the props available in IllustrationPrimitive c
 
 | Name       | Type            | Default    | Description                                                                                                                                     |
 | :--------- | :-------------- | :--------- | :---------------------------------------------------------------------------------------------------------------------------------------------- |
+| alt        | `string`        |            | Optional property for passing own `alt` attribute to the DOM image element. Bby default, the `name` of illustration is used.                    |
 | dataTest   | `string`        |            | Optional prop for testing purposes.                                                                                                             |
 | **name**   | `string`        |            | Name for the displayed illustrationPrimitive.                                                                                                   |
 | size       | [`enum`](#enum) | `"medium"` | The size of the IllustrationPrimitive.                                                                                                          |

--- a/src/primitives/IllustrationPrimitive/__tests__/index.test.js
+++ b/src/primitives/IllustrationPrimitive/__tests__/index.test.js
@@ -9,6 +9,7 @@ import defaultTheme from "../../../defaultTheme";
 
 const size = SIZE_OPTIONS.SMALL;
 const name = "Accommodation";
+const alt = "Alternative text";
 const dataTest = "test";
 
 const URL = "//images.kiwi.com/illustrations/0x90/Accommodation-Q85.png";
@@ -19,6 +20,7 @@ describe(`IllustrationPrimitive of ${name}`, () => {
     <IllustrationPrimitive
       size={size}
       name={name}
+      alt={alt}
       dataTest={dataTest}
       spaceAfter={SPACINGS_AFTER.NORMAL}
     />,
@@ -35,7 +37,7 @@ describe(`IllustrationPrimitive of ${name}`, () => {
 
   it("should have passed props", () => {
     expect(component.prop("size")).toBe(size);
-    expect(component.render().prop("alt")).toBe(name);
+    expect(component.render().prop("alt")).toBe(alt);
     expect(component.render().prop("data-test")).toBe(dataTest);
   });
 

--- a/src/primitives/IllustrationPrimitive/index.js
+++ b/src/primitives/IllustrationPrimitive/index.js
@@ -41,13 +41,14 @@ StyledImage.defaultProps = {
 
 const IllustrationPrimitive = ({
   name,
+  alt,
   size = SIZE_OPTIONS.MEDIUM,
   dataTest,
   spaceAfter,
 }: Props) => (
   <StyledImage
     illustrationName={name}
-    alt={name}
+    alt={alt || name}
     size={size}
     data-test={dataTest}
     spaceAfter={spaceAfter}

--- a/src/primitives/IllustrationPrimitive/index.js.flow
+++ b/src/primitives/IllustrationPrimitive/index.js.flow
@@ -8,6 +8,7 @@ import type { spaceAfter } from "../../common/getSpacingToken/index";
 export type Props = {|
   +size?: "small" | "medium" | "large" | "display",
   +name: string,
+  +alt?: string,
   ...Globals,
   ...spaceAfter,
 |};


### PR DESCRIPTION
Why: Sometimes we want to use different `alt` on the DOM element than the illustration name. It doesn't always cover the exact context.<br/><br/><br/><url>LiveURL: https://orbit-components-feat-illustration-alt-optional.surge.sh</url>