### PR TITLE
feat(Tile): Adding title attribute

### DIFF
--- a/src/Tile/README.md
+++ b/src/Tile/README.md
@@ -23,6 +23,7 @@ Table below contains all types of the props available in Tile component.
 | expandable      | `boolean`                  | `false` | If `true`, the Tile will be expandable.                                                                                      |
 | external        | `boolean`                  | `false` | If `true`, the Tile opens link in a new tab. [See Functional specs](#functional-specs)                                       |
 | href            | `string`                   |         | The URL of the link to open when Tile is clicked. [See Functional specs](#functional-specs)                                  |
+| htmlTitle       | `string`                   |         | HTML attribute title for adding extra piece of information.                                                                  |
 | icon            | `React.Node`               |         | Displayed icon on the left side of the Tile.                                                                                 |
 | onClick         | `event => void \| Promise` |         | Function for handling onClick event.                                                                                         |
 | title           | `React.Node`               |         | The title of the Tile.                                                                                                       |

--- a/src/Tile/Tile.stories.js
+++ b/src/Tile/Tile.stories.js
@@ -176,6 +176,8 @@ storiesOf("Tile", module)
       const noPadding = boolean("noPadding", false);
       const dataTest = text("dataTest", "test");
       const children = text("children", null);
+      const htmlTitle = text("htmlTitle", "Title for more info");
+
       return (
         <Tile
           href={href}
@@ -189,6 +191,7 @@ storiesOf("Tile", module)
           initialExpanded={initialExpanded}
           noPadding={noPadding}
           dataTest={dataTest}
+          htmlTitle={htmlTitle}
         >
           {children}
         </Tile>

--- a/src/Tile/__tests__/index.test.js
+++ b/src/Tile/__tests__/index.test.js
@@ -17,6 +17,8 @@ describe("Tile clickable", () => {
   const title = "Lorem ipsum dolor sit amet";
   const description = "Lorem ipsum dolor sit amet";
   const onClick = jest.fn();
+  const htmlTitle = "Lorem ipsum dolor sit amet";
+
   const component = shallow(
     <Tile
       dataTest={dataTest}
@@ -24,12 +26,14 @@ describe("Tile clickable", () => {
       title={title}
       description={description}
       onClick={onClick}
+      htmlTitle={htmlTitle}
     />,
   );
   it("should render proper attributes", () => {
     expect(component.render().prop("data-test")).toBe(dataTest);
     expect(component.render().prop("role")).toBe("button");
     expect(component.prop("as")).toBe("div");
+    expect(component.render().prop("title")).toBe(htmlTitle);
   });
   it("should return TileHeader with props", () => {
     const header = component.find(TileHeader);

--- a/src/Tile/components/TileExpandable/index.js
+++ b/src/Tile/components/TileExpandable/index.js
@@ -20,6 +20,7 @@ const TileExpandable = ({
   header,
   icon,
   dataTest,
+  htmlTitle,
 }: Props) => {
   const [expanded, setExpanded] = React.useState(initialExpanded);
   const [contentHeight, setContentHeight] = React.useState(initialExpanded ? null : 0);
@@ -62,6 +63,7 @@ const TileExpandable = ({
       tabIndex="0"
       id={labelID}
       dataTest={dataTest}
+      htmlTitle={htmlTitle}
     >
       {hasHeader && (
         <TileHeader

--- a/src/Tile/components/TileExpandable/index.js.flow
+++ b/src/Tile/components/TileExpandable/index.js.flow
@@ -12,6 +12,7 @@ export type Props = {|
   description?: React$Node,
   header?: React$Node,
   icon?: React$Node,
+  htmlTitle?: string,
 |};
 
 declare export default React$ComponentType<Props>;

--- a/src/Tile/components/TileWrapper/index.js
+++ b/src/Tile/components/TileWrapper/index.js
@@ -47,6 +47,7 @@ const TileWrapper = ({
   ariaExpanded,
   ariaControls,
   id,
+  htmlTitle,
 }: Props) => (
   <StyledTileWrapper
     target={href && external ? "_blank" : undefined}
@@ -61,6 +62,7 @@ const TileWrapper = ({
     ariaExpanded={ariaExpanded}
     ariaControls={ariaControls}
     id={id}
+    title={htmlTitle}
   >
     {children}
   </StyledTileWrapper>

--- a/src/Tile/components/TileWrapper/index.js.flow
+++ b/src/Tile/components/TileWrapper/index.js.flow
@@ -13,6 +13,7 @@ export type Props = {|
   role: ?string,
   ariaExpanded?: boolean,
   ariaControls?: string,
+  htmlTitle?: string,
   id?: string,
 |};
 

--- a/src/Tile/index.js
+++ b/src/Tile/index.js
@@ -21,6 +21,7 @@ const Tile = ({
   noPadding = false,
   expandable = false,
   initialExpanded = false,
+  htmlTitle,
   onClick,
 }: Props) => {
   if (expandable) {
@@ -34,6 +35,7 @@ const Tile = ({
         noPadding={noPadding}
         initialExpanded={initialExpanded}
         onClick={onClick}
+        htmlTitle={htmlTitle}
       >
         {children}
       </TileExpandable>
@@ -51,6 +53,7 @@ const Tile = ({
       as={href ? "a" : "div"}
       tabIndex={!href ? "0" : undefined}
       role={!href ? "button" : undefined}
+      htmlTitle={htmlTitle}
     >
       {hasHeader && (
         <TileHeader

--- a/src/Tile/index.js.flow
+++ b/src/Tile/index.js.flow
@@ -20,6 +20,7 @@ export type Props = {|
   +expandable?: boolean,
   +initialExpanded?: boolean,
   +noPadding?: boolean,
+  +htmlTitle?: string,
   ...Globals,
 |};
 


### PR DESCRIPTION
Adding title attribute to enable native tooltip on hover to appear, useful for adding extra piece of information.

@vepor What do you think about the naming? I was not able to think of anything better that that, due to already having a Title a Description taken 🤔 <br/><br/><br/><url>LiveURL: https://orbit-components-update-tile-title.surge.sh</url>