### PR TITLE
revert(FormElements): native design sync

### DIFF
--- a/src/InputField/index.js
+++ b/src/InputField/index.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from "react";
-import styled, { css } from "styled-components";
+import styled from "styled-components";
 
 import defaultTheme from "../defaultTheme";
 import { SIZE_OPTIONS, TYPE_OPTIONS, TOKENS } from "./consts";
@@ -15,7 +15,6 @@ import getFieldDataState from "../common/getFieldDataState";
 import { StyledButtonLink } from "../ButtonLink/index";
 import randomID from "../utils/randomID";
 import formElementFocus from "./helpers/formElementFocus";
-import media from "../utils/mediaQuery";
 
 import type { Props } from ".";
 
@@ -85,28 +84,16 @@ export const FakeInput = styled(({ children, className }) => (
   left: 0;
   box-sizing: border-box;
   height: ${getToken(TOKENS.heightInput)};
-  border-radius: ${({ theme }) => theme.orbit.borderRadiusLarge};
+  border-radius: ${({ theme }) => theme.orbit.borderRadiusNormal};
   box-shadow: inset 0 0 0
     ${({ theme, error }) =>
       `${theme.orbit.borderWidthInput} ${
-        error ? theme.orbit.borderColorInputError : theme.orbit.paletteCloudNormal
+        error ? theme.orbit.borderColorInputError : theme.orbit.borderColorInput
       }`};
   background-color: ${({ disabled, theme }) =>
-    disabled ? theme.orbit.backgroundInputDisabled : theme.orbit.paletteCloudNormal};
-
+    disabled ? theme.orbit.backgroundInputDisabled : theme.orbit.backgroundInput};
   font-size: ${getToken(TOKENS.fontSizeInput)};
   transition: all ${({ theme }) => theme.orbit.durationFast} ease-in-out;
-
-  ${media.largeMobile(css`
-    background-color: ${({ disabled, theme }) =>
-      disabled ? theme.orbit.backgroundInputDisabled : theme.orbit.backgroundInput};
-    border-radius: ${({ theme }) => theme.orbit.borderRadiusNormal};
-    box-shadow: inset 0 0 0
-      ${({ theme, error }) =>
-        `${theme.orbit.borderWidthInput} ${
-          error ? theme.orbit.borderColorInputError : theme.orbit.borderColorInput
-        }`};
-  `)}
 `;
 
 FakeInput.defaultProps = {
@@ -182,16 +169,8 @@ export const Prefix = styled(({ children, className }) => (
   & > svg {
     width: ${getToken(TOKENS.iconSize)};
     height: ${getToken(TOKENS.iconSize)};
-    color: ${({ theme, disabled }) => {
-      return disabled ? theme.orbit.paletteInkLighter : theme.orbit.paletteInkLight;
-    }};
+    color: ${({ theme }) => theme.orbit.colorIconInput};
   }
-
-  ${media.largeMobile(css`
-    & svg {
-      color: ${({ theme }) => theme.orbit.colorIconInput};
-    }
-  `)}
 `;
 
 Prefix.defaultProps = {
@@ -209,19 +188,12 @@ const Suffix = styled(({ children, className }) => <div className={className}>{c
   z-index: 3;
 
   & svg {
-    color: ${({ theme, disabled }) =>
-      disabled ? theme.orbit.colorIconSecondary : theme.orbit.paletteInkLight};
+    color: ${({ theme }) => theme.orbit.colorIconSecondary};
   }
   ${StyledServiceLogo} {
     height: 16px;
     padding: ${({ theme }) => rtlSpacing(`0 ${theme.orbit.spaceSmall} 0 0`)};
   }
-
-  ${media.largeMobile(css`
-    & svg {
-      color: ${({ theme }) => theme.orbit.colorIconSecondary};
-    }
-  `)}
 `;
 
 Suffix.defaultProps = {
@@ -275,46 +247,25 @@ export const Input = styled(
   }
 
   &::placeholder {
-    color: ${({ theme, disabled }) =>
-      disabled ? theme.orbit.paletteInkLighter : theme.orbit.paletteInkLight};
+    color: ${({ theme }) => theme.orbit.colorPlaceholderInput};
     /* Firefox */
     opacity: 1;
   }
 
   /* Internet Explorer 10-11 */
   &:-ms-input-placeholder {
-    color: ${({ theme, disabled }) =>
-      disabled ? theme.orbit.paletteInkLighter : theme.orbit.paletteInkLight};
+    color: ${({ theme }) => theme.orbit.colorPlaceholderInput};
   }
 
   /* Microsoft Edge */
   &::-ms-input-placeholder {
-    color: ${({ theme, disabled }) =>
-      disabled ? theme.orbit.paletteInkLighter : theme.orbit.paletteInkLight};
+    color: ${({ theme }) => theme.orbit.colorPlaceholderInput};
   }
 
   &::-ms-clear,
   &::-ms-reveal {
     display: none;
   }
-
-  ${media.largeMobile(css`
-    &::placeholder {
-      color: ${({ theme }) => theme.orbit.colorPlaceholderInput};
-      /* Firefox */
-      opacity: 1;
-    }
-
-    /* Internet Explorer 10-11 */
-    &:-ms-input-placeholder {
-      color: ${({ theme }) => theme.orbit.colorPlaceholderInput};
-    }
-
-    /* Microsoft Edge */
-    &::-ms-input-placeholder {
-      color: ${({ theme }) => theme.orbit.colorPlaceholderInput};
-    }
-  `)}
 `;
 
 Input.defaultProps = {
@@ -383,11 +334,7 @@ const InputField = React.forwardRef<Props, HTMLInputElement>((props, ref) => {
     >
       {label && !inlineLabel && <FormLabel label={label} isFilled={!!value} required={required} />}
       <InputContainer size={size} disabled={disabled} error={error}>
-        {prefix && (
-          <Prefix disabled={disabled} size={size}>
-            {prefix}
-          </Prefix>
-        )}
+        {prefix && <Prefix size={size}>{prefix}</Prefix>}
         {label && inlineLabel && (
           <StyledInlineLabel size={size}>
             <FormLabel label={label} isFilled={!!value} required={required} />
@@ -422,11 +369,7 @@ const InputField = React.forwardRef<Props, HTMLInputElement>((props, ref) => {
           inputMode={inputMode}
           dataAttrs={dataAttrs}
         />
-        {suffix && (
-          <Suffix disabled={disabled} size={size}>
-            {suffix}
-          </Suffix>
-        )}
+        {suffix && <Suffix size={size}>{suffix}</Suffix>}
         <FakeInput size={size} disabled={disabled} error={error} />
       </InputContainer>
       {help && !error && <FormFeedback type="help">{help}</FormFeedback>}

--- a/src/InputFile/index.js
+++ b/src/InputFile/index.js
@@ -1,8 +1,9 @@
 // @flow
 import * as React from "react";
-import styled, { css } from "styled-components";
+import styled from "styled-components";
 
 import defaultTheme from "../defaultTheme";
+import Button from "../Button";
 import ButtonLink, { StyledButtonLink } from "../ButtonLink";
 import FormLabel from "../FormLabel";
 import FormFeedback from "../FormFeedback";
@@ -12,7 +13,6 @@ import { rtlSpacing } from "../utils/rtl";
 import getSpacingToken from "../common/getSpacingToken";
 import getFieldDataState from "../common/getFieldDataState";
 import formElementFocus from "../InputField/helpers/formElementFocus";
-import media from "../utils/mediaQuery";
 
 import type { Props } from "./index";
 
@@ -34,22 +34,14 @@ const FakeInput = styled(({ children, className }) => <div className={className}
   align-items: center;
   padding: ${({ theme }) => rtlSpacing(theme.orbit.paddingInputFile)};
   height: ${({ theme }) => theme.orbit.heightInputNormal};
-  border-radius: ${({ theme }) => theme.orbit.borderRadiusLarge};
+  border-radius: ${({ theme }) => theme.orbit.borderRadiusNormal};
   box-shadow: inset 0 0 0
     ${({ theme, error }) =>
-      `${error ? theme.orbit.borderColorInputError : theme.orbit.paletteCloudNormal}`};
-  background-color: ${({ theme }) => theme.orbit.paletteCloudNormal};
+      `${theme.orbit.borderWidthInput} ${
+        error ? theme.orbit.borderColorInputError : theme.orbit.borderColorInput
+      }`};
+  background-color: ${({ theme }) => theme.backgroundInput};
   transition: box-shadow ${({ theme }) => theme.orbit.durationFast} ease-in-out;
-
-  ${media.largeMobile(css`
-    background-color: ${({ theme }) => theme.orbit.backgroundInput};
-    border-radius: ${({ theme }) => theme.orbit.borderRadiusNormal};
-    box-shadow: inset 0 0 0
-      ${({ theme, error }) =>
-        `${theme.orbit.borderWidthInput} ${
-          error ? theme.orbit.borderColorInputError : theme.orbit.borderColorInput
-        }`};
-  `)}
 
   &:hover {
     box-shadow: inset 0 0 0
@@ -83,10 +75,19 @@ Input.defaultProps = {
   theme: defaultTheme,
 };
 
+const getFileInputColor = ({ error, fileName }, theme) => {
+  if (error) {
+    return theme.orbit.paletteRedNormal;
+  }
+  if (fileName) {
+    return theme.orbit.colorTextInput;
+  }
+  return theme.orbit.paletteInkLight;
+};
+
 const StyledFileInput = styled.div`
   font-family: ${({ theme }) => theme.orbit.fontFamily};
-  color: ${({ fileName, theme }) =>
-    fileName ? theme.orbit.colorTextInput : theme.orbit.paletteInkLight};
+  color: ${({ error, fileName, theme }) => getFileInputColor({ error, fileName }, theme)};
   width: 100%;
   white-space: nowrap;
   overflow: hidden;
@@ -98,7 +99,7 @@ StyledFileInput.defaultProps = {
   theme: defaultTheme,
 };
 
-const InputButton = styled(ButtonLink)`
+const InputButton = styled(Button)`
   flex-shrink: 0;
 `;
 

--- a/src/InputGroup/index.js
+++ b/src/InputGroup/index.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from "react";
-import styled  from "styled-components";
+import styled from "styled-components";
 
 import defaultTheme from "../defaultTheme";
 import FormLabel from "../FormLabel";

--- a/src/InputGroup/index.js
+++ b/src/InputGroup/index.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from "react";
-import styled, { css } from "styled-components";
+import styled  from "styled-components";
 
 import defaultTheme from "../defaultTheme";
 import FormLabel from "../FormLabel";
@@ -12,7 +12,6 @@ import { right, rtlSpacing } from "../utils/rtl";
 import getSpacingToken from "../common/getSpacingToken";
 import randomID from "../utils/randomID";
 import formElementFocus from "../InputField/helpers/formElementFocus";
-import media from "../utils/mediaQuery";
 
 import type { Props, State } from "./index";
 
@@ -42,15 +41,15 @@ const FakeGroup = styled(({ children, className }) => (
   z-index: 1;
   box-sizing: border-box;
   height: ${getToken(TOKENS.height)};
-  border-radius: ${({ theme }) => theme.orbit.borderRadiusLarge};
+  border-radius: ${({ theme }) => theme.orbit.borderRadiusNormal};
   box-shadow: ${({ theme }) =>
-    `inset 0 0 0 ${theme.orbit.borderWidthInput} ${theme.orbit.paletteCloudNormal}`}; // Normal state
+    `inset 0 0 0 ${theme.orbit.borderWidthInput} ${theme.orbit.borderColorInput}`}; // Normal state
   box-shadow: ${({ theme, error }) =>
     error &&
     `inset 0 0 0 ${theme.orbit.borderWidthInput} ${theme.orbit.borderColorInputError}`}; // Error state
   ${({ active }) => active && formElementFocus}; // Active state
   background-color: ${({ disabled, theme }) =>
-    disabled ? theme.orbit.backgroundInputDisabled : theme.orbit.paletteCloudNormal};
+    disabled ? theme.orbit.backgroundInputDisabled : theme.orbit.backgroundInput};
   font-size: ${({ theme }) => theme.orbit.fontSizeInputNormal};
   transition: box-shadow ${({ theme }) => theme.orbit.durationFast} ease-in-out;
 
@@ -61,17 +60,6 @@ const FakeGroup = styled(({ children, className }) => (
           error ? theme.orbit.borderColorInputErrorHover : theme.orbit.borderColorInputHover
         }`};
   }
-
-  ${media.largeMobile(css`
-    background-color: ${({ disabled, theme }) =>
-      disabled ? theme.orbit.backgroundInputDisabled : theme.orbit.backgroundInput};
-    border-radius: ${({ theme }) => theme.orbit.borderRadiusNormal};
-    box-shadow: inset 0 0 0
-      ${({ theme, error }) =>
-        `${theme.orbit.borderWidthInput} ${
-          error ? theme.orbit.borderColorInputError : theme.orbit.borderColorInput
-        }`};
-  `)}
 `;
 
 FakeGroup.defaultProps = {

--- a/src/Select/index.js
+++ b/src/Select/index.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from "react";
-import styled, { css } from "styled-components";
+import styled from "styled-components";
 
 import defaultTheme from "../defaultTheme";
 import FormLabel from "../FormLabel";
@@ -12,7 +12,6 @@ import { right, left, rtlSpacing } from "../utils/rtl";
 import getSpacingToken from "../common/getSpacingToken";
 import getFieldDataState from "../common/getFieldDataState";
 import formElementFocus from "../InputField/helpers/formElementFocus";
-import media from "../utils/mediaQuery";
 
 import type { Props } from "./index";
 
@@ -76,11 +75,11 @@ const StyledSelect = styled(
   ),
 )`
   appearance: none;
-  background: ${({ theme }) => theme.orbit.paletteCloudNormal};
-  border-radius: ${({ theme }) => theme.orbit.borderRadiusLarge};
+  background: ${({ theme }) => theme.orbit.backgroundInput};
+  border-radius: ${({ theme }) => theme.orbit.borderRadiusNormal};
   cursor: pointer;
   color: ${({ theme, filled }) =>
-    filled ? theme.orbit.colorTextInput : theme.orbit.paletteInkLight};
+    filled ? theme.orbit.colorTextInput : theme.orbit.colorPlaceholderInput};
   font-family: ${({ theme }) => theme.orbit.fontFamily};
   font-size: ${({ theme, size }) =>
     size === SIZE_OPTIONS.SMALL ? theme.orbit.fontSizeInputSmall : theme.orbit.fontSizeInputNormal};
@@ -123,7 +122,7 @@ const StyledSelect = styled(
   box-shadow: inset 0 0 0
     ${({ theme, error }) =>
       `${theme.orbit.borderWidthInput} ${
-        error ? theme.orbit.borderColorInputError : theme.orbit.paletteCloudNormal
+        error ? theme.orbit.borderColorInputError : theme.orbit.borderColorInput
       }`};
 
   &:hover {
@@ -161,19 +160,6 @@ const StyledSelect = styled(
     }
   `}
   color: ${({ customValueText }) => customValueText && "transparent"} !important;
-
-
-  ${media.largeMobile(css`
-    color: ${({ customValueText }) => customValueText && "transparent"};
-    background-color: ${({ disabled, theme }) =>
-      disabled ? theme.orbit.backgroundInputDisabled : theme.orbit.backgroundInput};
-    border-radius: ${({ theme }) => theme.orbit.borderRadiusNormal};
-    box-shadow: inset 0 0 0
-      ${({ theme, error }) =>
-        `${theme.orbit.borderWidthInput} ${
-          error ? theme.orbit.borderColorInputError : theme.orbit.borderColorInput
-        }`};
-  `)}
 `;
 
 StyledSelect.defaultProps = {

--- a/src/Textarea/index.js
+++ b/src/Textarea/index.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from "react";
-import styled, { css } from "styled-components";
+import styled from "styled-components";
 
 import defaultTheme from "../defaultTheme";
 import FormFeedback from "../FormFeedback";
@@ -9,7 +9,6 @@ import { SIZE_OPTIONS, RESIZE_OPTIONS } from "./consts";
 import { rtlSpacing } from "../utils/rtl";
 import getSpacingToken from "../common/getSpacingToken";
 import formElementFocus from "../InputField/helpers/formElementFocus";
-import media from "../utils/mediaQuery";
 
 import type { Props } from "./index";
 
@@ -61,13 +60,14 @@ const StyledTextArea = styled.textarea`
   width: 100%;
   height: ${({ fullHeight }) => fullHeight && "100%"};
   padding: ${getPadding};
-  border-radius: ${({ theme }) => theme.orbit.borderRadiusLarge};
+  border-radius: ${({ theme }) => theme.orbit.borderRadiusNormal};
   box-shadow: inset 0 0 0
     ${({ theme, error }) =>
       `${theme.orbit.borderWidthInput} ${
-        error ? theme.orbit.borderColorInputError : theme.orbit.paletteCloudNormal
+        error ? theme.orbit.borderColorInputError : theme.orbit.borderColorInput
       }`};
-  background-color: ${({ theme }) => theme.orbit.paletteCloudNormal};
+  background-color: ${({ disabled, theme }) =>
+    disabled ? theme.orbit.backgroundInputDisabled : theme.orbit.backgroundInput};
   color: ${({ disabled, theme }) =>
     disabled ? theme.orbit.colorTextInputDisabled : theme.orbit.colorTextInput};
   font-size: ${getFontSize};
@@ -88,8 +88,7 @@ const StyledTextArea = styled.textarea`
   overflow: auto;
 
   &::placeholder {
-    color: ${({ theme, disabled }) =>
-      disabled ? theme.orbit.paletteInkLighter : theme.orbit.paletteInkLight};
+    color: ${({ theme }) => theme.orbit.colorPlaceholderInput};
   }
 
   &:hover {
@@ -104,20 +103,6 @@ const StyledTextArea = styled.textarea`
     ${formElementFocus}
     outline: none;
   }
-
-  ${media.largeMobile(css`
-    border-radius: ${({ theme }) => theme.orbit.borderRadiusNormal};
-    background-color: ${({ disabled, theme }) =>
-      disabled ? theme.orbit.backgroundInputDisabled : theme.orbit.backgroundInput};
-    box-shadow: inset 0 0 0
-      ${({ theme, error }) =>
-        `${theme.orbit.borderWidthInput} ${
-          error ? theme.orbit.borderColorInputError : theme.orbit.borderColorInput
-        }`};
-    &::placeholder {
-      color: ${({ theme }) => theme.orbit.paletteInkLight};
-    }
-  `)}
 `;
 
 StyledTextArea.defaultProps = {


### PR DESCRIPTION
This reverts commit c9b67164
Why: We need to revert native design sync for form elements, because some legacy implementations don't count with usage of grey inputs on not white background.  
<br/><br/><br/><url>LiveURL: https://orbit-components-revert-form-elements.surge.sh</url>