### PR TITLE
fix(Breadcrumbs): add mobile back button onClick

### DIFF
--- a/src/Breadcrumbs/_tests_/index.test.js
+++ b/src/Breadcrumbs/_tests_/index.test.js
@@ -33,6 +33,9 @@ describe("Breadcrumbs", () => {
   it("should execute onGoBack", () => {
     component.find("GoBackButton").simulate("click");
     expect(onGoBack).toHaveBeenCalled();
+
+    component.find("[dataTest='BreadcrumbsBack']").simulate("click");
+    expect(onGoBack).toHaveBeenCalled();
   });
 });
 

--- a/src/Breadcrumbs/index.js
+++ b/src/Breadcrumbs/index.js
@@ -93,6 +93,7 @@ const Breadcrumbs = (props: Props) => {
           compact
           iconLeft={<ChevronLeft reverseOnRtl />}
           dataTest="BreadcrumbsBack"
+          onClick={onGoBack} 
         >
           {goBackTitle}
         </ButtonLink>

--- a/src/Breadcrumbs/index.js
+++ b/src/Breadcrumbs/index.js
@@ -93,7 +93,7 @@ const Breadcrumbs = (props: Props) => {
           compact
           iconLeft={<ChevronLeft reverseOnRtl />}
           dataTest="BreadcrumbsBack"
-          onClick={onGoBack} 
+          onClick={onGoBack}
         >
           {goBackTitle}
         </ButtonLink>


### PR DESCRIPTION
This Pull Request meets the following criteria:

- [x] Tests have been added/adjusted for my new feature
- [x] New Components are registered in index.js of my project
<br/><br/><br/><url>LiveURL: https://orbit-components-sampi-breadcrumbs-mobile-back.surge.sh</url>