### PR TITLE
fix(InputField): missing inputMode in typescript props

### DIFF
--- a/src/InputField/index.d.ts
+++ b/src/InputField/index.d.ts
@@ -17,6 +17,7 @@ type KeyboardEvent = Common.Event<React.KeyboardEvent<HTMLInputElement>>;
 export interface Props extends Common.Global, Common.Ref, Common.SpaceAfter, Common.DataAttrs {
   readonly size?: Common.InputSize;
   readonly type?: Type;
+  readonly inputMode?: InputMode;
   readonly name?: string;
   readonly label?: Common.Translation;
   readonly inlineLabel?: boolean;


### PR DESCRIPTION
<br/><br/><br/><url>LiveURL: https://orbit-components-fix-inputfield-inputmode.surge.sh</url>