### PR TITLE
fix(types): adjust Typescript types for Heading and TextArea

### DIFF
--- a/src/Heading/index.d.ts
+++ b/src/Heading/index.d.ts
@@ -12,7 +12,7 @@ type Type = "display" | "displaySubtitle" | "title1" | "title2" | "title3" | "ti
 type As = "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "div";
 
 export interface Props extends Common.Global, Common.SpaceAfter {
-  readonly as?: Element;
+  readonly as?: As;
   readonly type?: Type;
   readonly children: React.ReactNode;
   readonly inverted?: boolean;

--- a/src/Textarea/index.d.ts
+++ b/src/Textarea/index.d.ts
@@ -12,7 +12,7 @@ type Resize = "vertical" | "none";
 // InputEvent
 type Event = Common.Event<React.SyntheticEvent<HTMLTextAreaElement>>;
 
-interface Props extends Common.Global, Common.SpaceAfter {
+interface Props extends Common.Global, Common.Ref, Common.SpaceAfter {
   readonly size?: Common.InputSize;
   readonly name?: string;
   readonly rows?: number;


### PR DESCRIPTION
Adjust the TS types for the` TextArea` (add `ref` attribute), and the `Heading` ( use the `As` type instead of `Element`).
