### PR TITLE
feat: expose design tokens as XML for Exponea

### DIFF
--- a/config/__tests__/createXMLDesignTokens.js
+++ b/config/__tests__/createXMLDesignTokens.js
@@ -1,0 +1,38 @@
+// @noflow
+/* eslint-disable global-require */
+const fsx = require("fs-extra");
+
+const createXMLDesignTokens = require("../createXMLDesignTokens");
+
+jest.mock("@kiwicom/orbit-design-tokens", () => ({
+  defaultTokens: {
+    black: "#000",
+    white: "#fff",
+    red: "#f00",
+  },
+}));
+
+jest.mock("fs", () => require("memfs").fs);
+
+describe(createXMLDesignTokens.name, () => {
+  it("writes tokens into an XML file", async () => {
+    await createXMLDesignTokens();
+    const content = await fsx.readFile("lib/design-tokens.xml");
+    expect(content.toString()).toMatchInlineSnapshot(`
+      "<designTokens>
+        <token>
+          <name>black</name>
+          <value>#000</value>
+        </token>
+        <token>
+          <name>white</name>
+          <value>#fff</value>
+        </token>
+        <token>
+          <name>red</name>
+          <value>#f00</value>
+        </token>
+      </designTokens>"
+    `);
+  });
+});

--- a/config/createXMLDesignTokens.js
+++ b/config/createXMLDesignTokens.js
@@ -1,0 +1,22 @@
+// @noflow
+const xml = require("xml");
+const { defaultTokens } = require("@kiwicom/orbit-design-tokens");
+const fsx = require("fs-extra");
+
+const createXMLDesignTokens = async () => {
+  const content = xml(
+    {
+      designTokens: Object.entries(defaultTokens).map(([name, value]) => ({
+        token: [{ name }, { value }],
+      })),
+    },
+    {
+      indent: "  ",
+    },
+  );
+
+  await fsx.mkdirp("lib");
+  await fsx.writeFile("lib/design-tokens.xml", content);
+};
+
+module.exports = createXMLDesignTokens;

--- a/package.json
+++ b/package.json
@@ -5,13 +5,14 @@
   "sideEffects": false,
   "scripts": {
     "storybook": "start-storybook -p 6007 -c .storybook --ci -s ./static",
-    "build": "yarn clean && yarn build:icons && yarn build:iconFont && yarn build:typeFiles && yarn build:lib && yarn build:module && yarn build:umd",
+    "build": "yarn clean && yarn build:icons && yarn build:iconFont && yarn build:typeFiles && yarn build:xmlDesignTokens && yarn build:lib && yarn build:module && yarn build:umd",
     "build:lib": "babel --out-dir lib --ignore **/*.stories.js,**/*.test.js,**/*.storyshot.js,**/__examples__/*.js,**/examples.js src && yarn copy:lib",
     "build:module": "cross-env BABEL_TARGET=\"js-esm\" babel --out-dir es --ignore **/*.stories.js,**/*.test.js,**/*.storyshot.js,**/__examples__/*.js,**/examples.js src && yarn copy:module",
     "build:icons": "babel-node config/build.js",
     "build:iconsPng": "node config/generatePngIcons.js",
     "build:typeFiles": "babel-node config/typeFiles.js",
     "build:iconFont": "babel-node config/createSVGFont.js && cd src/icons/; zip -r ../../orbit-svgs.zip ./svg; cd -; zip -j orbit-svgs.zip orbit-icons-font/orbit-icons.svg && zip -r orbit-icons-font.zip orbit-icons-font",
+    "build:xmlDesignTokens": "node -e \"require('./config/createXMLDesignTokens.js')()\"",
     "build:storybook": "cross-env BABEL_TARGET=storybook build-storybook -c .storybook -o .out -s ./static",
     "build:examples": "babel-node config/buildExample.js 'src/**/__examples__/*.js'",
     "build:umd": "webpack --mode=production",
@@ -119,9 +120,9 @@
     "@storybook/react": "^5.3.19",
     "@storybook/storybook-deployer": "^2.8.6",
     "@svgr/core": "^2.0.0",
+    "@types/styled-components": "^4.4.2",
     "@typescript-eslint/eslint-plugin": "^2.34.0",
     "@typescript-eslint/parser": "^2.34.0",
-    "@types/styled-components": "^4.4.2",
     "babel-core": "^7.0.0-bridge.0",
     "babel-eslint": "^10.1.0",
     "babel-jest": "^26.1.0",
@@ -156,6 +157,7 @@
     "jsdom": "^16.3.0",
     "loki": "^0.15.0",
     "make-runnable": "^1.3.6",
+    "memfs": "^3.2.0",
     "mkdirp": "^1.0.4",
     "prettier": "^2.0.5",
     "react": "^16.12.0",
@@ -170,6 +172,7 @@
     "svgicons2svgfont": "^9.0.4",
     "ttf2woff2": "^3.0.0",
     "typescript": "^3.9.6",
-    "webpack-cli": "^3.3.12"
+    "webpack-cli": "^3.3.12",
+    "xml": "^1.0.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6422,6 +6422,11 @@ fs-minipass@^2.0.0:
   dependencies:
     minipass "^3.0.0"
 
+fs-monkey@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/fs-monkey/-/fs-monkey-1.0.1.tgz#4a82f36944365e619f4454d9fff106553067b781"
+  integrity sha512-fcSa+wyTqZa46iWweI7/ZiUfegOZl0SG8+dltIwFXo7+zYU9J9kpS3NB6pZcSlJdhvIwp81Adx2XhZorncxiaA==
+
 fs-readdir-recursive@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz#e32fc030a2ccee44a6b5371308da54be0b397d27"
@@ -8979,6 +8984,13 @@ mem@^4.0.0:
     map-age-cleaner "^0.1.1"
     mimic-fn "^2.0.0"
     p-is-promise "^2.0.0"
+
+memfs@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/memfs/-/memfs-3.2.0.tgz#f9438e622b5acd1daa8a4ae160c496fdd1325b26"
+  integrity sha512-f/xxz2TpdKv6uDn6GtHee8ivFyxwxmPuXatBb1FBwxYNuVpbM3k/Y1Z+vC0mH/dIXXrukYfe3qe5J32Dfjg93A==
+  dependencies:
+    fs-monkey "1.0.1"
 
 memoize-one@^5.0.0:
   version "5.1.1"
@@ -13763,6 +13775,11 @@ xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
+
+xml@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/xml/-/xml-1.0.1.tgz#78ba72020029c5bc87b8a81a3cfcd74b4a2fc1e5"
+  integrity sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=
 
 xmlchars@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
The email team requires design tokens to use Orbit colors, and they said that exposing them as XML through an endpoint is enough. I was using Exponea's [documentation for imports](https://docs.exponea.com/docs/data-import) as a reference for which format to choose.

Design tokens are now being written into `lib/design-tokens.xml`, which they can access through [UNPKG](https://unpkg.com/).

This Pull Request meets the following criteria:

- [x] Tests have been added/adjusted for my new feature
<br/><br/><br/><url>LiveURL: https://orbit-components-feat-exponea-design-tokens.surge.sh</url>