### PR TITLE
feat(MediaQuery): add Typescript types for MediaQuery/consts

### DIFF
--- a/src/utils/mediaQuery/consts.d.ts
+++ b/src/utils/mediaQuery/consts.d.ts
@@ -1,0 +1,17 @@
+declare module "@kiwicom/orbit-components/lib/utils/mediaQuery/consts";
+
+export type Devices =
+  | "largeDesktop"
+  | "desktop"
+  | "tablet"
+  | "largeMobile"
+  | "mediumMobile"
+  | "smallMobile";
+
+declare const QUERIES: {
+  LARGEDESKTOP: "largeDesktop";
+  DESKTOP: "desktop";
+  TABLET: "tablet";
+  LARGEMOBILE: "largeMobile";
+  MEDIUMMOBILE: "mediumMobile";
+};

--- a/src/utils/mediaQuery/index.d.ts
+++ b/src/utils/mediaQuery/index.d.ts
@@ -3,18 +3,10 @@
 // Project: http://github.com/kiwicom/orbit-components
 import { Interpolation } from "styled-components";
 import { ThemeShape } from "../../defaultTheme";
-
+import { Devices } from "./consts";
 declare module "@kiwicom/orbit-components/lib/utils/mediaQuery";
 
 type QueryFunction = (style: Interpolation<any>) => Interpolation<any>;
-
-export type Devices =
-  | "largeDesktop"
-  | "desktop"
-  | "tablet"
-  | "largeMobile"
-  | "mediumMobile"
-  | "smallMobile";
 
 declare const MediaQuery: { [key in Devices]: QueryFunction };
 declare const getBreakpointWidth: (name: string, theme: ThemeShape, pure?: boolean) => string;


### PR DESCRIPTION
Added a new module `@kiwicom/orbit-components/lib/utils/mediaQuery/consts`, which exports the types for `mediaQuery/consts`. This is needed to correctly type the `QUERIES` object (using it for SSR breakpoints definitions). 

Before there were not present and typescript would infer the wrong type for the keys on the client.
