### PR TITLE
fix(Tooltip): with clickable element should close on mobile

### DIFF
--- a/src/Tooltip/components/TooltipContent.js
+++ b/src/Tooltip/components/TooltipContent.js
@@ -224,10 +224,11 @@ const TooltipContent = ({
         const focusableElements = tooltip.current.querySelectorAll(FOCUSABLE_ELEMENT_SELECTORS);
         if (Object.values(focusableElements).some(v => v === ev.target)) {
           onClose();
+          onCloseMobile();
         }
       }
     },
-    [onClose],
+    [onClose, onCloseMobile],
   );
   return (
     <StyledTooltip role="tooltip" id={tooltipId} data-test={dataTest}>


### PR DESCRIPTION
Extends #1742
<br/><br/><br/><url>LiveURL: https://orbit-components-fix-tooltip-close-mobile.surge.sh</url>