### PR TITLE
fix(InputStepper): improve TypeScript definition

### DIFF
--- a/src/InputStepper/index.d.ts
+++ b/src/InputStepper/index.d.ts
@@ -32,7 +32,7 @@ export interface SharedProps extends Common.Global, Common.Ref, Common.SpaceAfte
 
 export interface Props extends SharedProps {
   readonly defaultValue?: number;
-  readonly onChange?: (number) => void | Promise<void>;
+  readonly onChange?: (value: number) => void | Promise<void>;
 }
 
 declare const InputStepper: React.FunctionComponent<Props>;


### PR DESCRIPTION
I had this error when running my type-checking with TS:
```
node_modules/@kiwicom/orbit-components/lib/InputStepper/index.d.ts(35,24): error TS7051: Parameter has a name but no type. Did you mean 'arg0: number'?
```

This Pull Request meets the following criteria:

- [ ] ~~Tests have been added/adjusted for my new feature~~ N/A
- [ ] ~~New Components are registered in index.js of my project~~ N/A
<br/><br/><br/><url>LiveURL: https://orbit-components-RobinCsl-patch-1.surge.sh</url>