### PR TITLE
fix(types): adjust Breadcrumbs, Tile, Button type declarations and exports

### DIFF
--- a/src/Breadcrumbs/index.d.ts
+++ b/src/Breadcrumbs/index.d.ts
@@ -5,7 +5,7 @@
 import * as React from "react";
 
 import * as Common from "../common/common";
-import { Props as BreadcrumbsItemProps} from './BreadcrumbsItem';
+import { Props as BreadcrumbsItemProps } from "./BreadcrumbsItem";
 
 declare module "@kiwicom/orbit-components/lib/Breadcrumbs";
 
@@ -19,4 +19,4 @@ export interface Props extends Common.Global, Common.SpaceAfter {
 declare const Breadcrumbs: React.FunctionComponent<Props>;
 declare const BreadcrumbsItem: React.FunctionComponent<BreadcrumbsItemProps>;
 
-export { Breadcrumbs,BreadcrumbsItem, Breadcrumbs as default };
+export { Breadcrumbs, BreadcrumbsItem, Breadcrumbs as default };

--- a/src/Breadcrumbs/index.d.ts
+++ b/src/Breadcrumbs/index.d.ts
@@ -5,6 +5,7 @@
 import * as React from "react";
 
 import * as Common from "../common/common";
+import { Props as BreadcrumbsItemProps} from './BreadcrumbsItem';
 
 declare module "@kiwicom/orbit-components/lib/Breadcrumbs";
 
@@ -16,4 +17,6 @@ export interface Props extends Common.Global, Common.SpaceAfter {
 }
 
 declare const Breadcrumbs: React.FunctionComponent<Props>;
-export { Breadcrumbs, Breadcrumbs as default };
+declare const BreadcrumbsItem: React.FunctionComponent<BreadcrumbsItemProps>;
+
+export { Breadcrumbs,BreadcrumbsItem, Breadcrumbs as default };

--- a/src/Tile/index.d.ts
+++ b/src/Tile/index.d.ts
@@ -21,6 +21,8 @@ interface Props extends Common.Global {
   >;
   readonly expandable?: boolean;
   readonly initialExpanded?: boolean;
+  readonly noHeaderIcon?: boolean;
+  readonly htmlTitle?: string,
   readonly noPadding?: boolean;
 }
 

--- a/src/Tile/index.d.ts
+++ b/src/Tile/index.d.ts
@@ -22,7 +22,7 @@ interface Props extends Common.Global {
   readonly expandable?: boolean;
   readonly initialExpanded?: boolean;
   readonly noHeaderIcon?: boolean;
-  readonly htmlTitle?: string,
+  readonly htmlTitle?: string;
   readonly noPadding?: boolean;
 }
 

--- a/src/primitives/ButtonPrimitive/index.d.ts
+++ b/src/primitives/ButtonPrimitive/index.d.ts
@@ -6,7 +6,7 @@ import * as Common from "../../common/common";
 type inexactString = string | null | undefined;
 type functionReturningString = () => string;
 
-export interface ButtonCommonProps extends Common.Global, Common.SpaceAfter {
+export interface ButtonCommonProps extends Common.Global, Common.Ref, Common.SpaceAfter {
   readonly asComponent?: Common.Component;
   readonly ariaControls?: string;
   readonly ariaExpanded?: boolean;


### PR DESCRIPTION
- export `BreadcrumbsItem` component type from the index.d.ts file on `Breadcrumbs`
- add `noHeaderIcon` and `htmlTitle` to `Tile` props
- add `Ref` prop to `Button`