### PR TITLE
fix(IllustrationPrimitive): defaulting flex shrink to false

### DIFF
--- a/src/primitives/IllustrationPrimitive/index.js
+++ b/src/primitives/IllustrationPrimitive/index.js
@@ -35,6 +35,7 @@ export const StyledImage = styled.img.attrs(({ theme, size, illustrationName }) 
   max-width: 100%;
   background-color: ${({ theme }) => theme.orbit.backgroundIllustration};
   margin-bottom: ${getSpacingToken};
+  flex-shrink: 0;
 `;
 
 StyledImage.defaultProps = {


### PR DESCRIPTION
There is a issue when Illustration has a parent with flex properties, causing it to shrink unnecessary <br/><br/><br/><url>LiveURL: https://orbit-components-fix-illustration-shrink.surge.sh</url>