### PR TITLE
fix(Stack): add the "as" attribute to typescript types

### DIFF
--- a/src/Stack/index.d.ts
+++ b/src/Stack/index.d.ts
@@ -49,6 +49,7 @@ interface Props extends Common.Global, Common.SpaceAfter {
   readonly largeMobile?: MediaQuery;
   readonly tablet?: MediaQuery;
   readonly desktop?: MediaQuery;
+  readonly as?: string;
   readonly largeDesktop?: MediaQuery;
   readonly children: React.ReactNode;
 }


### PR DESCRIPTION
add `readonly as?: string` to the types definition of `Stack`, which was missing