### PR TITLE
feat(Breadcrumbs): add backHref prop

### DIFF
--- a/src/Breadcrumbs/Breadcrumbs.stories.js
+++ b/src/Breadcrumbs/Breadcrumbs.stories.js
@@ -36,8 +36,13 @@ storiesOf("Breadcrumbs", module)
       const spaceAfter = select("spaceAfter", [null, ...Object.values(SPACINGS_AFTER)]);
       const href = text("href", "https://kiwi.com");
       const withGoBack = boolean("onGoBack", true);
+      const backHref = text("backHref", null);
       return (
-        <Breadcrumbs onGoBack={withGoBack ? action("onGoBack") : undefined} spaceAfter={spaceAfter}>
+        <Breadcrumbs
+          backHref={backHref}
+          onGoBack={withGoBack ? action("onGoBack") : undefined}
+          spaceAfter={spaceAfter}
+        >
           <BreadcrumbsItem id="rocket" href={href} onClick={action("clicked")}>
             Kiwi.com
           </BreadcrumbsItem>

--- a/src/Breadcrumbs/__tests__/index.test.js
+++ b/src/Breadcrumbs/__tests__/index.test.js
@@ -2,6 +2,8 @@
 
 import * as React from "react";
 import { shallow } from "enzyme";
+import { render } from "react-dom";
+import { nullthrows } from "@adeira/js";
 
 import Breadcrumbs from "../index";
 import BreadcrumbsItem from "../BreadcrumbsItem";
@@ -36,6 +38,20 @@ describe("Breadcrumbs", () => {
 
     component.find("[dataTest='BreadcrumbsBack']").simulate("click");
     expect(onGoBack).toHaveBeenCalled();
+  });
+
+  it("should render as a link when backHref is passed", () => {
+    const container = document.createElement("div");
+    const body = nullthrows(document.body, "Expected document to have a body");
+    body.appendChild(container);
+    render(
+      <Breadcrumbs backHref="https://orbit.kiwi" dataTest={dataTest} onGoBack={onGoBack}>
+        <BreadcrumbsItem href="https://kiwi.com">Kiwi.com</BreadcrumbsItem>
+      </Breadcrumbs>,
+      container,
+    );
+
+    expect(container.querySelector('a[href="https://orbit.kiwi"]')).not.toBeNull();
   });
 });
 

--- a/src/Breadcrumbs/index.d.ts
+++ b/src/Breadcrumbs/index.d.ts
@@ -12,6 +12,7 @@ export interface Props extends Common.Global, Common.SpaceAfter {
   readonly children: React.ReactNode;
   readonly goBackTitle?: Common.Translation;
   readonly onGoBack?: Common.Event<React.SyntheticEvent<HTMLButtonElement>>;
+  readonly backHref?: string;
 }
 
 declare const Breadcrumbs: React.FunctionComponent<Props>;

--- a/src/Breadcrumbs/index.js
+++ b/src/Breadcrumbs/index.js
@@ -39,7 +39,7 @@ StyledBackButtonWrapper.defaultProps = {
   theme: defaultTheme,
 };
 
-const GoBackButton = ({ onClick }) => {
+const GoBackButton = ({ onClick, backHref }) => {
   const translate = useTranslate();
   return (
     <StyledBackButtonWrapper>
@@ -49,6 +49,7 @@ const GoBackButton = ({ onClick }) => {
         type="secondary"
         size="small"
         onClick={onClick}
+        href={backHref}
         title={translate("breadcrumbs_back")}
       />
     </StyledBackButtonWrapper>
@@ -63,6 +64,7 @@ const Breadcrumbs = (props: Props) => {
     onGoBack,
     goBackTitle = translate("breadcrumbs_back"),
     spaceAfter,
+    backHref,
   } = props;
   return (
     <>
@@ -74,7 +76,7 @@ const Breadcrumbs = (props: Props) => {
           spaceAfter={spaceAfter}
         >
           <StyledBreadcrumbsList itemScope itemType="http://schema.org/BreadcrumbList">
-            {onGoBack && <GoBackButton onClick={onGoBack} />}
+            {onGoBack && <GoBackButton backHref={backHref} onClick={onGoBack} />}
             {React.Children.map(children, (item, key) => {
               if (React.isValidElement(item)) {
                 return React.cloneElement(item, {

--- a/src/Breadcrumbs/index.js.flow
+++ b/src/Breadcrumbs/index.js.flow
@@ -10,6 +10,7 @@ export type Props = {|
   ...Globals,
   +children: React$Node,
   +onGoBack?: (ev: SyntheticEvent<HTMLButtonElement>) => void | Promise<any>,
+  +backHref?: string,
   +goBackTitle?: Translation,
   ...spaceAfter,
 |};


### PR DESCRIPTION
This will allow the back breadcrumb to be a link when needed

This Pull Request meets the following criteria:

- [x] Tests have been added/adjusted for my new feature
- [x] New Components are registered in index.js of my project
<br/><br/><br/><url>LiveURL: https://orbit-components-bread-crumbs-href.surge.sh</url>