### PR TITLE
docs: fix markup for Coupon example

### DIFF
--- a/examples/Collapse/DEFAULT.json
+++ b/examples/Collapse/DEFAULT.json
@@ -1,6 +1,6 @@
 {
 	"imports": "import Collapse from \"@kiwicom/orbit-components/lib/Collapse\";\nimport Text from \"@kiwicom/orbit-components/lib/Text\";\nimport TextLink from \"@kiwicom/orbit-components/lib/TextLink\";",
-	"example": "() => (\n  <Collapse label=\"See more\">\n    <Text>\n      Collapse components help with{\" \"}\n      <TextLink\n        external\n        href=\"https://orbit.kiwi/guides/progressive-disclosure/\"\n      >\n        progressive disclosure\n      </TextLink>\n      , ensuring users don&apos;t get overwhelmed by too much information or too\n      many choices at once.\n    </Text>\n  </Collapse>\n)\n",
+	"example": "() => (\n  <Collapse label=\"Collapse principles\">\n    <Text>\n      Collapse components help with{\" \"}\n      <TextLink\n        external\n        href=\"https://orbit.kiwi/guides/progressive-disclosure/\"\n      >\n        progressive disclosure\n      </TextLink>\n      , ensuring users don&apos;t get overwhelmed by too much information or too\n      many choices at once.\n    </Text>\n  </Collapse>\n)\n",
 	"info": {
 		"title": "Default collapse",
 		"description": "A collapse requires a label to describe what it's hiding and children to hide. By default, it is closed on initial load."

--- a/examples/Coupon/DEFAULT.json
+++ b/examples/Coupon/DEFAULT.json
@@ -3,6 +3,6 @@
 	"example": "() => (\n  <Text>\n    Use\n    <Coupon>Baggagefree</Coupon>\n    when booking to add free baggage.\n  </Text>\n)\n",
 	"info": {
 		"title": "Default coupon",
-		"description": "Coupons render their child text as a <mark> element styled as all caps."
+		"description": "Coupons render their child text as a <code>&lt;mark&gt;</code> element styled as all caps."
 	}
 }

--- a/src/Collapse/__examples__/DEFAULT.js
+++ b/src/Collapse/__examples__/DEFAULT.js
@@ -7,7 +7,7 @@ import TextLink from "../../TextLink";
 
 export default {
   Example: () => (
-    <Collapse label="See more">
+    <Collapse label="Collapse principles">
       <Text>
         Collapse components help with{" "}
         <TextLink external href="https://orbit.kiwi/guides/progressive-disclosure/">

--- a/src/Coupon/__examples__/DEFAULT.js
+++ b/src/Coupon/__examples__/DEFAULT.js
@@ -14,6 +14,7 @@ export default {
   ),
   info: {
     title: "Default coupon",
-    description: "Coupons render their child text as a <mark> element styled as all caps.",
+    description:
+      "Coupons render their child text as a <code>&lt;mark&gt;</code> element styled as all caps.",
   },
 };


### PR DESCRIPTION
So it works at orbit.kiwi
<br/><br/><br/><url>LiveURL: https://orbit-components-docs-examples.surge.sh</url>