### PR TITLE
chore(Storybook): open 'Knobs' panel by default

### DIFF
--- a/.storybook/manager.js
+++ b/.storybook/manager.js
@@ -1,6 +1,6 @@
 import { create } from "@storybook/theming"
-import "@storybook/addon-actions/register";
 import "@storybook/addon-knobs/register";
+import "@storybook/addon-actions/register";
 
 export default create({
   brandTitle: "Orbit",


### PR DESCRIPTION
If `addon-knobs` is registered first, it will show up as the first tab.

Every time I open a Storybook Playground page, I have to click on Knobs before I can start "playing".

This Pull Request meets the following criteria:

- [x] Storybook itself is not tested
- [x] No new components added
<br/><br/><br/><url>LiveURL: https://orbit-components-sampi-storybook-addon-knobs-first.surge.sh</url>